### PR TITLE
Add NonTraditional support to KeyData.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -38,7 +38,7 @@ file(GLOB_RECURSE SRC_MX_TEST_UTILITY ${PRIVATE_DIR}/mxtest/utility/*.cpp ${PRIV
 file(GLOB_RECURSE SRC_CPUL ${PRIVATE_DIR}/cpul/*.cpp ${SOURCE}/cpul/*.h)
 
 # Mx Library
-add_library(${PROJECT_NAME} STATIC ${SRC_MX_API} ${SRC_MX_CORE} ${SRC_MX_IMPL} ${SRC_MX_PUGIXML} ${SRC_MX_UTILITY})
+add_library(${PROJECT_NAME} STATIC ${HEADERS_MX_API} ${SRC_MX_API} ${SRC_MX_CORE} ${SRC_MX_IMPL} ${SRC_MX_PUGIXML} ${SRC_MX_UTILITY})
 source_group( "api-public" FILES ${HEADERS_MX_API})
 source_group( "api" FILES ${SRC_MX_API} )
 source_group( "core" FILES ${SRC_MX_CORE} )
@@ -103,6 +103,7 @@ if(MX_BUILD_TESTS)
     target_link_libraries(MxTest ${PROJECT_NAME})
     target_link_libraries(MxTest ${CMAKE_THREAD_LIBS_INIT})
     set_property(TARGET MxTest PROPERTY CXX_STANDARD 14)
+    set_property(DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR} PROPERTY VS_STARTUP_PROJECT MxTest)
 else()
     message(STATUS "${PROJECT_NAME}:${CMAKE_CURRENT_LIST_LINE} tests will NOT be compiled")
 endif()

--- a/Sourcecode/include/mx/api/KeyData.h
+++ b/Sourcecode/include/mx/api/KeyData.h
@@ -4,6 +4,10 @@
 
 #pragma once
 
+#include "mx/api/PitchData.h"
+
+#include <vector>
+
 namespace mx
 {
 	namespace api
@@ -49,6 +53,14 @@ namespace mx
             // within the part
             int staffIndex;
             
+            // If this is true, the KeyData is in "Non Traditional" mode.
+            // The the 'fifths' and 'mode' member variables will be ignored, and
+            // key data will be read from nonTraditionalPitchData.
+            bool nonTraditionalKey;
+            // The non-tradional accidentals.
+            // Fill this with your custom accidentals and alters.
+            std::vector<PitchData> nonTraditionalPitchData;
+
 			// TODO support position data and/or other attribtues
             
             KeyData()
@@ -57,6 +69,8 @@ namespace mx
             , mode{ KeyMode::unspecified }
             , tickTimePosition{ 0 }
             , staffIndex{ -1 }
+            , nonTraditionalKey{ false }
+            , nonTraditionalPitchData{}
             {
                 
             }
@@ -68,6 +82,8 @@ namespace mx
         MXAPI_EQUALS_MEMBER( mode )
         MXAPI_EQUALS_MEMBER( tickTimePosition )
         MXAPI_EQUALS_MEMBER( staffIndex )
+        MXAPI_EQUALS_MEMBER( nonTraditionalKey )
+        MXAPI_EQUALS_MEMBER( nonTraditionalPitchData )
         MXAPI_EQUALS_END;
         MXAPI_NOT_EQUALS_AND_VECTORS( KeyData );
 	}

--- a/Sourcecode/include/mx/api/PitchData.h
+++ b/Sourcecode/include/mx/api/PitchData.h
@@ -10,15 +10,16 @@ namespace mx
 {
     namespace api
     {
-    	enum class Step
-    	{
-    		c = 0,
-    		d = 1,
-    		e = 2,
-    		f = 3,
-    		g = 4,
-    		a = 5,
-    		b = 6,
+        enum class Step
+        {
+            c = 0,
+            d = 1,
+            e = 2,
+            f = 3,
+            g = 4,
+            a = 5,
+            b = 6,
+            count,
             unspecified = -1
     	};
 

--- a/Sourcecode/private/mx/impl/PropertiesWriter.h
+++ b/Sourcecode/private/mx/impl/PropertiesWriter.h
@@ -7,6 +7,7 @@
 #include "mx/api/TimeSignatureData.h"
 #include "mx/api/KeyData.h"
 #include "mx/api/ClefData.h"
+#include "mx/impl/Converter.h"
 #include <memory>
 
 namespace mx
@@ -53,6 +54,7 @@ namespace mx
         private:
             core::PropertiesPtr myProperties;
             const core::PartwiseMeasurePtr& myPartwiseMeasure;
+            const Converter myConverter;
         };
     }
 }

--- a/Sourcecode/private/mxtest/api/ApiMuAccidentals1ScoreData.h
+++ b/Sourcecode/private/mxtest/api/ApiMuAccidentals1ScoreData.h
@@ -91,8 +91,19 @@ namespace mxtest
         measure->timeSignature.beatType = 4;
         measure->timeSignature.isImplicit = true;
         measure->staves.emplace_back( StaffData{} );
+        measure->keys.emplace_back( KeyData{} );
+        key = measure->keys.back();
+        key.nonTraditionalKey = true;
+        for (size_t i = 0; i < size_t(Step::count); ++i) {
+            PitchData p;
+            p.step = Step(i);
+            p.accidental = Accidental::doubleSharp;
+            p.alter = 2;
+            key.nonTraditionalPitchData.push_back(std::move(p));
+        }
+
+
         staff = &measure->staves.back();
-        
         staff->voices[0].notes.emplace_back( NoteData{} );
         note = &staff->voices[0].notes.back();
         note->userRequestedVoiceNumber = 1;


### PR DESCRIPTION
Fixes https://github.com/webern/mx/issues/70

As far as I could tell, this should be enough to support non-traditional keys in `api`.

However, I couldn't for the life of me figure out your unit test framework :) Could you explain to me how to add some tests for this? ty

Of note
- Using a vector of `PitchData`. Maybe you'd rather I add a new "Data" type which only contains step, alter and accidental? `NonTraditionalData` maybe?
- Minor tweaks to cmake.
- No tests yet! PR will stay Draft until I can add some good tests.