### PR TITLE
support microtonal notes with cents #42

### DIFF
--- a/Sourcecode/include/mx/api/PitchData.h
+++ b/Sourcecode/include/mx/api/PitchData.h
@@ -66,6 +66,7 @@ namespace mx
 
         struct PitchData
         {
+            // default construction is middle c (c4)
             PitchData();
 
             // the note name. i.e. c, d, e, f, g, a, b

--- a/Sourcecode/include/mx/api/PitchData.h
+++ b/Sourcecode/include/mx/api/PitchData.h
@@ -84,7 +84,7 @@ namespace mx
             // dealing with integrals for the more common case on non-microtonal music. in order to still support
             // microtones without resording to a floating-point alter value, we break out microtonal adjustments to a
             // separate 'cents' field, which will be addeded to the alter integral:
-            // <alter> = (double)alter + (cents * 100.0)
+            // <alter> = (double)alter + (cents / 100.0)
             double cents;
 
             // in MusicXML, the accidental is completely independent of the sounding pitch and is only present when you

--- a/Sourcecode/include/mx/api/PitchData.h
+++ b/Sourcecode/include/mx/api/PitchData.h
@@ -68,6 +68,7 @@ namespace mx
         {
             PitchData();
 
+            // the note name. i.e. c, d, e, f, g, a, b
             Step step;
 
             // the alteration (number of semitones of pitch distance) from the step. for example, if step is 'c' and
@@ -85,11 +86,19 @@ namespace mx
             // <alter> = (double)alter + (cents * 100.0)
             double cents;
 
+            // in MusicXML, the accidental is completely independent of the sounding pitch and is only present when you
+            // actually want to show the accidental in the notated music. i.e. accidental is purely visual. for example,
+            // if you have a measure consisting of repeated c# notes, you would typically notate this with an accidental
+            // on the first note only. the rest of the notes of the measure would be 'sharped' by virtue of the first
+            // note's sharp. in MusicXML, the first note should have an accidental of 'sharp' and an alter of '1', and
+            // the remaining notes of the measure should have an accidental of 'none' and an alter of '1'.
             Accidental accidental;
             bool isAccidentalParenthetical;
             bool isAccidentalCautionary;
             bool isAccidentalEditorial;
             bool isAccidentalBracketed;
+
+            // which octave the note is located in. middle c is in octave 4.
             int octave;
 
             // automatically set the Accidental enum value by parsing the alter value (does not consider the value of

--- a/Sourcecode/include/mx/api/PitchData.h
+++ b/Sourcecode/include/mx/api/PitchData.h
@@ -69,7 +69,22 @@ namespace mx
             PitchData();
 
             Step step;
+
+            // the alteration (number of semitones of pitch distance) from the step. for example, if step is 'c' and
+            // alter is 1, then the sounding pitch is c#. if step is 'd' and alter is -2, then the sounding pitch is
+            // 'c' (i.e. d double flat). alter only affects the sounding pitch of the note. accidentals are applied
+            // independently. alter is always required to produce the correct sounding pitch, regardless of key
+            // signature or accidentals.
             int alter;
+
+            // additional alteration to the sounding pitch (in hundredths of a semitone). the MusicXML alter value is
+            // a floating point number to facilitate microtonal music. however for mx::api we wanted the simplicity of
+            // dealing with integrals for the more common case on non-microtonal music. in order to still support
+            // microtones without resording to a floating-point alter value, we break out microtonal adjustments to a
+            // separate 'cents' field, which will be addeded to the alter integral:
+            // <alter> = (double)alter + (cents * 100.0)
+            double cents;
+
             Accidental accidental;
             bool isAccidentalParenthetical;
             bool isAccidentalCautionary;
@@ -77,18 +92,19 @@ namespace mx
             bool isAccidentalBracketed;
             int octave;
 
-            // automatically set the Accidental enum value by
-            // parsing the alter value
+            // automatically set the Accidental enum value by parsing the alter value (does not consider the value of
+            // cents). this is a convenience function that simply adds the correct accidental given the current value
+            // of alter. for example, if alter is 1, then showAccidental will set the accidental field to 'sharp'.
             void showAccidental();
             
-            // set the accidental value to 'none' and clear out the
-            // other accidental-related values
+            // set the accidental value to 'none' and clear out the other accidental-related values
             void hideAccidental();
         };
         
         MXAPI_EQUALS_BEGIN( PitchData )
         MXAPI_EQUALS_MEMBER( step )
         MXAPI_EQUALS_MEMBER( alter )
+        MXAPI_DOUBLES_EQUALS_MEMBER( cents )
         MXAPI_EQUALS_MEMBER( accidental )
         MXAPI_EQUALS_MEMBER( isAccidentalParenthetical )
         MXAPI_EQUALS_MEMBER( isAccidentalCautionary )

--- a/Sourcecode/private/mx/api/PitchData.cpp
+++ b/Sourcecode/private/mx/api/PitchData.cpp
@@ -11,6 +11,7 @@ namespace mx
         PitchData::PitchData()
         : step{ Step::c }
         , alter{ 0 }
+        , cents{ 0.0 }
         , accidental{Accidental::none}
         , isAccidentalParenthetical{ false }
         , isAccidentalCautionary{ false }

--- a/Sourcecode/private/mx/impl/NoteFunctions.cpp
+++ b/Sourcecode/private/mx/impl/NoteFunctions.cpp
@@ -110,6 +110,7 @@ namespace mx
             auto converter = Converter{};
             myOutNoteData.pitchData.step = converter.convert( reader.getStep() );
             myOutNoteData.pitchData.alter = reader.getAlter();
+            myOutNoteData.pitchData.cents = reader.getCents();
             
             myOutNoteData.pitchData.accidental = api::Accidental::none;
             

--- a/Sourcecode/private/mx/impl/NoteReader.cpp
+++ b/Sourcecode/private/mx/impl/NoteReader.cpp
@@ -43,7 +43,7 @@
 #include "mx/utility/StringToInt.h"
 
 #include <map>
-#include <mx/api/PitchData.h>
+#include "mx/api/PitchData.h"
 
 namespace mx
 {

--- a/Sourcecode/private/mx/impl/NoteReader.cpp
+++ b/Sourcecode/private/mx/impl/NoteReader.cpp
@@ -43,6 +43,7 @@
 #include "mx/utility/StringToInt.h"
 
 #include <map>
+#include <mx/api/PitchData.h>
 
 namespace mx
 {
@@ -213,16 +214,18 @@ namespace mx
                     const auto& pitch = *fullNoteTypeChoice.getPitch();
                     myStep = pitch.getStep()->getValue();
                     myOctave = pitch.getOctave()->getValue().getValue();
-                    myAlter = static_cast<int>( std::ceil( pitch.getAlter()->getValue().getValue() - 0.5 ) );
+                    myAlter = static_cast<int>( pitch.getAlter()->getValue().getValue() );
 
                     const auto micro =
                         std::abs( static_cast<core::DecimalType>( myAlter ) - pitch.getAlter()->getValue().getValue() );
 
-                    const auto microDistance =std::abs( micro );
+                    const auto microDistance = std::abs( micro );
 
                     if( microDistance >= 0.000000000001 )
                     {
-                        myCents = static_cast<double>( micro * 100.0 );
+                        const auto theCents = micro * 100.0;
+                        const auto theNarrowCents = static_cast<decltype(mx::api::PitchData::cents)>( theCents );
+                        myCents = theNarrowCents;
                     }
                     break;
                 }

--- a/Sourcecode/private/mx/impl/NoteReader.cpp
+++ b/Sourcecode/private/mx/impl/NoteReader.cpp
@@ -64,6 +64,7 @@ namespace mx
         , myDurationValue( 0.0L )
         , myStep( core::StepEnum::c )
         , myAlter( 0 )
+        , myCents( 0.0 )
         , myOctave( 4 )
         , myStaffNumber( 0 )
         , myVoiceNumber( 0 )
@@ -213,6 +214,16 @@ namespace mx
                     myStep = pitch.getStep()->getValue();
                     myOctave = pitch.getOctave()->getValue().getValue();
                     myAlter = static_cast<int>( std::ceil( pitch.getAlter()->getValue().getValue() - 0.5 ) );
+
+                    const auto micro =
+                        std::abs( static_cast<core::DecimalType>( myAlter ) - pitch.getAlter()->getValue().getValue() );
+
+                    const auto microDistance =std::abs( micro );
+
+                    if( microDistance >= 0.000000000001 )
+                    {
+                        myCents = static_cast<double>( micro * 100.0 );
+                    }
                     break;
                 }
                     

--- a/Sourcecode/private/mx/impl/NoteReader.cpp
+++ b/Sourcecode/private/mx/impl/NoteReader.cpp
@@ -214,13 +214,11 @@ namespace mx
                     const auto& pitch = *fullNoteTypeChoice.getPitch();
                     myStep = pitch.getStep()->getValue();
                     myOctave = pitch.getOctave()->getValue().getValue();
-                    myAlter = static_cast<int>( pitch.getAlter()->getValue().getValue() );
-
-                    const auto micro =
-                        std::abs( static_cast<core::DecimalType>( myAlter ) - pitch.getAlter()->getValue().getValue() );
-
+                    const auto xmlAlter = pitch.getAlter()->getValue().getValue();
+                    const auto intAlter = static_cast<int>( xmlAlter );
+                    myAlter = intAlter;
+                    const auto micro = xmlAlter - static_cast<mx::core::DecimalType> ( intAlter );
                     const auto microDistance = std::abs( micro );
-
                     if( microDistance >= 0.000000000001 )
                     {
                         const auto theCents = micro * 100.0;

--- a/Sourcecode/private/mx/impl/NoteReader.h
+++ b/Sourcecode/private/mx/impl/NoteReader.h
@@ -50,7 +50,7 @@ namespace mx
             inline long double getDurationValue() const { return myDurationValue; }
             inline core::StepEnum getStep() const { return myStep; }
             inline int getAlter() const { return myAlter; }
-            inline int getCents() const { return myCents; }
+            inline double getCents() const { return myCents; }
             inline int getOctave() const { return myOctave; }
             inline int getStaffNumber() const { return myStaffNumber; }
             inline int getVoiceNumber() const { return myVoiceNumber; }

--- a/Sourcecode/private/mx/impl/NoteReader.h
+++ b/Sourcecode/private/mx/impl/NoteReader.h
@@ -50,6 +50,7 @@ namespace mx
             inline long double getDurationValue() const { return myDurationValue; }
             inline core::StepEnum getStep() const { return myStep; }
             inline int getAlter() const { return myAlter; }
+            inline int getCents() const { return myCents; }
             inline int getOctave() const { return myOctave; }
             inline int getStaffNumber() const { return myStaffNumber; }
             inline int getVoiceNumber() const { return myVoiceNumber; }
@@ -89,6 +90,7 @@ namespace mx
             long double myDurationValue;
             core::StepEnum myStep;
             int myAlter;
+            double myCents;
             int myOctave;
             int myStaffNumber;
             int myVoiceNumber;

--- a/Sourcecode/private/mx/impl/NoteWriter.cpp
+++ b/Sourcecode/private/mx/impl/NoteWriter.cpp
@@ -372,8 +372,13 @@ namespace mx
                 pitch->getStep()->setValue( myConverter.convert( myNoteData.pitchData.step ) );
                 if( myNoteData.pitchData.alter != 0 )
                 {
+                    core::DecimalType microtones = 0.0;
+                    if( myNoteData.pitchData.cents != 0.0 ) {
+                        microtones = static_cast<core::DecimalType>( myNoteData.pitchData.cents * 100.0 );
+                    }
+                    const auto alter = static_cast<core::DecimalType>( myNoteData.pitchData.alter ) + microtones;
                     pitch->setHasAlter( true );
-                    pitch->getAlter()->setValue( core::Semitones{ static_cast<core::DecimalType>( myNoteData.pitchData.alter ) } );
+                    pitch->getAlter()->setValue( core::Semitones{ alter } );
                 }
                 pitch->getOctave()->setValue( core::OctaveValue{ myNoteData.pitchData.octave } );
             }

--- a/Sourcecode/private/mx/impl/NoteWriter.cpp
+++ b/Sourcecode/private/mx/impl/NoteWriter.cpp
@@ -374,7 +374,7 @@ namespace mx
                 {
                     core::DecimalType microtones = 0.0;
                     if( myNoteData.pitchData.cents != 0.0 ) {
-                        microtones = static_cast<core::DecimalType>( myNoteData.pitchData.cents * 100.0 );
+                        microtones = static_cast<core::DecimalType>( myNoteData.pitchData.cents / 100.0 );
                     }
                     const auto alter = static_cast<core::DecimalType>( myNoteData.pitchData.alter ) + microtones;
                     pitch->setHasAlter( true );

--- a/Sourcecode/private/mxtest/api/NoteDataTest.cpp
+++ b/Sourcecode/private/mxtest/api/NoteDataTest.cpp
@@ -978,5 +978,4 @@ TEST( notePositionRoundTrip, NoteData )
 T_END;
 
 // TODO - write PitchData::cents tests
-
 #endif

--- a/Sourcecode/private/mxtest/api/NoteDataTest.cpp
+++ b/Sourcecode/private/mxtest/api/NoteDataTest.cpp
@@ -977,5 +977,4 @@ TEST( notePositionRoundTrip, NoteData )
 }
 T_END;
 
-// TODO - write PitchData::cents tests
 #endif

--- a/Sourcecode/private/mxtest/api/NoteDataTest.cpp
+++ b/Sourcecode/private/mxtest/api/NoteDataTest.cpp
@@ -977,4 +977,6 @@ TEST( notePositionRoundTrip, NoteData )
 }
 T_END;
 
+// TODO - write PitchData::cents tests
+
 #endif

--- a/Sourcecode/private/mxtest/api/PitchDataTest.cpp
+++ b/Sourcecode/private/mxtest/api/PitchDataTest.cpp
@@ -3,10 +3,9 @@
 // Distributed under the MIT License
 
 #include "mxtest/control/CompileControl.h"
-#if defined(MX_COMPILE_API_TESTS) && defined(MX_COMPILE_API_ROUNDTRIP)
+//#ifdef MX_COMPILE_API_TESTS
 
 #include "cpul/cpulTestHarness.h"
-#include "mxtest/api/RoundTrip.h"
 #include "mx/api/DocumentManager.h"
 #include "mx/core/Document.h"
 #include "mx/core/elements/ScorePartwise.h"
@@ -30,7 +29,6 @@
 
 using namespace std;
 using namespace mx::api;
-using namespace mxtest;
 
 TEST( microtones1, PitchData )
 {
@@ -72,4 +70,4 @@ TEST( microtones1, PitchData )
 }
 T_END;
 
-#endif
+//#endif

--- a/Sourcecode/private/mxtest/api/PitchDataTest.cpp
+++ b/Sourcecode/private/mxtest/api/PitchDataTest.cpp
@@ -228,7 +228,7 @@ TEST( AlmostDoubleFlat, PitchData )
 }
 T_END;
 
-TEST( Microtones4, PitchData )
+TEST( CrazyEdgeCase1, PitchData )
 {
     auto input = Input{};
     input.step = Step::g;
@@ -238,6 +238,27 @@ TEST( Microtones4, PitchData )
     const std::string expectedAlterString = "-1234566.89";
     const int expectedAlter = -1234566;
     const double expectedCents = -89.0;
+    const Accidental expectedAccidental = input.accidental;
+    const auto output = pitchDataTest( input );
+
+    CHECK_EQUAL( expectedAlterString, output.alterString );
+    CHECK_EQUAL( expectedAlterString, output.secondAlterString );
+    CHECK_EQUAL( expectedAlter, output.alter );
+    CHECK_DOUBLES_EQUAL( expectedCents, output.cents, MX_API_EQUALITY_EPSILON );
+    CHECK( expectedAccidental == output.accidental );
+}
+T_END;
+
+TEST( CrazyEdgeCase2, PitchData )
+{
+    auto input = Input{};
+    input.step = Step::e;
+    input.alter = 21;
+    input.cents = 100.01;
+    input.accidental = Accidental::sori;
+    const std::string expectedAlterString = "22.0001";
+    const int expectedAlter = 22;
+    const double expectedCents = 0.01;
     const Accidental expectedAccidental = input.accidental;
     const auto output = pitchDataTest( input );
 

--- a/Sourcecode/private/mxtest/api/PitchDataTest.cpp
+++ b/Sourcecode/private/mxtest/api/PitchDataTest.cpp
@@ -112,6 +112,7 @@ namespace
         Output output;
         output.alterString = alterString;
 
+// deserialize back to ScoreData
         const std::string xml = ss.str();
         std::istringstream iss{ xml };
         docId = mgr.createFromStream( iss );

--- a/Sourcecode/private/mxtest/api/PitchDataTest.cpp
+++ b/Sourcecode/private/mxtest/api/PitchDataTest.cpp
@@ -1,0 +1,75 @@
+// MusicXML Class Library
+// Copyright (c) by Matthew James Briggs
+// Distributed under the MIT License
+
+#include "mxtest/control/CompileControl.h"
+#if defined(MX_COMPILE_API_TESTS) && defined(MX_COMPILE_API_ROUNDTRIP)
+
+#include "cpul/cpulTestHarness.h"
+#include "mxtest/api/RoundTrip.h"
+#include "mx/api/DocumentManager.h"
+#include "mx/core/Document.h"
+#include "mx/core/elements/ScorePartwise.h"
+#include "mx/core/elements/PartwisePart.h"
+#include "mx/core/elements/PartwiseMeasure.h"
+#include "mx/core/elements/MusicDataGroup.h"
+#include "mx/core/elements/Note.h"
+#include "mx/core/elements/NoteChoice.h"
+#include "mx/core/elements/NormalNoteGroup.h"
+#include "mx/core/elements/FullNoteGroup.h"
+#include "mx/core/elements/FullNoteTypeChoice.h"
+#include "mx/core/elements/Pitch.h"
+#include "mx/core/elements/Notations.h"
+#include "mx/core/elements/NotationsChoice.h"
+#include "mx/core/elements/Tied.h"
+#include "mx/core/elements/MusicDataChoice.h"
+#include "mx/core/elements/Direction.h"
+#include "mx/core/elements/DirectionType.h"
+#include "mx/core/elements/Offset.h"
+#include "mx/core/elements/Pedal.h"
+
+using namespace std;
+using namespace mx::api;
+using namespace mxtest;
+
+TEST( microtones1, PitchData )
+{
+    ScoreData score;
+    score.parts.emplace_back();
+    auto& part = score.parts.back();
+    part.measures.emplace_back();
+    auto& measure = part.measures.back();
+    measure.staves.emplace_back();
+    auto& staff = measure.staves.back();
+    auto& voice = staff.voices[0];
+    voice.notes.emplace_back();
+    auto& note = voice.notes.back();
+    note.pitchData.step = Step::f;
+    note.pitchData.accidental = Accidental::threeQuartersSharp;
+    note.pitchData.alter = 1;
+    note.pitchData.cents = 50.0;
+
+    // round trip it through xml
+    auto& mgr = DocumentManager::getInstance();
+    auto docId = mgr.createFromScore( score );
+    std::stringstream ss;
+    mgr.writeToStream(docId, ss);
+    mgr.destroyDocument(docId);
+    const std::string xml = ss.str();
+    std::istringstream iss{ xml };
+    docId = mgr.createFromStream( iss );
+    auto oscore = mgr.getData(docId);
+
+    // get the data after the round trip
+    const auto& opart = oscore.parts.back();
+    const auto& omeasure = opart.measures.back();
+    const auto& ostaff = omeasure.staves.back();
+    const auto& ovoice = ostaff.voices.at( 0 );
+    const auto& onote = ovoice.notes.back();
+    CHECK( note.pitchData.step == onote.pitchData.step );
+    CHECK( note.pitchData.alter == onote.pitchData.alter );
+    CHECK_DOUBLES_EQUAL( 50.0, onote.pitchData.cents, 0.0001 );
+}
+T_END;
+
+#endif

--- a/Sourcecode/private/mxtest/api/PitchDataTest.cpp
+++ b/Sourcecode/private/mxtest/api/PitchDataTest.cpp
@@ -2,6 +2,7 @@
 // Copyright (c) by Matthew James Briggs
 // Distributed under the MIT License
 
+#include <extern/ezxml/src/include/ezxml/XFactory.h>
 #include "mxtest/control/CompileControl.h"
 //#ifdef MX_COMPILE_API_TESTS
 
@@ -26,47 +27,147 @@
 #include "mx/core/elements/DirectionType.h"
 #include "mx/core/elements/Offset.h"
 #include "mx/core/elements/Pedal.h"
+#include "ezxml/ezxml.h"
 
 using namespace std;
 using namespace mx::api;
 
-TEST( microtones1, PitchData )
+namespace
 {
-    ScoreData score;
-    score.parts.emplace_back();
-    auto& part = score.parts.back();
-    part.measures.emplace_back();
-    auto& measure = part.measures.back();
-    measure.staves.emplace_back();
-    auto& staff = measure.staves.back();
-    auto& voice = staff.voices[0];
-    voice.notes.emplace_back();
-    auto& note = voice.notes.back();
-    note.pitchData.step = Step::f;
-    note.pitchData.accidental = Accidental::threeQuartersSharp;
-    note.pitchData.alter = 1;
-    note.pitchData.cents = 50.0;
+    ezxml::XElementPtr bruteForceFindFirstElement( const ezxml::XElementPtr root, const std::string& inElementName )
+    {
+        if( !root )
+        {
+            throw std::runtime_error{ "bug in bruteForceFindFirstElement" };
+        }
 
-    // round trip it through xml
-    auto& mgr = DocumentManager::getInstance();
-    auto docId = mgr.createFromScore( score );
-    std::stringstream ss;
-    mgr.writeToStream(docId, ss);
-    mgr.destroyDocument(docId);
-    const std::string xml = ss.str();
-    std::istringstream iss{ xml };
-    docId = mgr.createFromStream( iss );
-    auto oscore = mgr.getData(docId);
+        if( root->getName() == inElementName )
+        {
+            return root;
+        }
 
-    // get the data after the round trip
-    const auto& opart = oscore.parts.back();
-    const auto& omeasure = opart.measures.back();
-    const auto& ostaff = omeasure.staves.back();
-    const auto& ovoice = ostaff.voices.at( 0 );
-    const auto& onote = ovoice.notes.back();
-    CHECK( note.pitchData.step == onote.pitchData.step );
-    CHECK( note.pitchData.alter == onote.pitchData.alter );
-    CHECK_DOUBLES_EQUAL( 50.0, onote.pitchData.cents, 0.0001 );
+        auto iter = root->begin();
+        const auto end = root->end();
+
+        for( ; iter != end; ++iter )
+        {
+            const auto possible = bruteForceFindFirstElement( iter->clone(), inElementName );
+            if( possible && possible->getName() == inElementName )
+            {
+                return possible;
+            }
+        }
+
+        return nullptr;
+    }
+
+    struct Input
+    {
+        Step step;
+        int alter;
+        double cents;
+        Accidental accidental;
+    };
+
+    struct Output
+    {
+        Step step;
+        int alter;
+        double cents;
+        Accidental accidental;
+        std::string alterString;
+    };
+
+    Output pitchDataTest( const Input& input )
+    {
+        ScoreData score;
+        score.parts.emplace_back();
+        auto& part = score.parts.back();
+        part.measures.emplace_back();
+        auto& measure = part.measures.back();
+        measure.staves.emplace_back();
+        auto& staff = measure.staves.back();
+        auto& voice = staff.voices[0];
+        voice.notes.emplace_back();
+        auto& note = voice.notes.back();
+        note.pitchData.step = input.step;
+        note.pitchData.accidental = input.accidental;
+        note.pitchData.alter = input.alter;
+        note.pitchData.cents = input.cents;
+
+        // round trip it through xml
+        auto& mgr = DocumentManager::getInstance();
+        auto docId = mgr.createFromScore( score );
+        std::stringstream ss;
+        mgr.writeToStream( docId, ss );
+
+        std::cout << std::endl << ss.str() << std::endl;
+
+        // check the alter value that was written to xml
+        const auto xdoc = ezxml::XFactory::makeXDoc();
+        xdoc->loadStream( ss );
+        auto elem = xdoc->getRoot();
+        elem = bruteForceFindFirstElement( elem, "alter" );
+        const auto alterString = elem->getValue();
+        Output output;
+        output.alterString = alterString;
+
+        mgr.destroyDocument( docId );
+        const std::string xml = ss.str();
+        std::istringstream iss{ xml };
+        docId = mgr.createFromStream( iss );
+        auto oscore = mgr.getData( docId );
+        mgr.destroyDocument( docId );
+        const auto& opart = oscore.parts.back();
+        const auto& omeasure = opart.measures.back();
+        const auto& ostaff = omeasure.staves.back();
+        const auto& ovoice = ostaff.voices.at( 0 );
+        const auto& onote = ovoice.notes.back();
+        output.step = onote.pitchData.step;
+        output.alter = onote.pitchData.alter;
+        output.cents = onote.pitchData.cents;
+        output.accidental = onote.pitchData.accidental;
+        return output;
+    }
+}
+
+TEST( Microtones1, PitchData )
+{
+    auto input = Input{};
+    input.step = Step::f;
+    input.alter = 1;
+    input.cents = 50.0;
+    input.accidental = Accidental::threeQuartersSharp;
+    const std::string expectedAlterString = "1.5";
+    const int expectedAlter = input.alter;
+    const double expectedCents = input.cents;
+    const Accidental expectedAccidental = input.accidental;
+    const auto output = pitchDataTest( input );
+
+    CHECK_EQUAL( expectedAlterString, output.alterString );
+    CHECK_EQUAL( expectedAlter, output.alter );
+    CHECK_DOUBLES_EQUAL( expectedCents, output.cents, MX_API_EQUALITY_EPSILON );
+    CHECK( expectedAccidental == output.accidental );
+}
+T_END;
+
+TEST( Microtones2, PitchData )
+{
+    auto input = Input{};
+    input.step = Step::g;
+    input.alter = 1;
+    input.cents = 99.999;
+    input.accidental = Accidental::none;
+    const std::string expectedAlterString = "1.99999";
+    const int expectedAlter = input.alter;
+    const double expectedCents = input.cents;
+    const Accidental expectedAccidental = input.accidental;
+    const auto output = pitchDataTest( input );
+
+    CHECK_EQUAL( expectedAlterString, output.alterString );
+    CHECK_EQUAL( expectedAlter, output.alter );
+    CHECK_DOUBLES_EQUAL( expectedCents, output.cents, MX_API_EQUALITY_EPSILON );
+    CHECK( expectedAccidental == output.accidental );
 }
 T_END;
 

--- a/Sourcecode/private/mxtest/api/PitchDataTest.cpp
+++ b/Sourcecode/private/mxtest/api/PitchDataTest.cpp
@@ -4,7 +4,7 @@
 
 #include <extern/ezxml/src/include/ezxml/XFactory.h>
 #include "mxtest/control/CompileControl.h"
-//#ifdef MX_COMPILE_API_TESTS
+#ifdef MX_COMPILE_API_TESTS
 
 #include "cpul/cpulTestHarness.h"
 #include "mx/api/DocumentManager.h"
@@ -270,4 +270,4 @@ TEST( CrazyEdgeCase2, PitchData )
 }
 T_END;
 
-//#endif
+#endif

--- a/Sourcecode/private/mxtest/api/RoundTrip.h
+++ b/Sourcecode/private/mxtest/api/RoundTrip.h
@@ -5,7 +5,6 @@
 #pragma once
 
 #include "mxtest/control/CompileControl.h"
-#ifdef MX_COMPILE_API_ROUNDTRIP
 
 #include "mx/api/DocumentManager.h"
 #include "mxtest/file/MxFileRepository.h"
@@ -45,4 +44,3 @@ namespace mxtest
     }
 }
 
-#endif

--- a/Sourcecode/private/mxtest/control/CompileControl.h
+++ b/Sourcecode/private/mxtest/control/CompileControl.h
@@ -4,14 +4,13 @@
 
 #pragma once
 
-#define MX_COMPILE_API_TESTS
-#define MX_COMPILE_API_ROUNDTRIP
-// #define MX_COMPILE_CORE_TESTS
-#define MX_COMPILE_IMPL_TESTS
-#define MX_COMPILE_IMPORT_TESTS
-#define MX_COMPILE_NEW_DECIMAL_TESTS
-#define MX_COMPILE_UTILTIY_TESTS
-#define MX_COMPILE_XML_TESTS
+//#define MX_COMPILE_API_TESTS
+//#define MX_COMPILE_API_ROUNDTRIP
+//#define MX_COMPILE_CORE_TESTS
+//#define MX_COMPILE_IMPL_TESTS
+//#define MX_COMPILE_IMPORT_TESTS
+//#define MX_COMPILE_NEW_DECIMAL_TESTS
+//#define MX_COMPILE_UTILTIY_TESTS
 
 // use this to restrict the size of the files that
 // the test run will open (compile-time constant).

--- a/Sourcecode/private/mxtest/control/CompileControl.h
+++ b/Sourcecode/private/mxtest/control/CompileControl.h
@@ -4,13 +4,14 @@
 
 #pragma once
 
-//#define MX_COMPILE_API_TESTS
-//#define MX_COMPILE_API_ROUNDTRIP
-//#define MX_COMPILE_CORE_TESTS
-//#define MX_COMPILE_IMPL_TESTS
-//#define MX_COMPILE_IMPORT_TESTS
-//#define MX_COMPILE_NEW_DECIMAL_TESTS
-//#define MX_COMPILE_UTILTIY_TESTS
+#define MX_COMPILE_API_TESTS
+#define MX_COMPILE_API_ROUNDTRIP
+// #define MX_COMPILE_CORE_TESTS
+#define MX_COMPILE_IMPL_TESTS
+#define MX_COMPILE_IMPORT_TESTS
+#define MX_COMPILE_NEW_DECIMAL_TESTS
+#define MX_COMPILE_UTILTIY_TESTS
+#define MX_COMPILE_XML_TESTS
 
 // use this to restrict the size of the files that
 // the test run will open (compile-time constant).

--- a/Sourcecode/private/mxtest/control/CompileControl.h
+++ b/Sourcecode/private/mxtest/control/CompileControl.h
@@ -13,7 +13,6 @@
 #define MX_COMPILE_UTILTIY_TESTS
 #define MX_COMPILE_XML_TESTS
 
-// use this to restrict the size of the files that
-// the test run will open (compile-time constant).
+// use this to restrict the size of the files that will be processed during the test run.
 // 0 indicates no limit
-constexpr const int MX_COMPILE_MAX_FILE_SIZE_BYTES = 0; // 1024 * 3; // (1024 * 1024);
+constexpr const int MX_COMPILE_MAX_FILE_SIZE_BYTES = 0;


### PR DESCRIPTION
As requested in #42, PitchData can now support a microtonal adjustment.