### PR TITLE
make binary names lowercase

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -27,11 +27,11 @@ jobs:
 
       - run:
           name: Run Examples
-          command: ./MxRead && ./MxWrite
+          command: ./mxread && ./mxwrite
 
       - run:
           name: Test
-          command: ./MxTest
+          command: ./mxtest
 
       # - store_artifacts:
       #     path: /tmp/coverage/

--- a/.circleci/dockerfile-test-entrypoint.sh
+++ b/.circleci/dockerfile-test-entrypoint.sh
@@ -20,23 +20,23 @@ sep
 make -j12
 
 sep
-echo "running MxHide"
-./MxHide
+echo "running mxhide"
+./mxhide
 echo "success"
 
 sep
-echo "running MxWrite"
-./MxWrite
+echo "running mxwrite"
+./mxwrite
 echo "success"
 
 sep
-echo "running MxRead"
-./MxRead
+echo "running mxread"
+./mxread
 echo "success"
 
 sep
-echo "running MxTest"
-./MxTest
+echo "running mxtest"
+./mxtest
 echo "success"
 
 echo ""

--- a/.github/workflows/ccpp.yml
+++ b/.github/workflows/ccpp.yml
@@ -24,10 +24,10 @@ jobs:
       run: export CORE_COUNT=$(nproc --all) && make -j$CORE_COUNT
       
     - name: Run Examples
-      run: ./MxRead && ./MxWrite
+      run: ./mxread && ./mxwrite
       
     - name: Run Tests
-      run: ./MxTest
+      run: ./mxtest
   
   windows:
     name: Windows
@@ -50,14 +50,14 @@ jobs:
     #- name: List Debug Dir
     #  run: cd x64 -and dir
       
-    - name: Run Example MxWrite
-      run: Debug\MxWrite.exe
+    - name: Run Example mxwrite
+      run: Debug\mxwrite.exe
     
-    - name: Run Example MxRead
-      run: Debug\MxRead.exe
+    - name: Run Example mxread
+      run: Debug\mxread.exe
     
     - name: Run Tests
-      run: Debug\MxTest.exe
+      run: Debug\mxtest.exe
   
   macos:
     name: macOS
@@ -74,14 +74,14 @@ jobs:
       run: |
           cmake --build .
     
-    - name: Run Example MxWrite
-      run: ./MxWrite
+    - name: Run Example mxwrite
+      run: ./mxwrite
     
-    - name: Run Example MxRead
-      run: ./MxRead
+    - name: Run Example mxread
+      run: ./mxread
     
     - name: Run Tests
-      run: ./MxTest
+      run: ./mxtest
 
   xcode:
     name: Xcode

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
 cmake_minimum_required(VERSION 3.7.2)
-project(Mx)
+project(mx)
 
 include(GNUInstallDirs)
 include(CMakePackageConfigHelpers)
@@ -36,7 +36,7 @@ file(GLOB_RECURSE SRC_MX_TEST_IMPORT ${PRIVATE_DIR}/mxtest/import/*.cpp ${PRIVAT
 file(GLOB_RECURSE SRC_MX_TEST_UTILITY ${PRIVATE_DIR}/mxtest/utility/*.cpp ${PRIVATE_DIR}/mxtest/utility/*.h)
 file(GLOB_RECURSE SRC_CPUL ${PRIVATE_DIR}/cpul/*.cpp ${SOURCE}/cpul/*.h)
 
-# Mx Library
+# mx static library
 add_library(${PROJECT_NAME} STATIC ${SRC_MX_API} ${SRC_MX_CORE} ${SRC_MX_IMPL} ${SRC_MX_UTILITY} ${SRC_MX_EZXML})
 source_group( "api-public" FILES ${HEADERS_MX_API})
 source_group( "api" FILES ${SRC_MX_API} )
@@ -89,9 +89,9 @@ file(WRITE ${PRIVATE_DIR}/mxtest/file/PathRoot.h
 )
 
 
-# MxTest
+# mxtest
 if(MX_BUILD_TESTS)
-    set(TEST_BINARY_NAME MxTest)
+    set(TEST_BINARY_NAME mxtest)
     message(STATUS "${PROJECT_NAME}:${CMAKE_CURRENT_LIST_LINE} tests will be compiled")
     if(MX_BUILD_CORE_TESTS)
         message(STATUS "${PROJECT_NAME}:${CMAKE_CURRENT_LIST_LINE} core tests will be compiled")
@@ -128,18 +128,18 @@ else()
     message(STATUS "${PROJECT_NAME}:${CMAKE_CURRENT_LIST_LINE} tests will NOT be compiled")
 endif()
 
-# MxExamples
+# mx examples
 if(MX_BUILD_EXAMPLES)
     message(STATUS "${PROJECT_NAME}:${CMAKE_CURRENT_LIST_LINE} examples will be compiled")
-    add_executable(MxRead ${PRIVATE_DIR}/mx/examples/Read.cpp)
-    add_executable(MxWrite ${PRIVATE_DIR}/mx/examples/Write.cpp)
-    add_executable(MxHide ${PRIVATE_DIR}/mx/examples/Hide.cpp)
-    target_link_libraries(MxRead ${PROJECT_NAME} ${CMAKE_THREAD_LIBS_INIT})
-    target_link_libraries(MxWrite ${PROJECT_NAME} ${CMAKE_THREAD_LIBS_INIT})
-    target_link_libraries(MxHide ${PROJECT_NAME} ${CMAKE_THREAD_LIBS_INIT})
-    set_property(TARGET MxRead PROPERTY CXX_STANDARD ${CPP_VERSION})
-    set_property(TARGET MxWrite PROPERTY CXX_STANDARD ${CPP_VERSION})
-    set_property(TARGET MxHide PROPERTY CXX_STANDARD ${CPP_VERSION})
+    add_executable(mxread ${PRIVATE_DIR}/mx/examples/Read.cpp)
+    add_executable(mxwrite ${PRIVATE_DIR}/mx/examples/Write.cpp)
+    add_executable(mxhide ${PRIVATE_DIR}/mx/examples/Hide.cpp)
+    target_link_libraries(mxread ${PROJECT_NAME} ${CMAKE_THREAD_LIBS_INIT})
+    target_link_libraries(mxwrite ${PROJECT_NAME} ${CMAKE_THREAD_LIBS_INIT})
+    target_link_libraries(mxhide ${PROJECT_NAME} ${CMAKE_THREAD_LIBS_INIT})
+    set_property(TARGET mxread PROPERTY CXX_STANDARD ${CPP_VERSION})
+    set_property(TARGET mxwrite PROPERTY CXX_STANDARD ${CPP_VERSION})
+    set_property(TARGET mxhide PROPERTY CXX_STANDARD ${CPP_VERSION})
 else()
     message(STATUS "${PROJECT_NAME}:${CMAKE_CURRENT_LIST_LINE} examples will NOT be compiled")
 endif()

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ mkdir build
 cd build
 cmake ../mx -DMX_BUILD_TESTS=on -DMX_BUILD_CORE_TESTS=off -DMX_BUILD_EXAMPLES=on
 make -j6
-./MxTest
+./mxtest
 ```
 
 ### Cmake Options
@@ -764,6 +764,6 @@ int main(int argc, const char * argv[])
 
 ### Unit Test Framework
 
-An executable program named MxTest is also included in the project.
-MxTest utilizes the Catch2 test framework.
+An executable program named mxtest is also included in the project.
+mxtest utilizes the Catch2 test framework.
 The core tests are slow to compile, see the [`cmake` options](#cmake-options) section for more info on how to skip compilation of the tests.


### PR DESCRIPTION
This change could be annoying on a case insensitive filesystem. But it seems somewhat uncool to name your binaries with uppercase letters.