### PR TITLE
further explain tick time position #43

### DIFF
--- a/Sourcecode/include/mx/api/NoteData.h
+++ b/Sourcecode/include/mx/api/NoteData.h
@@ -101,14 +101,14 @@ namespace mx
             PitchData pitchData;          // step, alter, octave, accidental, etc
             int userRequestedVoiceNumber;
             Stem stem;
-            
-            // the location of the note, timewise, within the measuredenominated in ticksPerQuarter as
-            // defined by ScoreData. in each measure, the note with tickTimePosition 0 is located at
+                        
+            // the time location of the note, within the measure, denominated in ticksPerQuarter which
+            // is defined in ScoreData. in each measure, the note with tickTimePosition 0 is located at
             // the start of the measure. if ScoreData defines ticksPerQuarter as N, then the note
             // located at tickTimePosition N will be located one quarter note after the start of the
-            // measure. MusicXML's <forward> and <backup> tags will be automatically derived and
-            // placed in to the MusicXML to facilitate the correct placement of notes based on their
-            // tickTimePosition defined here.
+            // measure. MusicXML's <forward> and <backup> tags will be automatically placed into the
+            // MusicXML as required to facilitate the correct timing of notes based on their 
+            // tickTimePosition values.
             int tickTimePosition;
             DurationData durationData;
             

--- a/Sourcecode/include/mx/api/NoteData.h
+++ b/Sourcecode/include/mx/api/NoteData.h
@@ -102,8 +102,13 @@ namespace mx
             int userRequestedVoiceNumber;
             Stem stem;
             
-            // the location of the note, timewise, within the measure
-            // denominated in ticksPerQuarter as defined by ScoreData
+            // the location of the note, timewise, within the measuredenominated in ticksPerQuarter as
+            // defined by ScoreData. in each measure, the note with tickTimePosition 0 is located at
+            // the start of the measure. if ScoreData defines ticksPerQuarter as N, then the note
+            // located at tickTimePosition N will be located one quarter note after the start of the
+            // measure. MusicXML's <forward> and <backup> tags will be automatically derived and
+            // placed in to the MusicXML to facilitate the correct placement of notes based on their
+            // tickTimePosition defined here.
             int tickTimePosition;
             DurationData durationData;
             


### PR DESCRIPTION
Attempt to better explain why a `<forward>` or `<backup>` element might be encountered when tickTimePosition is not used correctly. See #43 