### PR TITLE
codegen: regenerate enums from xsd

### DIFF
--- a/Sourcecode/private/mx/core/Enums.cpp
+++ b/Sourcecode/private/mx/core/Enums.cpp
@@ -4,10 +4,15 @@
 
 #include "mx/core/Enums.h"
 
+#include <ostream>
+#include <string>
+
 namespace mx
 {
     namespace core
     {
+        /// AboveBelow /////////////////////////////////////////////////////////////////////////////
+
         AboveBelow parseAboveBelow( const std::string& value )
         {
             if ( value == "above" ) { return AboveBelow::above; }
@@ -15,2394 +20,28 @@ namespace mx
             return AboveBelow::above;
         }
 
-
         std::string toString( const AboveBelow value )
         {
-            switch ( value ) 
+            switch ( value )
             {
-                case AboveBelow::above: return "above";
-                case AboveBelow::below: return "below";
+                case AboveBelow::above: { return "above"; }
+                case AboveBelow::below: { return "below"; }
                 default: break;
             }
             return "above";
         }
-
 
         std::ostream& toStream( std::ostream& os, const AboveBelow value )
         {
             return os << toString( value );
         }
 
-
         std::ostream& operator<<( std::ostream& os, const AboveBelow value )
         {
             return toStream( os, value );
         }
 
-        CssFontSize parseCssFontSize( const std::string& value )
-        {
-            if ( value == "xx-small" ) { return CssFontSize::xxSmall; }
-            else if ( value == "x-small" ) { return CssFontSize::xSmall; }
-            else if ( value == "small" ) { return CssFontSize::small; }
-            else if ( value == "medium" ) { return CssFontSize::medium; }
-            else if ( value == "large" ) { return CssFontSize::large; }
-            else if ( value == "x-large" ) { return CssFontSize::xLarge; }
-            else if ( value == "xx-large" ) { return CssFontSize::xxLarge; }
-            return CssFontSize::xxSmall;
-        }
-
-
-        std::string toString( const CssFontSize value )
-        {
-            switch ( value ) 
-            {
-                case CssFontSize::xxSmall: return "xx-small";
-                case CssFontSize::xSmall: return "x-small";
-                case CssFontSize::small: return "small";
-                case CssFontSize::medium: return "medium";
-                case CssFontSize::large: return "large";
-                case CssFontSize::xLarge: return "x-large";
-                case CssFontSize::xxLarge: return "xx-large";
-                default: break;
-            }
-            return "xx-small";
-        }
-
-
-        std::ostream& toStream( std::ostream& os, const CssFontSize value )
-        {
-            return os << toString( value );
-        }
-
-
-        std::ostream& operator<<( std::ostream& os, const CssFontSize value )
-        {
-            return toStream( os, value );
-        }
-
-        EnclosureShape parseEnclosureShape( const std::string& value )
-        {
-            if ( value == "rectangle" ) { return EnclosureShape::rectangle; }
-            else if ( value == "square" ) { return EnclosureShape::square; }
-            else if ( value == "oval" ) { return EnclosureShape::oval; }
-            else if ( value == "circle" ) { return EnclosureShape::circle; }
-            else if ( value == "bracket" ) { return EnclosureShape::bracket; }
-            else if ( value == "triangle" ) { return EnclosureShape::triangle; }
-            else if ( value == "diamond" ) { return EnclosureShape::diamond; }
-            else if ( value == "none" ) { return EnclosureShape::none; }
-            return EnclosureShape::rectangle;
-        }
-
-
-        std::string toString( const EnclosureShape value )
-        {
-            switch ( value ) 
-            {
-                case EnclosureShape::rectangle: return "rectangle";
-                case EnclosureShape::square: return "square";
-                case EnclosureShape::oval: return "oval";
-                case EnclosureShape::circle: return "circle";
-                case EnclosureShape::bracket: return "bracket";
-                case EnclosureShape::triangle: return "triangle";
-                case EnclosureShape::diamond: return "diamond";
-                case EnclosureShape::none: return "none";
-                default: break;
-            }
-            return "rectangle";
-        }
-
-
-        std::ostream& toStream( std::ostream& os, const EnclosureShape value )
-        {
-            return os << toString( value );
-        }
-
-
-        std::ostream& operator<<( std::ostream& os, const EnclosureShape value )
-        {
-            return toStream( os, value );
-        }
-
-        FermataShape parseFermataShape( const std::string& value )
-        {
-            if ( value == "normal" ) { return FermataShape::normal; }
-            else if ( value == "angled" ) { return FermataShape::angled; }
-            else if ( value == "square" ) { return FermataShape::square; }
-            else if ( value == "" ) { return FermataShape::emptystring; }
-            return FermataShape::normal;
-        }
-
-
-        std::string toString( const FermataShape value )
-        {
-            switch ( value ) 
-            {
-                case FermataShape::normal: return "normal";
-                case FermataShape::angled: return "angled";
-                case FermataShape::square: return "square";
-                case FermataShape::emptystring: return "";
-                default: break;
-            }
-            return "normal";
-        }
-
-
-        std::ostream& toStream( std::ostream& os, const FermataShape value )
-        {
-            return os << toString( value );
-        }
-
-
-        std::ostream& operator<<( std::ostream& os, const FermataShape value )
-        {
-            return toStream( os, value );
-        }
-
-        FontStyle parseFontStyle( const std::string& value )
-        {
-            if ( value == "normal" ) { return FontStyle::normal; }
-            else if ( value == "italic" ) { return FontStyle::italic; }
-            return FontStyle::normal;
-        }
-
-
-        std::string toString( const FontStyle value )
-        {
-            switch ( value ) 
-            {
-                case FontStyle::normal: return "normal";
-                case FontStyle::italic: return "italic";
-                default: break;
-            }
-            return "normal";
-        }
-
-
-        std::ostream& toStream( std::ostream& os, const FontStyle value )
-        {
-            return os << toString( value );
-        }
-
-
-        std::ostream& operator<<( std::ostream& os, const FontStyle value )
-        {
-            return toStream( os, value );
-        }
-
-        FontWeight parseFontWeight( const std::string& value )
-        {
-            if ( value == "normal" ) { return FontWeight::normal; }
-            else if ( value == "bold" ) { return FontWeight::bold; }
-            return FontWeight::normal;
-        }
-
-
-        std::string toString( const FontWeight value )
-        {
-            switch ( value ) 
-            {
-                case FontWeight::normal: return "normal";
-                case FontWeight::bold: return "bold";
-                default: break;
-            }
-            return "normal";
-        }
-
-
-        std::ostream& toStream( std::ostream& os, const FontWeight value )
-        {
-            return os << toString( value );
-        }
-
-
-        std::ostream& operator<<( std::ostream& os, const FontWeight value )
-        {
-            return toStream( os, value );
-        }
-
-        LeftCenterRight parseLeftCenterRight( const std::string& value )
-        {
-            if ( value == "left" ) { return LeftCenterRight::left; }
-            else if ( value == "center" ) { return LeftCenterRight::center; }
-            else if ( value == "right" ) { return LeftCenterRight::right; }
-            return LeftCenterRight::left;
-        }
-
-
-        std::string toString( const LeftCenterRight value )
-        {
-            switch ( value ) 
-            {
-                case LeftCenterRight::left: return "left";
-                case LeftCenterRight::center: return "center";
-                case LeftCenterRight::right: return "right";
-                default: break;
-            }
-            return "left";
-        }
-
-
-        std::ostream& toStream( std::ostream& os, const LeftCenterRight value )
-        {
-            return os << toString( value );
-        }
-
-
-        std::ostream& operator<<( std::ostream& os, const LeftCenterRight value )
-        {
-            return toStream( os, value );
-        }
-
-        LeftRight parseLeftRight( const std::string& value )
-        {
-            if ( value == "left" ) { return LeftRight::left; }
-            else if ( value == "right" ) { return LeftRight::right; }
-            return LeftRight::left;
-        }
-
-
-        std::string toString( const LeftRight value )
-        {
-            switch ( value ) 
-            {
-                case LeftRight::left: return "left";
-                case LeftRight::right: return "right";
-                default: break;
-            }
-            return "left";
-        }
-
-
-        std::ostream& toStream( std::ostream& os, const LeftRight value )
-        {
-            return os << toString( value );
-        }
-
-
-        std::ostream& operator<<( std::ostream& os, const LeftRight value )
-        {
-            return toStream( os, value );
-        }
-
-        LineShape parseLineShape( const std::string& value )
-        {
-            if ( value == "straight" ) { return LineShape::straight; }
-            else if ( value == "curved" ) { return LineShape::curved; }
-            return LineShape::straight;
-        }
-
-
-        std::string toString( const LineShape value )
-        {
-            switch ( value ) 
-            {
-                case LineShape::straight: return "straight";
-                case LineShape::curved: return "curved";
-                default: break;
-            }
-            return "straight";
-        }
-
-
-        std::ostream& toStream( std::ostream& os, const LineShape value )
-        {
-            return os << toString( value );
-        }
-
-
-        std::ostream& operator<<( std::ostream& os, const LineShape value )
-        {
-            return toStream( os, value );
-        }
-
-        LineType parseLineType( const std::string& value )
-        {
-            if ( value == "solid" ) { return LineType::solid; }
-            else if ( value == "dashed" ) { return LineType::dashed; }
-            else if ( value == "dotted" ) { return LineType::dotted; }
-            else if ( value == "wavy" ) { return LineType::wavy; }
-            return LineType::solid;
-        }
-
-
-        std::string toString( const LineType value )
-        {
-            switch ( value ) 
-            {
-                case LineType::solid: return "solid";
-                case LineType::dashed: return "dashed";
-                case LineType::dotted: return "dotted";
-                case LineType::wavy: return "wavy";
-                default: break;
-            }
-            return "solid";
-        }
-
-
-        std::ostream& toStream( std::ostream& os, const LineType value )
-        {
-            return os << toString( value );
-        }
-
-
-        std::ostream& operator<<( std::ostream& os, const LineType value )
-        {
-            return toStream( os, value );
-        }
-
-        MuteEnum parseMuteEnum( const std::string& value )
-        {
-            if ( value == "on" ) { return MuteEnum::on; }
-            else if ( value == "off" ) { return MuteEnum::off; }
-            else if ( value == "straight" ) { return MuteEnum::straight; }
-            else if ( value == "cup" ) { return MuteEnum::cup; }
-            else if ( value == "harmon-no-stem" ) { return MuteEnum::harmonNoStem; }
-            else if ( value == "harmon-stem" ) { return MuteEnum::harmonStem; }
-            else if ( value == "bucket" ) { return MuteEnum::bucket; }
-            else if ( value == "plunger" ) { return MuteEnum::plunger; }
-            else if ( value == "hat" ) { return MuteEnum::hat; }
-            else if ( value == "solotone" ) { return MuteEnum::solotone; }
-            else if ( value == "practice" ) { return MuteEnum::practice; }
-            else if ( value == "stop-mute" ) { return MuteEnum::stopMute; }
-            else if ( value == "stop-hand" ) { return MuteEnum::stopHand; }
-            else if ( value == "echo" ) { return MuteEnum::echo; }
-            else if ( value == "palm" ) { return MuteEnum::palm; }
-            return MuteEnum::on;
-        }
-
-
-        std::string toString( const MuteEnum value )
-        {
-            switch ( value ) 
-            {
-                case MuteEnum::on: return "on";
-                case MuteEnum::off: return "off";
-                case MuteEnum::straight: return "straight";
-                case MuteEnum::cup: return "cup";
-                case MuteEnum::harmonNoStem: return "harmon-no-stem";
-                case MuteEnum::harmonStem: return "harmon-stem";
-                case MuteEnum::bucket: return "bucket";
-                case MuteEnum::plunger: return "plunger";
-                case MuteEnum::hat: return "hat";
-                case MuteEnum::solotone: return "solotone";
-                case MuteEnum::practice: return "practice";
-                case MuteEnum::stopMute: return "stop-mute";
-                case MuteEnum::stopHand: return "stop-hand";
-                case MuteEnum::echo: return "echo";
-                case MuteEnum::palm: return "palm";
-                default: break;
-            }
-            return "on";
-        }
-
-
-        std::ostream& toStream( std::ostream& os, const MuteEnum value )
-        {
-            return os << toString( value );
-        }
-
-
-        std::ostream& operator<<( std::ostream& os, const MuteEnum value )
-        {
-            return toStream( os, value );
-        }
-
-        OverUnder parseOverUnder( const std::string& value )
-        {
-            if ( value == "over" ) { return OverUnder::over; }
-            else if ( value == "under" ) { return OverUnder::under; }
-            return OverUnder::over;
-        }
-
-
-        std::string toString( const OverUnder value )
-        {
-            switch ( value ) 
-            {
-                case OverUnder::over: return "over";
-                case OverUnder::under: return "under";
-                default: break;
-            }
-            return "over";
-        }
-
-
-        std::ostream& toStream( std::ostream& os, const OverUnder value )
-        {
-            return os << toString( value );
-        }
-
-
-        std::ostream& operator<<( std::ostream& os, const OverUnder value )
-        {
-            return toStream( os, value );
-        }
-
-        SemiPitchedEnum parseSemiPitchedEnum( const std::string& value )
-        {
-            if ( value == "high" ) { return SemiPitchedEnum::high; }
-            else if ( value == "medium-high" ) { return SemiPitchedEnum::mediumHigh; }
-            else if ( value == "medium" ) { return SemiPitchedEnum::medium; }
-            else if ( value == "medium-low" ) { return SemiPitchedEnum::mediumLow; }
-            else if ( value == "low" ) { return SemiPitchedEnum::low; }
-            else if ( value == "very-low" ) { return SemiPitchedEnum::veryLow; }
-            return SemiPitchedEnum::high;
-        }
-
-
-        std::string toString( const SemiPitchedEnum value )
-        {
-            switch ( value ) 
-            {
-                case SemiPitchedEnum::high: return "high";
-                case SemiPitchedEnum::mediumHigh: return "medium-high";
-                case SemiPitchedEnum::medium: return "medium";
-                case SemiPitchedEnum::mediumLow: return "medium-low";
-                case SemiPitchedEnum::low: return "low";
-                case SemiPitchedEnum::veryLow: return "very-low";
-                default: break;
-            }
-            return "high";
-        }
-
-
-        std::ostream& toStream( std::ostream& os, const SemiPitchedEnum value )
-        {
-            return os << toString( value );
-        }
-
-
-        std::ostream& operator<<( std::ostream& os, const SemiPitchedEnum value )
-        {
-            return toStream( os, value );
-        }
-
-        StartNote parseStartNote( const std::string& value )
-        {
-            if ( value == "upper" ) { return StartNote::upper; }
-            else if ( value == "main" ) { return StartNote::main; }
-            else if ( value == "below" ) { return StartNote::below; }
-            return StartNote::upper;
-        }
-
-
-        std::string toString( const StartNote value )
-        {
-            switch ( value ) 
-            {
-                case StartNote::upper: return "upper";
-                case StartNote::main: return "main";
-                case StartNote::below: return "below";
-                default: break;
-            }
-            return "upper";
-        }
-
-
-        std::ostream& toStream( std::ostream& os, const StartNote value )
-        {
-            return os << toString( value );
-        }
-
-
-        std::ostream& operator<<( std::ostream& os, const StartNote value )
-        {
-            return toStream( os, value );
-        }
-
-        StartStop parseStartStop( const std::string& value )
-        {
-            if ( value == "start" ) { return StartStop::start; }
-            else if ( value == "stop" ) { return StartStop::stop; }
-            return StartStop::start;
-        }
-
-
-        std::string toString( const StartStop value )
-        {
-            switch ( value ) 
-            {
-                case StartStop::start: return "start";
-                case StartStop::stop: return "stop";
-                default: break;
-            }
-            return "start";
-        }
-
-
-        std::ostream& toStream( std::ostream& os, const StartStop value )
-        {
-            return os << toString( value );
-        }
-
-
-        std::ostream& operator<<( std::ostream& os, const StartStop value )
-        {
-            return toStream( os, value );
-        }
-
-        StartStopContinue parseStartStopContinue( const std::string& value )
-        {
-            if ( value == "start" ) { return StartStopContinue::start; }
-            else if ( value == "stop" ) { return StartStopContinue::stop; }
-            else if ( value == "continue" ) { return StartStopContinue::continue_; }
-            return StartStopContinue::start;
-        }
-
-
-        std::string toString( const StartStopContinue value )
-        {
-            switch ( value ) 
-            {
-                case StartStopContinue::start: return "start";
-                case StartStopContinue::stop: return "stop";
-                case StartStopContinue::continue_: return "continue";
-                default: break;
-            }
-            return "start";
-        }
-
-
-        std::ostream& toStream( std::ostream& os, const StartStopContinue value )
-        {
-            return os << toString( value );
-        }
-
-
-        std::ostream& operator<<( std::ostream& os, const StartStopContinue value )
-        {
-            return toStream( os, value );
-        }
-
-        StartStopSingle parseStartStopSingle( const std::string& value )
-        {
-            if ( value == "start" ) { return StartStopSingle::start; }
-            else if ( value == "stop" ) { return StartStopSingle::stop; }
-            else if ( value == "single" ) { return StartStopSingle::single; }
-            return StartStopSingle::start;
-        }
-
-
-        std::string toString( const StartStopSingle value )
-        {
-            switch ( value ) 
-            {
-                case StartStopSingle::start: return "start";
-                case StartStopSingle::stop: return "stop";
-                case StartStopSingle::single: return "single";
-                default: break;
-            }
-            return "start";
-        }
-
-
-        std::ostream& toStream( std::ostream& os, const StartStopSingle value )
-        {
-            return os << toString( value );
-        }
-
-
-        std::ostream& operator<<( std::ostream& os, const StartStopSingle value )
-        {
-            return toStream( os, value );
-        }
-
-        SymbolSize parseSymbolSize( const std::string& value )
-        {
-            if ( value == "full" ) { return SymbolSize::full; }
-            else if ( value == "cue" ) { return SymbolSize::cue; }
-            else if ( value == "large" ) { return SymbolSize::large; }
-            return SymbolSize::full;
-        }
-
-
-        std::string toString( const SymbolSize value )
-        {
-            switch ( value ) 
-            {
-                case SymbolSize::full: return "full";
-                case SymbolSize::cue: return "cue";
-                case SymbolSize::large: return "large";
-                default: break;
-            }
-            return "full";
-        }
-
-
-        std::ostream& toStream( std::ostream& os, const SymbolSize value )
-        {
-            return os << toString( value );
-        }
-
-
-        std::ostream& operator<<( std::ostream& os, const SymbolSize value )
-        {
-            return toStream( os, value );
-        }
-
-        TextDirection parseTextDirection( const std::string& value )
-        {
-            if ( value == "ltr" ) { return TextDirection::ltr; }
-            else if ( value == "rtl" ) { return TextDirection::rtl; }
-            else if ( value == "lro" ) { return TextDirection::lro; }
-            else if ( value == "rlo" ) { return TextDirection::rlo; }
-            return TextDirection::ltr;
-        }
-
-
-        std::string toString( const TextDirection value )
-        {
-            switch ( value ) 
-            {
-                case TextDirection::ltr: return "ltr";
-                case TextDirection::rtl: return "rtl";
-                case TextDirection::lro: return "lro";
-                case TextDirection::rlo: return "rlo";
-                default: break;
-            }
-            return "ltr";
-        }
-
-
-        std::ostream& toStream( std::ostream& os, const TextDirection value )
-        {
-            return os << toString( value );
-        }
-
-
-        std::ostream& operator<<( std::ostream& os, const TextDirection value )
-        {
-            return toStream( os, value );
-        }
-
-        TopBottom parseTopBottom( const std::string& value )
-        {
-            if ( value == "top" ) { return TopBottom::top; }
-            else if ( value == "bottom" ) { return TopBottom::bottom; }
-            return TopBottom::top;
-        }
-
-
-        std::string toString( const TopBottom value )
-        {
-            switch ( value ) 
-            {
-                case TopBottom::top: return "top";
-                case TopBottom::bottom: return "bottom";
-                default: break;
-            }
-            return "top";
-        }
-
-
-        std::ostream& toStream( std::ostream& os, const TopBottom value )
-        {
-            return os << toString( value );
-        }
-
-
-        std::ostream& operator<<( std::ostream& os, const TopBottom value )
-        {
-            return toStream( os, value );
-        }
-
-        TrillStep parseTrillStep( const std::string& value )
-        {
-            if ( value == "whole" ) { return TrillStep::whole; }
-            else if ( value == "half" ) { return TrillStep::half; }
-            else if ( value == "unison" ) { return TrillStep::unison; }
-            return TrillStep::whole;
-        }
-
-
-        std::string toString( const TrillStep value )
-        {
-            switch ( value ) 
-            {
-                case TrillStep::whole: return "whole";
-                case TrillStep::half: return "half";
-                case TrillStep::unison: return "unison";
-                default: break;
-            }
-            return "whole";
-        }
-
-
-        std::ostream& toStream( std::ostream& os, const TrillStep value )
-        {
-            return os << toString( value );
-        }
-
-
-        std::ostream& operator<<( std::ostream& os, const TrillStep value )
-        {
-            return toStream( os, value );
-        }
-
-        TwoNoteTurn parseTwoNoteTurn( const std::string& value )
-        {
-            if ( value == "whole" ) { return TwoNoteTurn::whole; }
-            else if ( value == "half" ) { return TwoNoteTurn::half; }
-            else if ( value == "none" ) { return TwoNoteTurn::none; }
-            return TwoNoteTurn::whole;
-        }
-
-
-        std::string toString( const TwoNoteTurn value )
-        {
-            switch ( value ) 
-            {
-                case TwoNoteTurn::whole: return "whole";
-                case TwoNoteTurn::half: return "half";
-                case TwoNoteTurn::none: return "none";
-                default: break;
-            }
-            return "whole";
-        }
-
-
-        std::ostream& toStream( std::ostream& os, const TwoNoteTurn value )
-        {
-            return os << toString( value );
-        }
-
-
-        std::ostream& operator<<( std::ostream& os, const TwoNoteTurn value )
-        {
-            return toStream( os, value );
-        }
-
-        UpDown parseUpDown( const std::string& value )
-        {
-            if ( value == "up" ) { return UpDown::up; }
-            else if ( value == "down" ) { return UpDown::down; }
-            return UpDown::up;
-        }
-
-
-        std::string toString( const UpDown value )
-        {
-            switch ( value ) 
-            {
-                case UpDown::up: return "up";
-                case UpDown::down: return "down";
-                default: break;
-            }
-            return "up";
-        }
-
-
-        std::ostream& toStream( std::ostream& os, const UpDown value )
-        {
-            return os << toString( value );
-        }
-
-
-        std::ostream& operator<<( std::ostream& os, const UpDown value )
-        {
-            return toStream( os, value );
-        }
-
-        UprightInverted parseUprightInverted( const std::string& value )
-        {
-            if ( value == "upright" ) { return UprightInverted::upright; }
-            else if ( value == "inverted" ) { return UprightInverted::inverted; }
-            return UprightInverted::upright;
-        }
-
-
-        std::string toString( const UprightInverted value )
-        {
-            switch ( value ) 
-            {
-                case UprightInverted::upright: return "upright";
-                case UprightInverted::inverted: return "inverted";
-                default: break;
-            }
-            return "upright";
-        }
-
-
-        std::ostream& toStream( std::ostream& os, const UprightInverted value )
-        {
-            return os << toString( value );
-        }
-
-
-        std::ostream& operator<<( std::ostream& os, const UprightInverted value )
-        {
-            return toStream( os, value );
-        }
-
-        Valign parseValign( const std::string& value )
-        {
-            if ( value == "top" ) { return Valign::top; }
-            else if ( value == "middle" ) { return Valign::middle; }
-            else if ( value == "bottom" ) { return Valign::bottom; }
-            else if ( value == "baseline" ) { return Valign::baseline; }
-            return Valign::top;
-        }
-
-
-        std::string toString( const Valign value )
-        {
-            switch ( value ) 
-            {
-                case Valign::top: return "top";
-                case Valign::middle: return "middle";
-                case Valign::bottom: return "bottom";
-                case Valign::baseline: return "baseline";
-                default: break;
-            }
-            return "top";
-        }
-
-
-        std::ostream& toStream( std::ostream& os, const Valign value )
-        {
-            return os << toString( value );
-        }
-
-
-        std::ostream& operator<<( std::ostream& os, const Valign value )
-        {
-            return toStream( os, value );
-        }
-
-        ValignImage parseValignImage( const std::string& value )
-        {
-            if ( value == "top" ) { return ValignImage::top; }
-            else if ( value == "middle" ) { return ValignImage::middle; }
-            else if ( value == "bottom" ) { return ValignImage::bottom; }
-            return ValignImage::top;
-        }
-
-
-        std::string toString( const ValignImage value )
-        {
-            switch ( value ) 
-            {
-                case ValignImage::top: return "top";
-                case ValignImage::middle: return "middle";
-                case ValignImage::bottom: return "bottom";
-                default: break;
-            }
-            return "top";
-        }
-
-
-        std::ostream& toStream( std::ostream& os, const ValignImage value )
-        {
-            return os << toString( value );
-        }
-
-
-        std::ostream& operator<<( std::ostream& os, const ValignImage value )
-        {
-            return toStream( os, value );
-        }
-
-        YesNo parseYesNo( const std::string& value )
-        {
-            if ( value == "yes" ) { return YesNo::yes; }
-            else if ( value == "no" ) { return YesNo::no; }
-            return YesNo::yes;
-        }
-
-
-        std::string toString( const YesNo value )
-        {
-            switch ( value ) 
-            {
-                case YesNo::yes: return "yes";
-                case YesNo::no: return "no";
-                default: break;
-            }
-            return "yes";
-        }
-
-
-        std::ostream& toStream( std::ostream& os, const YesNo value )
-        {
-            return os << toString( value );
-        }
-
-
-        std::ostream& operator<<( std::ostream& os, const YesNo value )
-        {
-            return toStream( os, value );
-        }
-
-        CancelLocation parseCancelLocation( const std::string& value )
-        {
-            if ( value == "left" ) { return CancelLocation::left; }
-            else if ( value == "right" ) { return CancelLocation::right; }
-            else if ( value == "before-barline" ) { return CancelLocation::beforeBarline; }
-            return CancelLocation::left;
-        }
-
-
-        std::string toString( const CancelLocation value )
-        {
-            switch ( value ) 
-            {
-                case CancelLocation::left: return "left";
-                case CancelLocation::right: return "right";
-                case CancelLocation::beforeBarline: return "before-barline";
-                default: break;
-            }
-            return "left";
-        }
-
-
-        std::ostream& toStream( std::ostream& os, const CancelLocation value )
-        {
-            return os << toString( value );
-        }
-
-
-        std::ostream& operator<<( std::ostream& os, const CancelLocation value )
-        {
-            return toStream( os, value );
-        }
-
-        ClefSign parseClefSign( const std::string& value )
-        {
-            if ( value == "G" ) { return ClefSign::g; }
-            else if ( value == "F" ) { return ClefSign::f; }
-            else if ( value == "C" ) { return ClefSign::c; }
-            else if ( value == "percussion" ) { return ClefSign::percussion; }
-            else if ( value == "TAB" ) { return ClefSign::tab; }
-            else if ( value == "jianpu" ) { return ClefSign::jianpu; }
-            else if ( value == "none" ) { return ClefSign::none; }
-            return ClefSign::g;
-        }
-
-
-        std::string toString( const ClefSign value )
-        {
-            switch ( value ) 
-            {
-                case ClefSign::g: return "G";
-                case ClefSign::f: return "F";
-                case ClefSign::c: return "C";
-                case ClefSign::percussion: return "percussion";
-                case ClefSign::tab: return "TAB";
-                case ClefSign::jianpu: return "jianpu";
-                case ClefSign::none: return "none";
-                default: break;
-            }
-            return "G";
-        }
-
-
-        std::ostream& toStream( std::ostream& os, const ClefSign value )
-        {
-            return os << toString( value );
-        }
-
-
-        std::ostream& operator<<( std::ostream& os, const ClefSign value )
-        {
-            return toStream( os, value );
-        }
-
-        ShowFrets parseShowFrets( const std::string& value )
-        {
-            if ( value == "numbers" ) { return ShowFrets::numbers; }
-            else if ( value == "letters" ) { return ShowFrets::letters; }
-            return ShowFrets::numbers;
-        }
-
-
-        std::string toString( const ShowFrets value )
-        {
-            switch ( value ) 
-            {
-                case ShowFrets::numbers: return "numbers";
-                case ShowFrets::letters: return "letters";
-                default: break;
-            }
-            return "numbers";
-        }
-
-
-        std::ostream& toStream( std::ostream& os, const ShowFrets value )
-        {
-            return os << toString( value );
-        }
-
-
-        std::ostream& operator<<( std::ostream& os, const ShowFrets value )
-        {
-            return toStream( os, value );
-        }
-
-        StaffTypeEnum parseStaffTypeEnum( const std::string& value )
-        {
-            if ( value == "ossia" ) { return StaffTypeEnum::ossia; }
-            else if ( value == "cue" ) { return StaffTypeEnum::cue; }
-            else if ( value == "editorial" ) { return StaffTypeEnum::editorial; }
-            else if ( value == "regular" ) { return StaffTypeEnum::regular; }
-            else if ( value == "alternate" ) { return StaffTypeEnum::alternate; }
-            return StaffTypeEnum::ossia;
-        }
-
-
-        std::string toString( const StaffTypeEnum value )
-        {
-            switch ( value ) 
-            {
-                case StaffTypeEnum::ossia: return "ossia";
-                case StaffTypeEnum::cue: return "cue";
-                case StaffTypeEnum::editorial: return "editorial";
-                case StaffTypeEnum::regular: return "regular";
-                case StaffTypeEnum::alternate: return "alternate";
-                default: break;
-            }
-            return "ossia";
-        }
-
-
-        std::ostream& toStream( std::ostream& os, const StaffTypeEnum value )
-        {
-            return os << toString( value );
-        }
-
-
-        std::ostream& operator<<( std::ostream& os, const StaffTypeEnum value )
-        {
-            return toStream( os, value );
-        }
-
-        TimeRelationEnum parseTimeRelationEnum( const std::string& value )
-        {
-            if ( value == "parentheses" ) { return TimeRelationEnum::parentheses; }
-            else if ( value == "bracket" ) { return TimeRelationEnum::bracket; }
-            else if ( value == "equals" ) { return TimeRelationEnum::equals; }
-            else if ( value == "slash" ) { return TimeRelationEnum::slash; }
-            else if ( value == "space" ) { return TimeRelationEnum::space; }
-            else if ( value == "hyphen" ) { return TimeRelationEnum::hyphen; }
-            return TimeRelationEnum::parentheses;
-        }
-
-
-        std::string toString( const TimeRelationEnum value )
-        {
-            switch ( value ) 
-            {
-                case TimeRelationEnum::parentheses: return "parentheses";
-                case TimeRelationEnum::bracket: return "bracket";
-                case TimeRelationEnum::equals: return "equals";
-                case TimeRelationEnum::slash: return "slash";
-                case TimeRelationEnum::space: return "space";
-                case TimeRelationEnum::hyphen: return "hyphen";
-                default: break;
-            }
-            return "parentheses";
-        }
-
-
-        std::ostream& toStream( std::ostream& os, const TimeRelationEnum value )
-        {
-            return os << toString( value );
-        }
-
-
-        std::ostream& operator<<( std::ostream& os, const TimeRelationEnum value )
-        {
-            return toStream( os, value );
-        }
-
-        TimeSeparator parseTimeSeparator( const std::string& value )
-        {
-            if ( value == "none" ) { return TimeSeparator::none; }
-            else if ( value == "horizontal" ) { return TimeSeparator::horizontal; }
-            else if ( value == "diagonal" ) { return TimeSeparator::diagonal; }
-            else if ( value == "vertical" ) { return TimeSeparator::vertical; }
-            else if ( value == "adjacent" ) { return TimeSeparator::adjacent; }
-            return TimeSeparator::none;
-        }
-
-
-        std::string toString( const TimeSeparator value )
-        {
-            switch ( value ) 
-            {
-                case TimeSeparator::none: return "none";
-                case TimeSeparator::horizontal: return "horizontal";
-                case TimeSeparator::diagonal: return "diagonal";
-                case TimeSeparator::vertical: return "vertical";
-                case TimeSeparator::adjacent: return "adjacent";
-                default: break;
-            }
-            return "none";
-        }
-
-
-        std::ostream& toStream( std::ostream& os, const TimeSeparator value )
-        {
-            return os << toString( value );
-        }
-
-
-        std::ostream& operator<<( std::ostream& os, const TimeSeparator value )
-        {
-            return toStream( os, value );
-        }
-
-        TimeSymbol parseTimeSymbol( const std::string& value )
-        {
-            if ( value == "common" ) { return TimeSymbol::common; }
-            else if ( value == "cut" ) { return TimeSymbol::cut; }
-            else if ( value == "single-number" ) { return TimeSymbol::singleNumber; }
-            else if ( value == "note" ) { return TimeSymbol::note; }
-            else if ( value == "dotted-note" ) { return TimeSymbol::dottedNote; }
-            else if ( value == "normal" ) { return TimeSymbol::normal; }
-            return TimeSymbol::common;
-        }
-
-
-        std::string toString( const TimeSymbol value )
-        {
-            switch ( value ) 
-            {
-                case TimeSymbol::common: return "common";
-                case TimeSymbol::cut: return "cut";
-                case TimeSymbol::singleNumber: return "single-number";
-                case TimeSymbol::note: return "note";
-                case TimeSymbol::dottedNote: return "dotted-note";
-                case TimeSymbol::normal: return "normal";
-                default: break;
-            }
-            return "common";
-        }
-
-
-        std::ostream& toStream( std::ostream& os, const TimeSymbol value )
-        {
-            return os << toString( value );
-        }
-
-
-        std::ostream& operator<<( std::ostream& os, const TimeSymbol value )
-        {
-            return toStream( os, value );
-        }
-
-        BackwardForward parseBackwardForward( const std::string& value )
-        {
-            if ( value == "backward" ) { return BackwardForward::backward; }
-            else if ( value == "forward" ) { return BackwardForward::forward; }
-            return BackwardForward::backward;
-        }
-
-
-        std::string toString( const BackwardForward value )
-        {
-            switch ( value ) 
-            {
-                case BackwardForward::backward: return "backward";
-                case BackwardForward::forward: return "forward";
-                default: break;
-            }
-            return "backward";
-        }
-
-
-        std::ostream& toStream( std::ostream& os, const BackwardForward value )
-        {
-            return os << toString( value );
-        }
-
-
-        std::ostream& operator<<( std::ostream& os, const BackwardForward value )
-        {
-            return toStream( os, value );
-        }
-
-        BarStyleEnum parseBarStyleEnum( const std::string& value )
-        {
-            if ( value == "regular" ) { return BarStyleEnum::regular; }
-            else if ( value == "dotted" ) { return BarStyleEnum::dotted; }
-            else if ( value == "dashed" ) { return BarStyleEnum::dashed; }
-            else if ( value == "heavy" ) { return BarStyleEnum::heavy; }
-            else if ( value == "light-light" ) { return BarStyleEnum::lightLight; }
-            else if ( value == "light-heavy" ) { return BarStyleEnum::lightHeavy; }
-            else if ( value == "heavy-light" ) { return BarStyleEnum::heavyLight; }
-            else if ( value == "heavy-heavy" ) { return BarStyleEnum::heavyHeavy; }
-            else if ( value == "tick" ) { return BarStyleEnum::tick; }
-            else if ( value == "short" ) { return BarStyleEnum::short_; }
-            else if ( value == "none" ) { return BarStyleEnum::none; }
-            return BarStyleEnum::regular;
-        }
-
-
-        std::string toString( const BarStyleEnum value )
-        {
-            switch ( value ) 
-            {
-                case BarStyleEnum::regular: return "regular";
-                case BarStyleEnum::dotted: return "dotted";
-                case BarStyleEnum::dashed: return "dashed";
-                case BarStyleEnum::heavy: return "heavy";
-                case BarStyleEnum::lightLight: return "light-light";
-                case BarStyleEnum::lightHeavy: return "light-heavy";
-                case BarStyleEnum::heavyLight: return "heavy-light";
-                case BarStyleEnum::heavyHeavy: return "heavy-heavy";
-                case BarStyleEnum::tick: return "tick";
-                case BarStyleEnum::short_: return "short";
-                case BarStyleEnum::none: return "none";
-                default: break;
-            }
-            return "regular";
-        }
-
-
-        std::ostream& toStream( std::ostream& os, const BarStyleEnum value )
-        {
-            return os << toString( value );
-        }
-
-
-        std::ostream& operator<<( std::ostream& os, const BarStyleEnum value )
-        {
-            return toStream( os, value );
-        }
-
-        RightLeftMiddle parseRightLeftMiddle( const std::string& value )
-        {
-            if ( value == "right" ) { return RightLeftMiddle::right; }
-            else if ( value == "left" ) { return RightLeftMiddle::left; }
-            else if ( value == "middle" ) { return RightLeftMiddle::middle; }
-            return RightLeftMiddle::right;
-        }
-
-
-        std::string toString( const RightLeftMiddle value )
-        {
-            switch ( value ) 
-            {
-                case RightLeftMiddle::right: return "right";
-                case RightLeftMiddle::left: return "left";
-                case RightLeftMiddle::middle: return "middle";
-                default: break;
-            }
-            return "right";
-        }
-
-
-        std::ostream& toStream( std::ostream& os, const RightLeftMiddle value )
-        {
-            return os << toString( value );
-        }
-
-
-        std::ostream& operator<<( std::ostream& os, const RightLeftMiddle value )
-        {
-            return toStream( os, value );
-        }
-
-        StartStopDiscontinue parseStartStopDiscontinue( const std::string& value )
-        {
-            if ( value == "start" ) { return StartStopDiscontinue::start; }
-            else if ( value == "stop" ) { return StartStopDiscontinue::stop; }
-            else if ( value == "discontinue" ) { return StartStopDiscontinue::discontinue; }
-            return StartStopDiscontinue::start;
-        }
-
-
-        std::string toString( const StartStopDiscontinue value )
-        {
-            switch ( value ) 
-            {
-                case StartStopDiscontinue::start: return "start";
-                case StartStopDiscontinue::stop: return "stop";
-                case StartStopDiscontinue::discontinue: return "discontinue";
-                default: break;
-            }
-            return "start";
-        }
-
-
-        std::ostream& toStream( std::ostream& os, const StartStopDiscontinue value )
-        {
-            return os << toString( value );
-        }
-
-
-        std::ostream& operator<<( std::ostream& os, const StartStopDiscontinue value )
-        {
-            return toStream( os, value );
-        }
-
-        Winged parseWinged( const std::string& value )
-        {
-            if ( value == "none" ) { return Winged::none; }
-            else if ( value == "straight" ) { return Winged::straight; }
-            else if ( value == "curved" ) { return Winged::curved; }
-            else if ( value == "double-straight" ) { return Winged::doubleStraight; }
-            else if ( value == "double-curved" ) { return Winged::doubleCurved; }
-            return Winged::none;
-        }
-
-
-        std::string toString( const Winged value )
-        {
-            switch ( value ) 
-            {
-                case Winged::none: return "none";
-                case Winged::straight: return "straight";
-                case Winged::curved: return "curved";
-                case Winged::doubleStraight: return "double-straight";
-                case Winged::doubleCurved: return "double-curved";
-                default: break;
-            }
-            return "none";
-        }
-
-
-        std::ostream& toStream( std::ostream& os, const Winged value )
-        {
-            return os << toString( value );
-        }
-
-
-        std::ostream& operator<<( std::ostream& os, const Winged value )
-        {
-            return toStream( os, value );
-        }
-
-        BeaterValue parseBeaterValue( const std::string& value )
-        {
-            if ( value == "bow" ) { return BeaterValue::bow; }
-            else if ( value == "chime hammer" ) { return BeaterValue::chimeHammer; }
-            else if ( value == "coin" ) { return BeaterValue::coin; }
-            else if ( value == "finger" ) { return BeaterValue::finger; }
-            else if ( value == "fingernail" ) { return BeaterValue::fingernail; }
-            else if ( value == "fist" ) { return BeaterValue::fist; }
-            else if ( value == "guiro scraper" ) { return BeaterValue::guiroScraper; }
-            else if ( value == "hammer" ) { return BeaterValue::hammer; }
-            else if ( value == "hand" ) { return BeaterValue::hand; }
-            else if ( value == "jazz stick" ) { return BeaterValue::jazzStick; }
-            else if ( value == "knitting needle" ) { return BeaterValue::knittingNeedle; }
-            else if ( value == "metal hammer" ) { return BeaterValue::metalHammer; }
-            else if ( value == "snare stick" ) { return BeaterValue::snareStick; }
-            else if ( value == "spoon mallet" ) { return BeaterValue::spoonMallet; }
-            else if ( value == "triangle beater" ) { return BeaterValue::triangleBeater; }
-            else if ( value == "triangle beater plain" ) { return BeaterValue::triangleBeaterPlain; }
-            else if ( value == "wire brush" ) { return BeaterValue::wireBrush; }
-            return BeaterValue::bow;
-        }
-
-
-        std::string toString( const BeaterValue value )
-        {
-            switch ( value ) 
-            {
-                case BeaterValue::bow: return "bow";
-                case BeaterValue::chimeHammer: return "chime hammer";
-                case BeaterValue::coin: return "coin";
-                case BeaterValue::finger: return "finger";
-                case BeaterValue::fingernail: return "fingernail";
-                case BeaterValue::fist: return "fist";
-                case BeaterValue::guiroScraper: return "guiro scraper";
-                case BeaterValue::hammer: return "hammer";
-                case BeaterValue::hand: return "hand";
-                case BeaterValue::jazzStick: return "jazz stick";
-                case BeaterValue::knittingNeedle: return "knitting needle";
-                case BeaterValue::metalHammer: return "metal hammer";
-                case BeaterValue::snareStick: return "snare stick";
-                case BeaterValue::spoonMallet: return "spoon mallet";
-                case BeaterValue::triangleBeater: return "triangle beater";
-                case BeaterValue::triangleBeaterPlain: return "triangle beater plain";
-                case BeaterValue::wireBrush: return "wire brush";
-                default: break;
-            }
-            return "bow";
-        }
-
-
-        std::ostream& toStream( std::ostream& os, const BeaterValue value )
-        {
-            return os << toString( value );
-        }
-
-
-        std::ostream& operator<<( std::ostream& os, const BeaterValue value )
-        {
-            return toStream( os, value );
-        }
-
-        DegreeSymbolValue parseDegreeSymbolValue( const std::string& value )
-        {
-            if ( value == "major" ) { return DegreeSymbolValue::major; }
-            else if ( value == "minor" ) { return DegreeSymbolValue::minor; }
-            else if ( value == "augmented" ) { return DegreeSymbolValue::augmented; }
-            else if ( value == "diminished" ) { return DegreeSymbolValue::diminished; }
-            else if ( value == "half-diminished" ) { return DegreeSymbolValue::halfDiminished; }
-            return DegreeSymbolValue::major;
-        }
-
-
-        std::string toString( const DegreeSymbolValue value )
-        {
-            switch ( value ) 
-            {
-                case DegreeSymbolValue::major: return "major";
-                case DegreeSymbolValue::minor: return "minor";
-                case DegreeSymbolValue::augmented: return "augmented";
-                case DegreeSymbolValue::diminished: return "diminished";
-                case DegreeSymbolValue::halfDiminished: return "half-diminished";
-                default: break;
-            }
-            return "major";
-        }
-
-
-        std::ostream& toStream( std::ostream& os, const DegreeSymbolValue value )
-        {
-            return os << toString( value );
-        }
-
-
-        std::ostream& operator<<( std::ostream& os, const DegreeSymbolValue value )
-        {
-            return toStream( os, value );
-        }
-
-        DegreeTypeValue parseDegreeTypeValue( const std::string& value )
-        {
-            if ( value == "add" ) { return DegreeTypeValue::add; }
-            else if ( value == "alter" ) { return DegreeTypeValue::alter; }
-            else if ( value == "subtract" ) { return DegreeTypeValue::subtract; }
-            return DegreeTypeValue::add;
-        }
-
-
-        std::string toString( const DegreeTypeValue value )
-        {
-            switch ( value ) 
-            {
-                case DegreeTypeValue::add: return "add";
-                case DegreeTypeValue::alter: return "alter";
-                case DegreeTypeValue::subtract: return "subtract";
-                default: break;
-            }
-            return "add";
-        }
-
-
-        std::ostream& toStream( std::ostream& os, const DegreeTypeValue value )
-        {
-            return os << toString( value );
-        }
-
-
-        std::ostream& operator<<( std::ostream& os, const DegreeTypeValue value )
-        {
-            return toStream( os, value );
-        }
-
-        EffectEnum parseEffectEnum( const std::string& value )
-        {
-            if ( value == "anvil" ) { return EffectEnum::anvil; }
-            else if ( value == "auto horn" ) { return EffectEnum::autoHorn; }
-            else if ( value == "bird whistle" ) { return EffectEnum::birdWhistle; }
-            else if ( value == "cannon" ) { return EffectEnum::cannon; }
-            else if ( value == "duck call" ) { return EffectEnum::duckCall; }
-            else if ( value == "gun shot" ) { return EffectEnum::gunShot; }
-            else if ( value == "klaxon horn" ) { return EffectEnum::klaxonHorn; }
-            else if ( value == "lions roar" ) { return EffectEnum::lionsRoar; }
-            else if ( value == "police whistle" ) { return EffectEnum::policeWhistle; }
-            else if ( value == "siren" ) { return EffectEnum::siren; }
-            else if ( value == "slide whistle" ) { return EffectEnum::slideWhistle; }
-            else if ( value == "thunder sheet" ) { return EffectEnum::thunderSheet; }
-            else if ( value == "wind machine" ) { return EffectEnum::windMachine; }
-            else if ( value == "wind whistle" ) { return EffectEnum::windWhistle; }
-            return EffectEnum::anvil;
-        }
-
-
-        std::string toString( const EffectEnum value )
-        {
-            switch ( value ) 
-            {
-                case EffectEnum::anvil: return "anvil";
-                case EffectEnum::autoHorn: return "auto horn";
-                case EffectEnum::birdWhistle: return "bird whistle";
-                case EffectEnum::cannon: return "cannon";
-                case EffectEnum::duckCall: return "duck call";
-                case EffectEnum::gunShot: return "gun shot";
-                case EffectEnum::klaxonHorn: return "klaxon horn";
-                case EffectEnum::lionsRoar: return "lions roar";
-                case EffectEnum::policeWhistle: return "police whistle";
-                case EffectEnum::siren: return "siren";
-                case EffectEnum::slideWhistle: return "slide whistle";
-                case EffectEnum::thunderSheet: return "thunder sheet";
-                case EffectEnum::windMachine: return "wind machine";
-                case EffectEnum::windWhistle: return "wind whistle";
-                default: break;
-            }
-            return "anvil";
-        }
-
-
-        std::ostream& toStream( std::ostream& os, const EffectEnum value )
-        {
-            return os << toString( value );
-        }
-
-
-        std::ostream& operator<<( std::ostream& os, const EffectEnum value )
-        {
-            return toStream( os, value );
-        }
-
-        GlassEnum parseGlassEnum( const std::string& value )
-        {
-            if ( value == "wind chimes" ) { return GlassEnum::windChimes; }
-            return GlassEnum::windChimes;
-        }
-
-
-        std::string toString( const GlassEnum value )
-        {
-            switch ( value ) 
-            {
-                case GlassEnum::windChimes: return "wind chimes";
-                default: break;
-            }
-            return "wind chimes";
-        }
-
-
-        std::ostream& toStream( std::ostream& os, const GlassEnum value )
-        {
-            return os << toString( value );
-        }
-
-
-        std::ostream& operator<<( std::ostream& os, const GlassEnum value )
-        {
-            return toStream( os, value );
-        }
-
-        HarmonyType parseHarmonyType( const std::string& value )
-        {
-            if ( value == "explicit" ) { return HarmonyType::explicit_; }
-            else if ( value == "implied" ) { return HarmonyType::implied; }
-            else if ( value == "alternate" ) { return HarmonyType::alternate; }
-            return HarmonyType::explicit_;
-        }
-
-
-        std::string toString( const HarmonyType value )
-        {
-            switch ( value ) 
-            {
-                case HarmonyType::explicit_: return "explicit";
-                case HarmonyType::implied: return "implied";
-                case HarmonyType::alternate: return "alternate";
-                default: break;
-            }
-            return "explicit";
-        }
-
-
-        std::ostream& toStream( std::ostream& os, const HarmonyType value )
-        {
-            return os << toString( value );
-        }
-
-
-        std::ostream& operator<<( std::ostream& os, const HarmonyType value )
-        {
-            return toStream( os, value );
-        }
-
-        KindValue parseKindValue( const std::string& value )
-        {
-            if ( value == "major" ) { return KindValue::major; }
-            else if ( value == "minor" ) { return KindValue::minor; }
-            else if ( value == "augmented" ) { return KindValue::augmented; }
-            else if ( value == "diminished" ) { return KindValue::diminished; }
-            else if ( value == "dominant" ) { return KindValue::dominant; }
-            else if ( value == "major-seventh" ) { return KindValue::majorSeventh; }
-            else if ( value == "minor-seventh" ) { return KindValue::minorSeventh; }
-            else if ( value == "diminished-seventh" ) { return KindValue::diminishedSeventh; }
-            else if ( value == "augmented-seventh" ) { return KindValue::augmentedSeventh; }
-            else if ( value == "half-diminished" ) { return KindValue::halfDiminished; }
-            else if ( value == "major-minor" ) { return KindValue::majorMinor; }
-            else if ( value == "major-sixth" ) { return KindValue::majorSixth; }
-            else if ( value == "minor-sixth" ) { return KindValue::minorSixth; }
-            else if ( value == "dominant-ninth" ) { return KindValue::dominantNinth; }
-            else if ( value == "major-ninth" ) { return KindValue::majorNinth; }
-            else if ( value == "minor-ninth" ) { return KindValue::minorNinth; }
-            else if ( value == "dominant-11th" ) { return KindValue::dominant11Th; }
-            else if ( value == "major-11th" ) { return KindValue::major11Th; }
-            else if ( value == "minor-11th" ) { return KindValue::minor11Th; }
-            else if ( value == "dominant-13th" ) { return KindValue::dominant13Th; }
-            else if ( value == "major-13th" ) { return KindValue::major13Th; }
-            else if ( value == "minor-13th" ) { return KindValue::minor13Th; }
-            else if ( value == "suspended-second" ) { return KindValue::suspendedSecond; }
-            else if ( value == "suspended-fourth" ) { return KindValue::suspendedFourth; }
-            else if ( value == "Neapolitan" ) { return KindValue::neapolitan; }
-            else if ( value == "Italian" ) { return KindValue::italian; }
-            else if ( value == "French" ) { return KindValue::french; }
-            else if ( value == "German" ) { return KindValue::german; }
-            else if ( value == "pedal" ) { return KindValue::pedal; }
-            else if ( value == "power" ) { return KindValue::power; }
-            else if ( value == "Tristan" ) { return KindValue::tristan; }
-            else if ( value == "other" ) { return KindValue::other; }
-            else if ( value == "none" ) { return KindValue::none; }
-            
-            // here are a couple of unsupported types but we will catch them
-            // most of these are coming from musuite_test_harmonly.xml
-            else if ( value == "dominant-seventh" ) { return KindValue::dominant; }
-            else if ( value == "neapolitan" ) { return KindValue::neapolitan; }
-            else if ( value == "italian" ) { return KindValue::italian; }
-            else if ( value == "french" ) { return KindValue::french; }
-            else if ( value == "german" ) { return KindValue::german; }
-            else if ( value == "french" ) { return KindValue::french; }
-            else if ( value == "tristan" ) { return KindValue::tristan; }
-            
-            return KindValue::none;
-        }
-
-
-        std::string toString( const KindValue value )
-        {
-            switch ( value ) 
-            {
-                case KindValue::major: return "major";
-                case KindValue::minor: return "minor";
-                case KindValue::augmented: return "augmented";
-                case KindValue::diminished: return "diminished";
-                case KindValue::dominant: return "dominant";
-                case KindValue::majorSeventh: return "major-seventh";
-                case KindValue::minorSeventh: return "minor-seventh";
-                case KindValue::diminishedSeventh: return "diminished-seventh";
-                case KindValue::augmentedSeventh: return "augmented-seventh";
-                case KindValue::halfDiminished: return "half-diminished";
-                case KindValue::majorMinor: return "major-minor";
-                case KindValue::majorSixth: return "major-sixth";
-                case KindValue::minorSixth: return "minor-sixth";
-                case KindValue::dominantNinth: return "dominant-ninth";
-                case KindValue::majorNinth: return "major-ninth";
-                case KindValue::minorNinth: return "minor-ninth";
-                case KindValue::dominant11Th: return "dominant-11th";
-                case KindValue::major11Th: return "major-11th";
-                case KindValue::minor11Th: return "minor-11th";
-                case KindValue::dominant13Th: return "dominant-13th";
-                case KindValue::major13Th: return "major-13th";
-                case KindValue::minor13Th: return "minor-13th";
-                case KindValue::suspendedSecond: return "suspended-second";
-                case KindValue::suspendedFourth: return "suspended-fourth";
-                case KindValue::neapolitan: return "Neapolitan";
-                case KindValue::italian: return "Italian";
-                case KindValue::french: return "French";
-                case KindValue::german: return "German";
-                case KindValue::pedal: return "pedal";
-                case KindValue::power: return "power";
-                case KindValue::tristan: return "Tristan";
-                case KindValue::other: return "other";
-                case KindValue::none: return "none";
-                default: break;
-            }
-            return "major";
-        }
-
-
-        std::ostream& toStream( std::ostream& os, const KindValue value )
-        {
-            return os << toString( value );
-        }
-
-
-        std::ostream& operator<<( std::ostream& os, const KindValue value )
-        {
-            return toStream( os, value );
-        }
-
-        LineEnd parseLineEnd( const std::string& value )
-        {
-            if ( value == "up" ) { return LineEnd::up; }
-            else if ( value == "down" ) { return LineEnd::down; }
-            else if ( value == "both" ) { return LineEnd::both; }
-            else if ( value == "arrow" ) { return LineEnd::arrow; }
-            else if ( value == "none" ) { return LineEnd::none; }
-            return LineEnd::up;
-        }
-
-
-        std::string toString( const LineEnd value )
-        {
-            switch ( value ) 
-            {
-                case LineEnd::up: return "up";
-                case LineEnd::down: return "down";
-                case LineEnd::both: return "both";
-                case LineEnd::arrow: return "arrow";
-                case LineEnd::none: return "none";
-                default: break;
-            }
-            return "up";
-        }
-
-
-        std::ostream& toStream( std::ostream& os, const LineEnd value )
-        {
-            return os << toString( value );
-        }
-
-
-        std::ostream& operator<<( std::ostream& os, const LineEnd value )
-        {
-            return toStream( os, value );
-        }
-
-        MeasureNumberingValue parseMeasureNumberingValue( const std::string& value )
-        {
-            if ( value == "none" ) { return MeasureNumberingValue::none; }
-            else if ( value == "measure" ) { return MeasureNumberingValue::measure; }
-            else if ( value == "system" ) { return MeasureNumberingValue::system; }
-            return MeasureNumberingValue::none;
-        }
-
-
-        std::string toString( const MeasureNumberingValue value )
-        {
-            switch ( value ) 
-            {
-                case MeasureNumberingValue::none: return "none";
-                case MeasureNumberingValue::measure: return "measure";
-                case MeasureNumberingValue::system: return "system";
-                default: break;
-            }
-            return "none";
-        }
-
-
-        std::ostream& toStream( std::ostream& os, const MeasureNumberingValue value )
-        {
-            return os << toString( value );
-        }
-
-
-        std::ostream& operator<<( std::ostream& os, const MeasureNumberingValue value )
-        {
-            return toStream( os, value );
-        }
-
-        MembraneEnum parseMembraneEnum( const std::string& value )
-        {
-            if ( value == "bass drum" ) { return MembraneEnum::bassDrum; }
-            else if ( value == "bass drum on side" ) { return MembraneEnum::bassDrumOnSide; }
-            else if ( value == "bongos" ) { return MembraneEnum::bongos; }
-            else if ( value == "conga drum" ) { return MembraneEnum::congaDrum; }
-            else if ( value == "goblet drum" ) { return MembraneEnum::gobletDrum; }
-            else if ( value == "military drum" ) { return MembraneEnum::militaryDrum; }
-            else if ( value == "snare drum" ) { return MembraneEnum::snareDrum; }
-            else if ( value == "snare drum snares off" ) { return MembraneEnum::snareDrumSnaresOff; }
-            else if ( value == "tambourine" ) { return MembraneEnum::tambourine; }
-            else if ( value == "tenor drum" ) { return MembraneEnum::tenorDrum; }
-            else if ( value == "timbales" ) { return MembraneEnum::timbales; }
-            else if ( value == "tomtom" ) { return MembraneEnum::tomtom; }
-            return MembraneEnum::bassDrum;
-        }
-
-
-        std::string toString( const MembraneEnum value )
-        {
-            switch ( value ) 
-            {
-                case MembraneEnum::bassDrum: return "bass drum";
-                case MembraneEnum::bassDrumOnSide: return "bass drum on side";
-                case MembraneEnum::bongos: return "bongos";
-                case MembraneEnum::congaDrum: return "conga drum";
-                case MembraneEnum::gobletDrum: return "goblet drum";
-                case MembraneEnum::militaryDrum: return "military drum";
-                case MembraneEnum::snareDrum: return "snare drum";
-                case MembraneEnum::snareDrumSnaresOff: return "snare drum snares off";
-                case MembraneEnum::tambourine: return "tambourine";
-                case MembraneEnum::tenorDrum: return "tenor drum";
-                case MembraneEnum::timbales: return "timbales";
-                case MembraneEnum::tomtom: return "tomtom";
-                default: break;
-            }
-            return "bass drum";
-        }
-
-
-        std::ostream& toStream( std::ostream& os, const MembraneEnum value )
-        {
-            return os << toString( value );
-        }
-
-
-        std::ostream& operator<<( std::ostream& os, const MembraneEnum value )
-        {
-            return toStream( os, value );
-        }
-
-        MetalEnum parseMetalEnum( const std::string& value )
-        {
-            if ( value == "almglocken" ) { return MetalEnum::almglocken; }
-            else if ( value == "bell" ) { return MetalEnum::bell; }
-            else if ( value == "bell plate" ) { return MetalEnum::bellPlate; }
-            else if ( value == "brake drum" ) { return MetalEnum::brakeDrum; }
-            else if ( value == "Chinese cymbal" ) { return MetalEnum::chineseCymbal; }
-            else if ( value == "cowbell" ) { return MetalEnum::cowbell; }
-            else if ( value == "crash cymbals" ) { return MetalEnum::crashCymbals; }
-            else if ( value == "crotale" ) { return MetalEnum::crotale; }
-            else if ( value == "cymbal tongs" ) { return MetalEnum::cymbalTongs; }
-            else if ( value == "domed gong" ) { return MetalEnum::domedGong; }
-            else if ( value == "finger cymbals" ) { return MetalEnum::fingerCymbals; }
-            else if ( value == "flexatone" ) { return MetalEnum::flexatone; }
-            else if ( value == "gong" ) { return MetalEnum::gong; }
-            else if ( value == "hi-hat" ) { return MetalEnum::hiHat; }
-            else if ( value == "high-hat cymbals" ) { return MetalEnum::highHatCymbals; }
-            else if ( value == "handbell" ) { return MetalEnum::handbell; }
-            else if ( value == "sistrum" ) { return MetalEnum::sistrum; }
-            else if ( value == "sizzle cymbal" ) { return MetalEnum::sizzleCymbal; }
-            else if ( value == "sleigh bells" ) { return MetalEnum::sleighBells; }
-            else if ( value == "suspended cymbal" ) { return MetalEnum::suspendedCymbal; }
-            else if ( value == "tam tam" ) { return MetalEnum::tamTam; }
-            else if ( value == "triangle" ) { return MetalEnum::triangle; }
-            else if ( value == "Vietnamese hat" ) { return MetalEnum::vietnameseHat; }
-            return MetalEnum::almglocken;
-        }
-
-
-        std::string toString( const MetalEnum value )
-        {
-            switch ( value ) 
-            {
-                case MetalEnum::almglocken: return "almglocken";
-                case MetalEnum::bell: return "bell";
-                case MetalEnum::bellPlate: return "bell plate";
-                case MetalEnum::brakeDrum: return "brake drum";
-                case MetalEnum::chineseCymbal: return "Chinese cymbal";
-                case MetalEnum::cowbell: return "cowbell";
-                case MetalEnum::crashCymbals: return "crash cymbals";
-                case MetalEnum::crotale: return "crotale";
-                case MetalEnum::cymbalTongs: return "cymbal tongs";
-                case MetalEnum::domedGong: return "domed gong";
-                case MetalEnum::fingerCymbals: return "finger cymbals";
-                case MetalEnum::flexatone: return "flexatone";
-                case MetalEnum::gong: return "gong";
-                case MetalEnum::hiHat: return "hi-hat";
-                case MetalEnum::highHatCymbals: return "high-hat cymbals";
-                case MetalEnum::handbell: return "handbell";
-                case MetalEnum::sistrum: return "sistrum";
-                case MetalEnum::sizzleCymbal: return "sizzle cymbal";
-                case MetalEnum::sleighBells: return "sleigh bells";
-                case MetalEnum::suspendedCymbal: return "suspended cymbal";
-                case MetalEnum::tamTam: return "tam tam";
-                case MetalEnum::triangle: return "triangle";
-                case MetalEnum::vietnameseHat: return "Vietnamese hat";
-                default: break;
-            }
-            return "almglocken";
-        }
-
-
-        std::ostream& toStream( std::ostream& os, const MetalEnum value )
-        {
-            return os << toString( value );
-        }
-
-
-        std::ostream& operator<<( std::ostream& os, const MetalEnum value )
-        {
-            return toStream( os, value );
-        }
-
-        OnOff parseOnOff( const std::string& value )
-        {
-            if ( value == "on" ) { return OnOff::on; }
-            else if ( value == "off" ) { return OnOff::off; }
-            return OnOff::on;
-        }
-
-
-        std::string toString( const OnOff value )
-        {
-            switch ( value ) 
-            {
-                case OnOff::on: return "on";
-                case OnOff::off: return "off";
-                default: break;
-            }
-            return "on";
-        }
-
-
-        std::ostream& toStream( std::ostream& os, const OnOff value )
-        {
-            return os << toString( value );
-        }
-
-
-        std::ostream& operator<<( std::ostream& os, const OnOff value )
-        {
-            return toStream( os, value );
-        }
-
-        PitchedEnum parsePitchedEnum( const std::string& value )
-        {
-            if ( value == "chimes" ) { return PitchedEnum::chimes; }
-            else if ( value == "glockenspiel" ) { return PitchedEnum::glockenspiel; }
-            else if ( value == "mallet" ) { return PitchedEnum::mallet; }
-            else if ( value == "marimba" ) { return PitchedEnum::marimba; }
-            else if ( value == "tubular chimes" ) { return PitchedEnum::tubularChimes; }
-            else if ( value == "vibraphone" ) { return PitchedEnum::vibraphone; }
-            else if ( value == "xylophone" ) { return PitchedEnum::xylophone; }
-            return PitchedEnum::chimes;
-        }
-
-
-        std::string toString( const PitchedEnum value )
-        {
-            switch ( value ) 
-            {
-                case PitchedEnum::chimes: return "chimes";
-                case PitchedEnum::glockenspiel: return "glockenspiel";
-                case PitchedEnum::mallet: return "mallet";
-                case PitchedEnum::marimba: return "marimba";
-                case PitchedEnum::tubularChimes: return "tubular chimes";
-                case PitchedEnum::vibraphone: return "vibraphone";
-                case PitchedEnum::xylophone: return "xylophone";
-                default: break;
-            }
-            return "chimes";
-        }
-
-
-        std::ostream& toStream( std::ostream& os, const PitchedEnum value )
-        {
-            return os << toString( value );
-        }
-
-
-        std::ostream& operator<<( std::ostream& os, const PitchedEnum value )
-        {
-            return toStream( os, value );
-        }
-
-        PrincipalVoiceSymbol parsePrincipalVoiceSymbol( const std::string& value )
-        {
-            if ( value == "Hauptstimme" ) { return PrincipalVoiceSymbol::hauptstimme; }
-            else if ( value == "Nebenstimme" ) { return PrincipalVoiceSymbol::nebenstimme; }
-            else if ( value == "plain" ) { return PrincipalVoiceSymbol::plain; }
-            else if ( value == "none" ) { return PrincipalVoiceSymbol::none; }
-            return PrincipalVoiceSymbol::hauptstimme;
-        }
-
-
-        std::string toString( const PrincipalVoiceSymbol value )
-        {
-            switch ( value ) 
-            {
-                case PrincipalVoiceSymbol::hauptstimme: return "Hauptstimme";
-                case PrincipalVoiceSymbol::nebenstimme: return "Nebenstimme";
-                case PrincipalVoiceSymbol::plain: return "plain";
-                case PrincipalVoiceSymbol::none: return "none";
-                default: break;
-            }
-            return "Hauptstimme";
-        }
-
-
-        std::ostream& toStream( std::ostream& os, const PrincipalVoiceSymbol value )
-        {
-            return os << toString( value );
-        }
-
-
-        std::ostream& operator<<( std::ostream& os, const PrincipalVoiceSymbol value )
-        {
-            return toStream( os, value );
-        }
-
-        StartStopChangeContinue parseStartStopChangeContinue( const std::string& value )
-        {
-            if ( value == "start" ) { return StartStopChangeContinue::start; }
-            else if ( value == "stop" ) { return StartStopChangeContinue::stop; }
-            else if ( value == "change" ) { return StartStopChangeContinue::change; }
-            else if ( value == "continue" ) { return StartStopChangeContinue::continue_; }
-            return StartStopChangeContinue::start;
-        }
-
-
-        std::string toString( const StartStopChangeContinue value )
-        {
-            switch ( value ) 
-            {
-                case StartStopChangeContinue::start: return "start";
-                case StartStopChangeContinue::stop: return "stop";
-                case StartStopChangeContinue::change: return "change";
-                case StartStopChangeContinue::continue_: return "continue";
-                default: break;
-            }
-            return "start";
-        }
-
-
-        std::ostream& toStream( std::ostream& os, const StartStopChangeContinue value )
-        {
-            return os << toString( value );
-        }
-
-
-        std::ostream& operator<<( std::ostream& os, const StartStopChangeContinue value )
-        {
-            return toStream( os, value );
-        }
-
-        TipDirection parseTipDirection( const std::string& value )
-        {
-            if ( value == "up" ) { return TipDirection::up; }
-            else if ( value == "down" ) { return TipDirection::down; }
-            else if ( value == "left" ) { return TipDirection::left; }
-            else if ( value == "right" ) { return TipDirection::right; }
-            else if ( value == "northwest" ) { return TipDirection::northwest; }
-            else if ( value == "northeast" ) { return TipDirection::northeast; }
-            else if ( value == "southeast" ) { return TipDirection::southeast; }
-            else if ( value == "southwest" ) { return TipDirection::southwest; }
-            return TipDirection::up;
-        }
-
-
-        std::string toString( const TipDirection value )
-        {
-            switch ( value ) 
-            {
-                case TipDirection::up: return "up";
-                case TipDirection::down: return "down";
-                case TipDirection::left: return "left";
-                case TipDirection::right: return "right";
-                case TipDirection::northwest: return "northwest";
-                case TipDirection::northeast: return "northeast";
-                case TipDirection::southeast: return "southeast";
-                case TipDirection::southwest: return "southwest";
-                default: break;
-            }
-            return "up";
-        }
-
-
-        std::ostream& toStream( std::ostream& os, const TipDirection value )
-        {
-            return os << toString( value );
-        }
-
-
-        std::ostream& operator<<( std::ostream& os, const TipDirection value )
-        {
-            return toStream( os, value );
-        }
-
-        StickLocationEnum parseStickLocationEnum( const std::string& value )
-        {
-            if ( value == "center" ) { return StickLocationEnum::center; }
-            else if ( value == "rim" ) { return StickLocationEnum::rim; }
-            else if ( value == "cymbal bell" ) { return StickLocationEnum::cymbalBell; }
-            else if ( value == "cymbal edge" ) { return StickLocationEnum::cymbalEdge; }
-            return StickLocationEnum::center;
-        }
-
-
-        std::string toString( const StickLocationEnum value )
-        {
-            switch ( value ) 
-            {
-                case StickLocationEnum::center: return "center";
-                case StickLocationEnum::rim: return "rim";
-                case StickLocationEnum::cymbalBell: return "cymbal bell";
-                case StickLocationEnum::cymbalEdge: return "cymbal edge";
-                default: break;
-            }
-            return "center";
-        }
-
-
-        std::ostream& toStream( std::ostream& os, const StickLocationEnum value )
-        {
-            return os << toString( value );
-        }
-
-
-        std::ostream& operator<<( std::ostream& os, const StickLocationEnum value )
-        {
-            return toStream( os, value );
-        }
-
-        StickMaterialEnum parseStickMaterialEnum( const std::string& value )
-        {
-            if ( value == "soft" ) { return StickMaterialEnum::soft; }
-            else if ( value == "medium" ) { return StickMaterialEnum::medium; }
-            else if ( value == "hard" ) { return StickMaterialEnum::hard; }
-            else if ( value == "shaded" ) { return StickMaterialEnum::shaded; }
-            else if ( value == "x" ) { return StickMaterialEnum::x; }
-            return StickMaterialEnum::soft;
-        }
-
-
-        std::string toString( const StickMaterialEnum value )
-        {
-            switch ( value ) 
-            {
-                case StickMaterialEnum::soft: return "soft";
-                case StickMaterialEnum::medium: return "medium";
-                case StickMaterialEnum::hard: return "hard";
-                case StickMaterialEnum::shaded: return "shaded";
-                case StickMaterialEnum::x: return "x";
-                default: break;
-            }
-            return "soft";
-        }
-
-
-        std::ostream& toStream( std::ostream& os, const StickMaterialEnum value )
-        {
-            return os << toString( value );
-        }
-
-
-        std::ostream& operator<<( std::ostream& os, const StickMaterialEnum value )
-        {
-            return toStream( os, value );
-        }
-
-        StickTypeEnum parseStickTypeEnum( const std::string& value )
-        {
-            if ( value == "bass drum" ) { return StickTypeEnum::bassDrum; }
-            else if ( value == "double bass drum" ) { return StickTypeEnum::doubleBassDrum; }
-            else if ( value == "timpani" ) { return StickTypeEnum::timpani; }
-            else if ( value == "xylophone" ) { return StickTypeEnum::xylophone; }
-            else if ( value == "yarn" ) { return StickTypeEnum::yarn; }
-            return StickTypeEnum::bassDrum;
-        }
-
-
-        std::string toString( const StickTypeEnum value )
-        {
-            switch ( value ) 
-            {
-                case StickTypeEnum::bassDrum: return "bass drum";
-                case StickTypeEnum::doubleBassDrum: return "double bass drum";
-                case StickTypeEnum::timpani: return "timpani";
-                case StickTypeEnum::xylophone: return "xylophone";
-                case StickTypeEnum::yarn: return "yarn";
-                default: break;
-            }
-            return "bass drum";
-        }
-
-
-        std::ostream& toStream( std::ostream& os, const StickTypeEnum value )
-        {
-            return os << toString( value );
-        }
-
-
-        std::ostream& operator<<( std::ostream& os, const StickTypeEnum value )
-        {
-            return toStream( os, value );
-        }
-
-        UpDownStopContinue parseUpDownStopContinue( const std::string& value )
-        {
-            if ( value == "up" ) { return UpDownStopContinue::up; }
-            else if ( value == "down" ) { return UpDownStopContinue::down; }
-            else if ( value == "stop" ) { return UpDownStopContinue::stop; }
-            else if ( value == "continue" ) { return UpDownStopContinue::continue_; }
-            return UpDownStopContinue::up;
-        }
-
-
-        std::string toString( const UpDownStopContinue value )
-        {
-            switch ( value ) 
-            {
-                case UpDownStopContinue::up: return "up";
-                case UpDownStopContinue::down: return "down";
-                case UpDownStopContinue::stop: return "stop";
-                case UpDownStopContinue::continue_: return "continue";
-                default: break;
-            }
-            return "up";
-        }
-
-
-        std::ostream& toStream( std::ostream& os, const UpDownStopContinue value )
-        {
-            return os << toString( value );
-        }
-
-
-        std::ostream& operator<<( std::ostream& os, const UpDownStopContinue value )
-        {
-            return toStream( os, value );
-        }
-
-        WedgeType parseWedgeType( const std::string& value )
-        {
-            if ( value == "crescendo" ) { return WedgeType::crescendo; }
-            else if ( value == "diminuendo" ) { return WedgeType::diminuendo; }
-            else if ( value == "stop" ) { return WedgeType::stop; }
-            else if ( value == "continue" ) { return WedgeType::continue_; }
-            return WedgeType::crescendo;
-        }
-
-
-        std::string toString( const WedgeType value )
-        {
-            switch ( value ) 
-            {
-                case WedgeType::crescendo: return "crescendo";
-                case WedgeType::diminuendo: return "diminuendo";
-                case WedgeType::stop: return "stop";
-                case WedgeType::continue_: return "continue";
-                default: break;
-            }
-            return "crescendo";
-        }
-
-
-        std::ostream& toStream( std::ostream& os, const WedgeType value )
-        {
-            return os << toString( value );
-        }
-
-
-        std::ostream& operator<<( std::ostream& os, const WedgeType value )
-        {
-            return toStream( os, value );
-        }
-
-        WoodEnum parseWoodEnum( const std::string& value )
-        {
-            if ( value == "board clapper" ) { return WoodEnum::boardClapper; }
-            else if ( value == "cabasa" ) { return WoodEnum::cabasa; }
-            else if ( value == "castanets" ) { return WoodEnum::castanets; }
-            else if ( value == "claves" ) { return WoodEnum::claves; }
-            else if ( value == "guiro" ) { return WoodEnum::guiro; }
-            else if ( value == "log drum" ) { return WoodEnum::logDrum; }
-            else if ( value == "maraca" ) { return WoodEnum::maraca; }
-            else if ( value == "maracas" ) { return WoodEnum::maracas; }
-            else if ( value == "ratchet" ) { return WoodEnum::ratchet; }
-            else if ( value == "sandpaper blocks" ) { return WoodEnum::sandpaperBlocks; }
-            else if ( value == "slit drum" ) { return WoodEnum::slitDrum; }
-            else if ( value == "temple block" ) { return WoodEnum::templeBlock; }
-            else if ( value == "vibraslap" ) { return WoodEnum::vibraslap; }
-            else if ( value == "wood block" ) { return WoodEnum::woodBlock; }
-            return WoodEnum::boardClapper;
-        }
-
-
-        std::string toString( const WoodEnum value )
-        {
-            switch ( value ) 
-            {
-                case WoodEnum::boardClapper: return "board clapper";
-                case WoodEnum::cabasa: return "cabasa";
-                case WoodEnum::castanets: return "castanets";
-                case WoodEnum::claves: return "claves";
-                case WoodEnum::guiro: return "guiro";
-                case WoodEnum::logDrum: return "log drum";
-                case WoodEnum::maraca: return "maraca";
-                case WoodEnum::maracas: return "maracas";
-                case WoodEnum::ratchet: return "ratchet";
-                case WoodEnum::sandpaperBlocks: return "sandpaper blocks";
-                case WoodEnum::slitDrum: return "slit drum";
-                case WoodEnum::templeBlock: return "temple block";
-                case WoodEnum::vibraslap: return "vibraslap";
-                case WoodEnum::woodBlock: return "wood block";
-                default: break;
-            }
-            return "board clapper";
-        }
-
-
-        std::ostream& toStream( std::ostream& os, const WoodEnum value )
-        {
-            return os << toString( value );
-        }
-
-
-        std::ostream& operator<<( std::ostream& os, const WoodEnum value )
-        {
-            return toStream( os, value );
-        }
-
-        MarginType parseMarginType( const std::string& value )
-        {
-            if ( value == "odd" ) { return MarginType::odd; }
-            else if ( value == "even" ) { return MarginType::even; }
-            else if ( value == "both" ) { return MarginType::both; }
-            return MarginType::odd;
-        }
-
-
-        std::string toString( const MarginType value )
-        {
-            switch ( value ) 
-            {
-                case MarginType::odd: return "odd";
-                case MarginType::even: return "even";
-                case MarginType::both: return "both";
-                default: break;
-            }
-            return "odd";
-        }
-
-
-        std::ostream& toStream( std::ostream& os, const MarginType value )
-        {
-            return os << toString( value );
-        }
-
-
-        std::ostream& operator<<( std::ostream& os, const MarginType value )
-        {
-            return toStream( os, value );
-        }
-
-        NoteSizeType parseNoteSizeType( const std::string& value )
-        {
-            if ( value == "cue" ) { return NoteSizeType::cue; }
-            else if ( value == "grace" ) { return NoteSizeType::grace; }
-            else if ( value == "large" ) { return NoteSizeType::large; }
-            return NoteSizeType::cue;
-        }
-
-
-        std::string toString( const NoteSizeType value )
-        {
-            switch ( value ) 
-            {
-                case NoteSizeType::cue: return "cue";
-                case NoteSizeType::grace: return "grace";
-                case NoteSizeType::large: return "large";
-                default: break;
-            }
-            return "cue";
-        }
-
-
-        std::ostream& toStream( std::ostream& os, const NoteSizeType value )
-        {
-            return os << toString( value );
-        }
-
-
-        std::ostream& operator<<( std::ostream& os, const NoteSizeType value )
-        {
-            return toStream( os, value );
-        }
+        /// AccidentalValue ////////////////////////////////////////////////////////////////////////
 
         AccidentalValue parseAccidentalValue( const std::string& value )
         {
@@ -2443,61 +82,60 @@ namespace mx
             return AccidentalValue::sharp;
         }
 
-
         std::string toString( const AccidentalValue value )
         {
-            switch ( value ) 
+            switch ( value )
             {
-                case AccidentalValue::sharp: return "sharp";
-                case AccidentalValue::natural: return "natural";
-                case AccidentalValue::flat: return "flat";
-                case AccidentalValue::doubleSharp: return "double-sharp";
-                case AccidentalValue::sharpSharp: return "sharp-sharp";
-                case AccidentalValue::flatFlat: return "flat-flat";
-                case AccidentalValue::naturalSharp: return "natural-sharp";
-                case AccidentalValue::naturalFlat: return "natural-flat";
-                case AccidentalValue::quarterFlat: return "quarter-flat";
-                case AccidentalValue::quarterSharp: return "quarter-sharp";
-                case AccidentalValue::threeQuartersFlat: return "three-quarters-flat";
-                case AccidentalValue::threeQuartersSharp: return "three-quarters-sharp";
-                case AccidentalValue::sharpDown: return "sharp-down";
-                case AccidentalValue::sharpUp: return "sharp-up";
-                case AccidentalValue::naturalDown: return "natural-down";
-                case AccidentalValue::naturalUp: return "natural-up";
-                case AccidentalValue::flatDown: return "flat-down";
-                case AccidentalValue::flatUp: return "flat-up";
-                case AccidentalValue::tripleSharp: return "triple-sharp";
-                case AccidentalValue::tripleFlat: return "triple-flat";
-                case AccidentalValue::slashQuarterSharp: return "slash-quarter-sharp";
-                case AccidentalValue::slashSharp: return "slash-sharp";
-                case AccidentalValue::slashFlat: return "slash-flat";
-                case AccidentalValue::doubleSlashFlat: return "double-slash-flat";
-                case AccidentalValue::sharp1: return "sharp-1";
-                case AccidentalValue::sharp2: return "sharp-2";
-                case AccidentalValue::sharp3: return "sharp-3";
-                case AccidentalValue::sharp5: return "sharp-5";
-                case AccidentalValue::flat1: return "flat-1";
-                case AccidentalValue::flat2: return "flat-2";
-                case AccidentalValue::flat3: return "flat-3";
-                case AccidentalValue::flat4: return "flat-4";
-                case AccidentalValue::sori: return "sori";
-                case AccidentalValue::koron: return "koron";
+                case AccidentalValue::sharp: { return "sharp"; }
+                case AccidentalValue::natural: { return "natural"; }
+                case AccidentalValue::flat: { return "flat"; }
+                case AccidentalValue::doubleSharp: { return "double-sharp"; }
+                case AccidentalValue::sharpSharp: { return "sharp-sharp"; }
+                case AccidentalValue::flatFlat: { return "flat-flat"; }
+                case AccidentalValue::naturalSharp: { return "natural-sharp"; }
+                case AccidentalValue::naturalFlat: { return "natural-flat"; }
+                case AccidentalValue::quarterFlat: { return "quarter-flat"; }
+                case AccidentalValue::quarterSharp: { return "quarter-sharp"; }
+                case AccidentalValue::threeQuartersFlat: { return "three-quarters-flat"; }
+                case AccidentalValue::threeQuartersSharp: { return "three-quarters-sharp"; }
+                case AccidentalValue::sharpDown: { return "sharp-down"; }
+                case AccidentalValue::sharpUp: { return "sharp-up"; }
+                case AccidentalValue::naturalDown: { return "natural-down"; }
+                case AccidentalValue::naturalUp: { return "natural-up"; }
+                case AccidentalValue::flatDown: { return "flat-down"; }
+                case AccidentalValue::flatUp: { return "flat-up"; }
+                case AccidentalValue::tripleSharp: { return "triple-sharp"; }
+                case AccidentalValue::tripleFlat: { return "triple-flat"; }
+                case AccidentalValue::slashQuarterSharp: { return "slash-quarter-sharp"; }
+                case AccidentalValue::slashSharp: { return "slash-sharp"; }
+                case AccidentalValue::slashFlat: { return "slash-flat"; }
+                case AccidentalValue::doubleSlashFlat: { return "double-slash-flat"; }
+                case AccidentalValue::sharp1: { return "sharp-1"; }
+                case AccidentalValue::sharp2: { return "sharp-2"; }
+                case AccidentalValue::sharp3: { return "sharp-3"; }
+                case AccidentalValue::sharp5: { return "sharp-5"; }
+                case AccidentalValue::flat1: { return "flat-1"; }
+                case AccidentalValue::flat2: { return "flat-2"; }
+                case AccidentalValue::flat3: { return "flat-3"; }
+                case AccidentalValue::flat4: { return "flat-4"; }
+                case AccidentalValue::sori: { return "sori"; }
+                case AccidentalValue::koron: { return "koron"; }
                 default: break;
             }
             return "sharp";
         }
-
 
         std::ostream& toStream( std::ostream& os, const AccidentalValue value )
         {
             return os << toString( value );
         }
 
-
         std::ostream& operator<<( std::ostream& os, const AccidentalValue value )
         {
             return toStream( os, value );
         }
+
+        /// ArrowDirectionEnum /////////////////////////////////////////////////////////////////////
 
         ArrowDirectionEnum parseArrowDirectionEnum( const std::string& value )
         {
@@ -2517,40 +155,39 @@ namespace mx
             return ArrowDirectionEnum::left;
         }
 
-
         std::string toString( const ArrowDirectionEnum value )
         {
-            switch ( value ) 
+            switch ( value )
             {
-                case ArrowDirectionEnum::left: return "left";
-                case ArrowDirectionEnum::up: return "up";
-                case ArrowDirectionEnum::right: return "right";
-                case ArrowDirectionEnum::down: return "down";
-                case ArrowDirectionEnum::northwest: return "northwest";
-                case ArrowDirectionEnum::northeast: return "northeast";
-                case ArrowDirectionEnum::southeast: return "southeast";
-                case ArrowDirectionEnum::southwest: return "southwest";
-                case ArrowDirectionEnum::leftRight: return "left right";
-                case ArrowDirectionEnum::upDown: return "up down";
-                case ArrowDirectionEnum::northwestSoutheast: return "northwest southeast";
-                case ArrowDirectionEnum::northeastSouthwest: return "northeast southwest";
-                case ArrowDirectionEnum::other: return "other";
+                case ArrowDirectionEnum::left: { return "left"; }
+                case ArrowDirectionEnum::up: { return "up"; }
+                case ArrowDirectionEnum::right: { return "right"; }
+                case ArrowDirectionEnum::down: { return "down"; }
+                case ArrowDirectionEnum::northwest: { return "northwest"; }
+                case ArrowDirectionEnum::northeast: { return "northeast"; }
+                case ArrowDirectionEnum::southeast: { return "southeast"; }
+                case ArrowDirectionEnum::southwest: { return "southwest"; }
+                case ArrowDirectionEnum::leftRight: { return "left right"; }
+                case ArrowDirectionEnum::upDown: { return "up down"; }
+                case ArrowDirectionEnum::northwestSoutheast: { return "northwest southeast"; }
+                case ArrowDirectionEnum::northeastSouthwest: { return "northeast southwest"; }
+                case ArrowDirectionEnum::other: { return "other"; }
                 default: break;
             }
             return "left";
         }
-
 
         std::ostream& toStream( std::ostream& os, const ArrowDirectionEnum value )
         {
             return os << toString( value );
         }
 
-
         std::ostream& operator<<( std::ostream& os, const ArrowDirectionEnum value )
         {
             return toStream( os, value );
         }
+
+        /// ArrowStyleEnum /////////////////////////////////////////////////////////////////////////
 
         ArrowStyleEnum parseArrowStyleEnum( const std::string& value )
         {
@@ -2564,34 +201,111 @@ namespace mx
             return ArrowStyleEnum::single;
         }
 
-
         std::string toString( const ArrowStyleEnum value )
         {
-            switch ( value ) 
+            switch ( value )
             {
-                case ArrowStyleEnum::single: return "single";
-                case ArrowStyleEnum::double_: return "double";
-                case ArrowStyleEnum::filled: return "filled";
-                case ArrowStyleEnum::hollow: return "hollow";
-                case ArrowStyleEnum::paired: return "paired";
-                case ArrowStyleEnum::combined: return "combined";
-                case ArrowStyleEnum::other: return "other";
+                case ArrowStyleEnum::single: { return "single"; }
+                case ArrowStyleEnum::double_: { return "double"; }
+                case ArrowStyleEnum::filled: { return "filled"; }
+                case ArrowStyleEnum::hollow: { return "hollow"; }
+                case ArrowStyleEnum::paired: { return "paired"; }
+                case ArrowStyleEnum::combined: { return "combined"; }
+                case ArrowStyleEnum::other: { return "other"; }
                 default: break;
             }
             return "single";
         }
-
 
         std::ostream& toStream( std::ostream& os, const ArrowStyleEnum value )
         {
             return os << toString( value );
         }
 
-
         std::ostream& operator<<( std::ostream& os, const ArrowStyleEnum value )
         {
             return toStream( os, value );
         }
+
+        /// BackwardForward ////////////////////////////////////////////////////////////////////////
+
+        BackwardForward parseBackwardForward( const std::string& value )
+        {
+            if ( value == "backward" ) { return BackwardForward::backward; }
+            else if ( value == "forward" ) { return BackwardForward::forward; }
+            return BackwardForward::backward;
+        }
+
+        std::string toString( const BackwardForward value )
+        {
+            switch ( value )
+            {
+                case BackwardForward::backward: { return "backward"; }
+                case BackwardForward::forward: { return "forward"; }
+                default: break;
+            }
+            return "backward";
+        }
+
+        std::ostream& toStream( std::ostream& os, const BackwardForward value )
+        {
+            return os << toString( value );
+        }
+
+        std::ostream& operator<<( std::ostream& os, const BackwardForward value )
+        {
+            return toStream( os, value );
+        }
+
+        /// BarStyleEnum ///////////////////////////////////////////////////////////////////////////
+
+        BarStyleEnum parseBarStyleEnum( const std::string& value )
+        {
+            if ( value == "regular" ) { return BarStyleEnum::regular; }
+            else if ( value == "dotted" ) { return BarStyleEnum::dotted; }
+            else if ( value == "dashed" ) { return BarStyleEnum::dashed; }
+            else if ( value == "heavy" ) { return BarStyleEnum::heavy; }
+            else if ( value == "light-light" ) { return BarStyleEnum::lightLight; }
+            else if ( value == "light-heavy" ) { return BarStyleEnum::lightHeavy; }
+            else if ( value == "heavy-light" ) { return BarStyleEnum::heavyLight; }
+            else if ( value == "heavy-heavy" ) { return BarStyleEnum::heavyHeavy; }
+            else if ( value == "tick" ) { return BarStyleEnum::tick; }
+            else if ( value == "short" ) { return BarStyleEnum::short_; }
+            else if ( value == "none" ) { return BarStyleEnum::none; }
+            return BarStyleEnum::regular;
+        }
+
+        std::string toString( const BarStyleEnum value )
+        {
+            switch ( value )
+            {
+                case BarStyleEnum::regular: { return "regular"; }
+                case BarStyleEnum::dotted: { return "dotted"; }
+                case BarStyleEnum::dashed: { return "dashed"; }
+                case BarStyleEnum::heavy: { return "heavy"; }
+                case BarStyleEnum::lightLight: { return "light-light"; }
+                case BarStyleEnum::lightHeavy: { return "light-heavy"; }
+                case BarStyleEnum::heavyLight: { return "heavy-light"; }
+                case BarStyleEnum::heavyHeavy: { return "heavy-heavy"; }
+                case BarStyleEnum::tick: { return "tick"; }
+                case BarStyleEnum::short_: { return "short"; }
+                case BarStyleEnum::none: { return "none"; }
+                default: break;
+            }
+            return "regular";
+        }
+
+        std::ostream& toStream( std::ostream& os, const BarStyleEnum value )
+        {
+            return os << toString( value );
+        }
+
+        std::ostream& operator<<( std::ostream& os, const BarStyleEnum value )
+        {
+            return toStream( os, value );
+        }
+
+        /// BeamValue //////////////////////////////////////////////////////////////////////////////
 
         BeamValue parseBeamValue( const std::string& value )
         {
@@ -2603,32 +317,91 @@ namespace mx
             return BeamValue::begin;
         }
 
-
         std::string toString( const BeamValue value )
         {
-            switch ( value ) 
+            switch ( value )
             {
-                case BeamValue::begin: return "begin";
-                case BeamValue::continue_: return "continue";
-                case BeamValue::end: return "end";
-                case BeamValue::forwardHook: return "forward hook";
-                case BeamValue::backwardHook: return "backward hook";
+                case BeamValue::begin: { return "begin"; }
+                case BeamValue::continue_: { return "continue"; }
+                case BeamValue::end: { return "end"; }
+                case BeamValue::forwardHook: { return "forward hook"; }
+                case BeamValue::backwardHook: { return "backward hook"; }
                 default: break;
             }
             return "begin";
         }
-
 
         std::ostream& toStream( std::ostream& os, const BeamValue value )
         {
             return os << toString( value );
         }
 
-
         std::ostream& operator<<( std::ostream& os, const BeamValue value )
         {
             return toStream( os, value );
         }
+
+        /// BeaterValue ////////////////////////////////////////////////////////////////////////////
+
+        BeaterValue parseBeaterValue( const std::string& value )
+        {
+            if ( value == "bow" ) { return BeaterValue::bow; }
+            else if ( value == "chime hammer" ) { return BeaterValue::chimeHammer; }
+            else if ( value == "coin" ) { return BeaterValue::coin; }
+            else if ( value == "finger" ) { return BeaterValue::finger; }
+            else if ( value == "fingernail" ) { return BeaterValue::fingernail; }
+            else if ( value == "fist" ) { return BeaterValue::fist; }
+            else if ( value == "guiro scraper" ) { return BeaterValue::guiroScraper; }
+            else if ( value == "hammer" ) { return BeaterValue::hammer; }
+            else if ( value == "hand" ) { return BeaterValue::hand; }
+            else if ( value == "jazz stick" ) { return BeaterValue::jazzStick; }
+            else if ( value == "knitting needle" ) { return BeaterValue::knittingNeedle; }
+            else if ( value == "metal hammer" ) { return BeaterValue::metalHammer; }
+            else if ( value == "snare stick" ) { return BeaterValue::snareStick; }
+            else if ( value == "spoon mallet" ) { return BeaterValue::spoonMallet; }
+            else if ( value == "triangle beater" ) { return BeaterValue::triangleBeater; }
+            else if ( value == "triangle beater plain" ) { return BeaterValue::triangleBeaterPlain; }
+            else if ( value == "wire brush" ) { return BeaterValue::wireBrush; }
+            return BeaterValue::bow;
+        }
+
+        std::string toString( const BeaterValue value )
+        {
+            switch ( value )
+            {
+                case BeaterValue::bow: { return "bow"; }
+                case BeaterValue::chimeHammer: { return "chime hammer"; }
+                case BeaterValue::coin: { return "coin"; }
+                case BeaterValue::finger: { return "finger"; }
+                case BeaterValue::fingernail: { return "fingernail"; }
+                case BeaterValue::fist: { return "fist"; }
+                case BeaterValue::guiroScraper: { return "guiro scraper"; }
+                case BeaterValue::hammer: { return "hammer"; }
+                case BeaterValue::hand: { return "hand"; }
+                case BeaterValue::jazzStick: { return "jazz stick"; }
+                case BeaterValue::knittingNeedle: { return "knitting needle"; }
+                case BeaterValue::metalHammer: { return "metal hammer"; }
+                case BeaterValue::snareStick: { return "snare stick"; }
+                case BeaterValue::spoonMallet: { return "spoon mallet"; }
+                case BeaterValue::triangleBeater: { return "triangle beater"; }
+                case BeaterValue::triangleBeaterPlain: { return "triangle beater plain"; }
+                case BeaterValue::wireBrush: { return "wire brush"; }
+                default: break;
+            }
+            return "bow";
+        }
+
+        std::ostream& toStream( std::ostream& os, const BeaterValue value )
+        {
+            return os << toString( value );
+        }
+
+        std::ostream& operator<<( std::ostream& os, const BeaterValue value )
+        {
+            return toStream( os, value );
+        }
+
+        /// BreathMarkValue ////////////////////////////////////////////////////////////////////////
 
         BreathMarkValue parseBreathMarkValue( const std::string& value )
         {
@@ -2638,30 +411,61 @@ namespace mx
             return BreathMarkValue::emptystring;
         }
 
-
         std::string toString( const BreathMarkValue value )
         {
-            switch ( value ) 
+            switch ( value )
             {
-                case BreathMarkValue::emptystring: return "";
-                case BreathMarkValue::comma: return "comma";
-                case BreathMarkValue::tick: return "tick";
+                case BreathMarkValue::emptystring: { return ""; }
+                case BreathMarkValue::comma: { return "comma"; }
+                case BreathMarkValue::tick: { return "tick"; }
                 default: break;
             }
             return "";
         }
-
 
         std::ostream& toStream( std::ostream& os, const BreathMarkValue value )
         {
             return os << toString( value );
         }
 
-
         std::ostream& operator<<( std::ostream& os, const BreathMarkValue value )
         {
             return toStream( os, value );
         }
+
+        /// CancelLocation /////////////////////////////////////////////////////////////////////////
+
+        CancelLocation parseCancelLocation( const std::string& value )
+        {
+            if ( value == "left" ) { return CancelLocation::left; }
+            else if ( value == "right" ) { return CancelLocation::right; }
+            else if ( value == "before-barline" ) { return CancelLocation::beforeBarline; }
+            return CancelLocation::left;
+        }
+
+        std::string toString( const CancelLocation value )
+        {
+            switch ( value )
+            {
+                case CancelLocation::left: { return "left"; }
+                case CancelLocation::right: { return "right"; }
+                case CancelLocation::beforeBarline: { return "before-barline"; }
+                default: break;
+            }
+            return "left";
+        }
+
+        std::ostream& toStream( std::ostream& os, const CancelLocation value )
+        {
+            return os << toString( value );
+        }
+
+        std::ostream& operator<<( std::ostream& os, const CancelLocation value )
+        {
+            return toStream( os, value );
+        }
+
+        /// CircularArrowEnum //////////////////////////////////////////////////////////////////////
 
         CircularArrowEnum parseCircularArrowEnum( const std::string& value )
         {
@@ -2670,723 +474,240 @@ namespace mx
             return CircularArrowEnum::clockwise;
         }
 
-
         std::string toString( const CircularArrowEnum value )
         {
-            switch ( value ) 
+            switch ( value )
             {
-                case CircularArrowEnum::clockwise: return "clockwise";
-                case CircularArrowEnum::anticlockwise: return "anticlockwise";
+                case CircularArrowEnum::clockwise: { return "clockwise"; }
+                case CircularArrowEnum::anticlockwise: { return "anticlockwise"; }
                 default: break;
             }
             return "clockwise";
         }
-
 
         std::ostream& toStream( std::ostream& os, const CircularArrowEnum value )
         {
             return os << toString( value );
         }
 
-
         std::ostream& operator<<( std::ostream& os, const CircularArrowEnum value )
         {
             return toStream( os, value );
         }
 
-        Fan parseFan( const std::string& value )
+        /// ClefSign ///////////////////////////////////////////////////////////////////////////////
+
+        ClefSign parseClefSign( const std::string& value )
         {
-            if ( value == "accel" ) { return Fan::accel; }
-            else if ( value == "rit" ) { return Fan::rit; }
-            else if ( value == "none" ) { return Fan::none; }
-            return Fan::accel;
+            if ( value == "G" ) { return ClefSign::g; }
+            else if ( value == "F" ) { return ClefSign::f; }
+            else if ( value == "C" ) { return ClefSign::c; }
+            else if ( value == "percussion" ) { return ClefSign::percussion; }
+            else if ( value == "TAB" ) { return ClefSign::tab; }
+            else if ( value == "jianpu" ) { return ClefSign::jianpu; }
+            else if ( value == "none" ) { return ClefSign::none; }
+            return ClefSign::g;
         }
 
-
-        std::string toString( const Fan value )
-        {
-            switch ( value ) 
-            {
-                case Fan::accel: return "accel";
-                case Fan::rit: return "rit";
-                case Fan::none: return "none";
-                default: break;
-            }
-            return "accel";
-        }
-
-
-        std::ostream& toStream( std::ostream& os, const Fan value )
-        {
-            return os << toString( value );
-        }
-
-
-        std::ostream& operator<<( std::ostream& os, const Fan value )
-        {
-            return toStream( os, value );
-        }
-
-        HandbellValue parseHandbellValue( const std::string& value )
-        {
-            if ( value == "damp" ) { return HandbellValue::damp; }
-            else if ( value == "echo" ) { return HandbellValue::echo; }
-            else if ( value == "gyro" ) { return HandbellValue::gyro; }
-            else if ( value == "hand martellato" ) { return HandbellValue::handMartellato; }
-            else if ( value == "mallet lift" ) { return HandbellValue::malletLift; }
-            else if ( value == "mallet table" ) { return HandbellValue::malletTable; }
-            else if ( value == "martellato" ) { return HandbellValue::martellato; }
-            else if ( value == "martellato lift" ) { return HandbellValue::martellatoLift; }
-            else if ( value == "muted martellato" ) { return HandbellValue::mutedMartellato; }
-            else if ( value == "pluck lift" ) { return HandbellValue::pluckLift; }
-            else if ( value == "swing" ) { return HandbellValue::swing; }
-            return HandbellValue::damp;
-        }
-
-
-        std::string toString( const HandbellValue value )
-        {
-            switch ( value ) 
-            {
-                case HandbellValue::damp: return "damp";
-                case HandbellValue::echo: return "echo";
-                case HandbellValue::gyro: return "gyro";
-                case HandbellValue::handMartellato: return "hand martellato";
-                case HandbellValue::malletLift: return "mallet lift";
-                case HandbellValue::malletTable: return "mallet table";
-                case HandbellValue::martellato: return "martellato";
-                case HandbellValue::martellatoLift: return "martellato lift";
-                case HandbellValue::mutedMartellato: return "muted martellato";
-                case HandbellValue::pluckLift: return "pluck lift";
-                case HandbellValue::swing: return "swing";
-                default: break;
-            }
-            return "damp";
-        }
-
-
-        std::ostream& toStream( std::ostream& os, const HandbellValue value )
-        {
-            return os << toString( value );
-        }
-
-
-        std::ostream& operator<<( std::ostream& os, const HandbellValue value )
-        {
-            return toStream( os, value );
-        }
-
-        HoleClosedLocation parseHoleClosedLocation( const std::string& value )
-        {
-            if ( value == "right" ) { return HoleClosedLocation::right; }
-            else if ( value == "bottom" ) { return HoleClosedLocation::bottom; }
-            else if ( value == "left" ) { return HoleClosedLocation::left; }
-            else if ( value == "top" ) { return HoleClosedLocation::top; }
-            return HoleClosedLocation::right;
-        }
-
-
-        std::string toString( const HoleClosedLocation value )
-        {
-            switch ( value ) 
-            {
-                case HoleClosedLocation::right: return "right";
-                case HoleClosedLocation::bottom: return "bottom";
-                case HoleClosedLocation::left: return "left";
-                case HoleClosedLocation::top: return "top";
-                default: break;
-            }
-            return "right";
-        }
-
-
-        std::ostream& toStream( std::ostream& os, const HoleClosedLocation value )
-        {
-            return os << toString( value );
-        }
-
-
-        std::ostream& operator<<( std::ostream& os, const HoleClosedLocation value )
-        {
-            return toStream( os, value );
-        }
-
-        HoleClosedValue parseHoleClosedValue( const std::string& value )
-        {
-            if ( value == "yes" ) { return HoleClosedValue::yes; }
-            else if ( value == "no" ) { return HoleClosedValue::no; }
-            else if ( value == "half" ) { return HoleClosedValue::half; }
-            return HoleClosedValue::yes;
-        }
-
-
-        std::string toString( const HoleClosedValue value )
-        {
-            switch ( value ) 
-            {
-                case HoleClosedValue::yes: return "yes";
-                case HoleClosedValue::no: return "no";
-                case HoleClosedValue::half: return "half";
-                default: break;
-            }
-            return "yes";
-        }
-
-
-        std::ostream& toStream( std::ostream& os, const HoleClosedValue value )
-        {
-            return os << toString( value );
-        }
-
-
-        std::ostream& operator<<( std::ostream& os, const HoleClosedValue value )
-        {
-            return toStream( os, value );
-        }
-
-        NoteTypeValue parseNoteTypeValue( const std::string& value )
-        {
-            if ( value == "1024th" ) { return NoteTypeValue::oneThousandTwentyFourth; }
-            else if ( value == "512th" ) { return NoteTypeValue::fiveHundredTwelfth; }
-            else if ( value == "256th" ) { return NoteTypeValue::twoHundredFifthySixth; }
-            else if ( value == "128th" ) { return NoteTypeValue::oneHundredTwentyEighth; }
-            else if ( value == "64th" ) { return NoteTypeValue::sixtyFourth; }
-            else if ( value == "32nd" ) { return NoteTypeValue::thirtySecond; }
-            else if ( value == "16th" ) { return NoteTypeValue::sixteenth; }
-            else if ( value == "eighth" ) { return NoteTypeValue::eighth; }
-            else if ( value == "quarter" ) { return NoteTypeValue::quarter; }
-            else if ( value == "half" ) { return NoteTypeValue::half; }
-            else if ( value == "whole" ) { return NoteTypeValue::whole; }
-            else if ( value == "breve" ) { return NoteTypeValue::breve; }
-            else if ( value == "long" ) { return NoteTypeValue::long_; }
-            else if ( value == "maxima" ) { return NoteTypeValue::maxima; }
-            return NoteTypeValue::oneThousandTwentyFourth;
-        }
-
-
-        std::string toString( const NoteTypeValue value )
-        {
-            switch ( value ) 
-            {
-                case NoteTypeValue::oneThousandTwentyFourth: return "1024th";
-                case NoteTypeValue::fiveHundredTwelfth: return "512th";
-                case NoteTypeValue::twoHundredFifthySixth: return "256th";
-                case NoteTypeValue::oneHundredTwentyEighth: return "128th";
-                case NoteTypeValue::sixtyFourth: return "64th";
-                case NoteTypeValue::thirtySecond: return "32nd";
-                case NoteTypeValue::sixteenth: return "16th";
-                case NoteTypeValue::eighth: return "eighth";
-                case NoteTypeValue::quarter: return "quarter";
-                case NoteTypeValue::half: return "half";
-                case NoteTypeValue::whole: return "whole";
-                case NoteTypeValue::breve: return "breve";
-                case NoteTypeValue::long_: return "long";
-                case NoteTypeValue::maxima: return "maxima";
-                default: break;
-            }
-            return "1024th";
-        }
-
-
-        std::ostream& toStream( std::ostream& os, const NoteTypeValue value )
-        {
-            return os << toString( value );
-        }
-
-
-        std::ostream& operator<<( std::ostream& os, const NoteTypeValue value )
-        {
-            return toStream( os, value );
-        }
-
-        NoteheadValue parseNoteheadValue( const std::string& value )
-        {
-            if ( value == "slash" ) { return NoteheadValue::slash; }
-            else if ( value == "triangle" ) { return NoteheadValue::triangle; }
-            else if ( value == "diamond" ) { return NoteheadValue::diamond; }
-            else if ( value == "square" ) { return NoteheadValue::square; }
-            else if ( value == "cross" ) { return NoteheadValue::cross; }
-            else if ( value == "x" ) { return NoteheadValue::x; }
-            else if ( value == "circle-x" ) { return NoteheadValue::circleX; }
-            else if ( value == "inverted triangle" ) { return NoteheadValue::invertedTriangle; }
-            else if ( value == "arrow down" ) { return NoteheadValue::arrowDown; }
-            else if ( value == "arrow up" ) { return NoteheadValue::arrowUp; }
-            else if ( value == "slashed" ) { return NoteheadValue::slashed; }
-            else if ( value == "back slashed" ) { return NoteheadValue::backSlashed; }
-            else if ( value == "normal" ) { return NoteheadValue::normal; }
-            else if ( value == "cluster" ) { return NoteheadValue::cluster; }
-            else if ( value == "circle dot" ) { return NoteheadValue::circleDot; }
-            else if ( value == "left triangle" ) { return NoteheadValue::leftTriangle; }
-            else if ( value == "rectangle" ) { return NoteheadValue::rectangle; }
-            else if ( value == "none" ) { return NoteheadValue::none; }
-            else if ( value == "do" ) { return NoteheadValue::do_; }
-            else if ( value == "re" ) { return NoteheadValue::re; }
-            else if ( value == "mi" ) { return NoteheadValue::mi; }
-            else if ( value == "fa" ) { return NoteheadValue::fa; }
-            else if ( value == "fa up" ) { return NoteheadValue::faUp; }
-            else if ( value == "so" ) { return NoteheadValue::so; }
-            else if ( value == "la" ) { return NoteheadValue::la; }
-            else if ( value == "ti" ) { return NoteheadValue::ti; }
-            return NoteheadValue::slash;
-        }
-
-
-        std::string toString( const NoteheadValue value )
-        {
-            switch ( value ) 
-            {
-                case NoteheadValue::slash: return "slash";
-                case NoteheadValue::triangle: return "triangle";
-                case NoteheadValue::diamond: return "diamond";
-                case NoteheadValue::square: return "square";
-                case NoteheadValue::cross: return "cross";
-                case NoteheadValue::x: return "x";
-                case NoteheadValue::circleX: return "circle-x";
-                case NoteheadValue::invertedTriangle: return "inverted triangle";
-                case NoteheadValue::arrowDown: return "arrow down";
-                case NoteheadValue::arrowUp: return "arrow up";
-                case NoteheadValue::slashed: return "slashed";
-                case NoteheadValue::backSlashed: return "back slashed";
-                case NoteheadValue::normal: return "normal";
-                case NoteheadValue::cluster: return "cluster";
-                case NoteheadValue::circleDot: return "circle dot";
-                case NoteheadValue::leftTriangle: return "left triangle";
-                case NoteheadValue::rectangle: return "rectangle";
-                case NoteheadValue::none: return "none";
-                case NoteheadValue::do_: return "do";
-                case NoteheadValue::re: return "re";
-                case NoteheadValue::mi: return "mi";
-                case NoteheadValue::fa: return "fa";
-                case NoteheadValue::faUp: return "fa up";
-                case NoteheadValue::so: return "so";
-                case NoteheadValue::la: return "la";
-                case NoteheadValue::ti: return "ti";
-                default: break;
-            }
-            return "slash";
-        }
-
-
-        std::ostream& toStream( std::ostream& os, const NoteheadValue value )
-        {
-            return os << toString( value );
-        }
-
-
-        std::ostream& operator<<( std::ostream& os, const NoteheadValue value )
-        {
-            return toStream( os, value );
-        }
-
-        ShowTuplet parseShowTuplet( const std::string& value )
-        {
-            if ( value == "actual" ) { return ShowTuplet::actual; }
-            else if ( value == "both" ) { return ShowTuplet::both; }
-            else if ( value == "none" ) { return ShowTuplet::none; }
-            return ShowTuplet::actual;
-        }
-
-
-        std::string toString( const ShowTuplet value )
-        {
-            switch ( value ) 
-            {
-                case ShowTuplet::actual: return "actual";
-                case ShowTuplet::both: return "both";
-                case ShowTuplet::none: return "none";
-                default: break;
-            }
-            return "actual";
-        }
-
-
-        std::ostream& toStream( std::ostream& os, const ShowTuplet value )
-        {
-            return os << toString( value );
-        }
-
-
-        std::ostream& operator<<( std::ostream& os, const ShowTuplet value )
-        {
-            return toStream( os, value );
-        }
-
-        StemValue parseStemValue( const std::string& value )
-        {
-            if ( value == "down" ) { return StemValue::down; }
-            else if ( value == "up" ) { return StemValue::up; }
-            else if ( value == "double" ) { return StemValue::double_; }
-            else if ( value == "none" ) { return StemValue::none; }
-            return StemValue::down;
-        }
-
-
-        std::string toString( const StemValue value )
-        {
-            switch ( value ) 
-            {
-                case StemValue::down: return "down";
-                case StemValue::up: return "up";
-                case StemValue::double_: return "double";
-                case StemValue::none: return "none";
-                default: break;
-            }
-            return "down";
-        }
-
-
-        std::ostream& toStream( std::ostream& os, const StemValue value )
-        {
-            return os << toString( value );
-        }
-
-
-        std::ostream& operator<<( std::ostream& os, const StemValue value )
-        {
-            return toStream( os, value );
-        }
-
-        StepEnum parseStepEnum( const std::string& value )
-        {
-            if ( value == "A" ) { return StepEnum::a; }
-            else if ( value == "B" ) { return StepEnum::b; }
-            else if ( value == "C" ) { return StepEnum::c; }
-            else if ( value == "D" ) { return StepEnum::d; }
-            else if ( value == "E" ) { return StepEnum::e; }
-            else if ( value == "F" ) { return StepEnum::f; }
-            else if ( value == "G" ) { return StepEnum::g; }
-            return StepEnum::a;
-        }
-
-
-        std::string toString( const StepEnum value )
-        {
-            switch ( value ) 
-            {
-                case StepEnum::a: return "A";
-                case StepEnum::b: return "B";
-                case StepEnum::c: return "C";
-                case StepEnum::d: return "D";
-                case StepEnum::e: return "E";
-                case StepEnum::f: return "F";
-                case StepEnum::g: return "G";
-                default: break;
-            }
-            return "A";
-        }
-
-
-        std::ostream& toStream( std::ostream& os, const StepEnum value )
-        {
-            return os << toString( value );
-        }
-
-
-        std::ostream& operator<<( std::ostream& os, const StepEnum value )
-        {
-            return toStream( os, value );
-        }
-
-        SyllabicEnum parseSyllabicEnum( const std::string& value )
-        {
-            if ( value == "single" ) { return SyllabicEnum::single; }
-            else if ( value == "begin" ) { return SyllabicEnum::begin; }
-            else if ( value == "end" ) { return SyllabicEnum::end; }
-            else if ( value == "middle" ) { return SyllabicEnum::middle; }
-            return SyllabicEnum::single;
-        }
-
-
-        std::string toString( const SyllabicEnum value )
-        {
-            switch ( value ) 
-            {
-                case SyllabicEnum::single: return "single";
-                case SyllabicEnum::begin: return "begin";
-                case SyllabicEnum::end: return "end";
-                case SyllabicEnum::middle: return "middle";
-                default: break;
-            }
-            return "single";
-        }
-
-
-        std::ostream& toStream( std::ostream& os, const SyllabicEnum value )
-        {
-            return os << toString( value );
-        }
-
-
-        std::ostream& operator<<( std::ostream& os, const SyllabicEnum value )
-        {
-            return toStream( os, value );
-        }
-
-        GroupBarlineValue parseGroupBarlineValue( const std::string& value )
-        {
-            if ( value == "yes" ) { return GroupBarlineValue::yes; }
-            else if ( value == "no" ) { return GroupBarlineValue::no; }
-            else if ( value == "Mensurstrich" ) { return GroupBarlineValue::mensurstrich; }
-            return GroupBarlineValue::yes;
-        }
-
-
-        std::string toString( const GroupBarlineValue value )
-        {
-            switch ( value ) 
-            {
-                case GroupBarlineValue::yes: return "yes";
-                case GroupBarlineValue::no: return "no";
-                case GroupBarlineValue::mensurstrich: return "Mensurstrich";
-                default: break;
-            }
-            return "yes";
-        }
-
-
-        std::ostream& toStream( std::ostream& os, const GroupBarlineValue value )
-        {
-            return os << toString( value );
-        }
-
-
-        std::ostream& operator<<( std::ostream& os, const GroupBarlineValue value )
-        {
-            return toStream( os, value );
-        }
-
-        GroupSymbolValue parseGroupSymbolValue( const std::string& value )
-        {
-            if ( value == "none" ) { return GroupSymbolValue::none; }
-            else if ( value == "brace" ) { return GroupSymbolValue::brace; }
-            else if ( value == "line" ) { return GroupSymbolValue::line; }
-            else if ( value == "bracket" ) { return GroupSymbolValue::bracket; }
-            else if ( value == "square" ) { return GroupSymbolValue::square; }
-            return GroupSymbolValue::none;
-        }
-
-
-        std::string toString( const GroupSymbolValue value )
-        {
-            switch ( value ) 
-            {
-                case GroupSymbolValue::none: return "none";
-                case GroupSymbolValue::brace: return "brace";
-                case GroupSymbolValue::line: return "line";
-                case GroupSymbolValue::bracket: return "bracket";
-                case GroupSymbolValue::square: return "square";
-                default: break;
-            }
-            return "none";
-        }
-
-
-        std::ostream& toStream( std::ostream& os, const GroupSymbolValue value )
-        {
-            return os << toString( value );
-        }
-
-
-        std::ostream& operator<<( std::ostream& os, const GroupSymbolValue value )
-        {
-            return toStream( os, value );
-        }
-        
-        ModeEnum parseModeEnum( const std::string& value, bool& success  )
-        {
-            success = true;
-            if ( value == "major" ) { return ModeEnum::major; }
-            else if ( value == "minor" ) { return ModeEnum::minor; }
-            else if ( value == "dorian" ) { return ModeEnum::dorian; }
-            else if ( value == "phrygian" ) { return ModeEnum::phrygian; }
-            else if ( value == "lydian" ) { return ModeEnum::lydian; }
-            else if ( value == "mixolydian" ) { return ModeEnum::mixolydian; }
-            else if ( value == "aeolian" ) { return ModeEnum::aeolian; }
-            else if ( value == "ionian" ) { return ModeEnum::ionian; }
-            else if ( value == "locrian" ) { return ModeEnum::locrian; }
-            else if ( value == "none" ) { return ModeEnum::none; }
-            else if ( value == "other" ) { success = false; return ModeEnum::other; }
-            success = false;
-            return ModeEnum::other;
-        }
-        ModeEnum parseModeEnum( const std::string& value )
-        {
-            bool temp;
-            return parseModeEnum( value, temp );
-        }
-
-
-        std::string toString( const ModeEnum value )
+        std::string toString( const ClefSign value )
         {
             switch ( value )
             {
-                case ModeEnum::major: return "major";
-                case ModeEnum::minor: return "minor";
-                case ModeEnum::dorian: return "dorian";
-                case ModeEnum::phrygian: return "phrygian";
-                case ModeEnum::lydian: return "lydian";
-                case ModeEnum::mixolydian: return "mixolydian";
-                case ModeEnum::aeolian: return "aeolian";
-                case ModeEnum::ionian: return "ionian";
-                case ModeEnum::locrian: return "locrian";
-                case ModeEnum::none: return "none";
-                case ModeEnum::other: return "other";
+                case ClefSign::g: { return "G"; }
+                case ClefSign::f: { return "F"; }
+                case ClefSign::c: { return "C"; }
+                case ClefSign::percussion: { return "percussion"; }
+                case ClefSign::tab: { return "TAB"; }
+                case ClefSign::jianpu: { return "jianpu"; }
+                case ClefSign::none: { return "none"; }
                 default: break;
             }
-            return "other";
+            return "G";
         }
 
-
-        std::ostream& toStream( std::ostream& os, const ModeEnum value )
+        std::ostream& toStream( std::ostream& os, const ClefSign value )
         {
             return os << toString( value );
         }
 
-
-        std::ostream& operator<<( std::ostream& os, const ModeEnum value )
+        std::ostream& operator<<( std::ostream& os, const ClefSign value )
         {
             return toStream( os, value );
         }
 
-        ModeValue::ModeValue( const ModeEnum value )
-        :myEnum( value )
-        ,myCustomValue( "" )
+        /// CssFontSize ////////////////////////////////////////////////////////////////////////////
+
+        CssFontSize parseCssFontSize( const std::string& value )
         {
-            setValue( value );
-        }
-        ModeValue::ModeValue( const std::string& value )
-        :myEnum( ModeEnum::other )
-        ,myCustomValue( value )
-        {
-            setValue( value );
-        }
-        ModeValue::ModeValue()
-        :myEnum( ModeEnum::major )
-        ,myCustomValue( "" )
-        {
-            setValue( ModeEnum::major );
-        }
-        ModeEnum ModeValue::getValue() const
-        {
-            return myEnum;
+            if ( value == "xx-small" ) { return CssFontSize::xxSmall; }
+            else if ( value == "x-small" ) { return CssFontSize::xSmall; }
+            else if ( value == "small" ) { return CssFontSize::small; }
+            else if ( value == "medium" ) { return CssFontSize::medium; }
+            else if ( value == "large" ) { return CssFontSize::large; }
+            else if ( value == "x-large" ) { return CssFontSize::xLarge; }
+            else if ( value == "xx-large" ) { return CssFontSize::xxLarge; }
+            return CssFontSize::xxSmall;
         }
 
-
-        std::string ModeValue::getValueString() const
+        std::string toString( const CssFontSize value )
         {
-            if ( myEnum != ModeEnum::other )
+            switch ( value )
             {
-                return toString( myEnum );
+                case CssFontSize::xxSmall: { return "xx-small"; }
+                case CssFontSize::xSmall: { return "x-small"; }
+                case CssFontSize::small: { return "small"; }
+                case CssFontSize::medium: { return "medium"; }
+                case CssFontSize::large: { return "large"; }
+                case CssFontSize::xLarge: { return "x-large"; }
+                case CssFontSize::xxLarge: { return "xx-large"; }
+                default: break;
             }
-            else
-            {
-                return myCustomValue;
-            }
-        }
-        void ModeValue::setValue( const ModeEnum value )
-        {
-            myEnum = value;
-        }
-        void ModeValue::setValue( const std::string& value )
-        {
-            bool found = false;
-            ModeEnum temp = parseModeEnum( value, found );
-            if ( found )
-            {
-                myEnum = temp;
-            }
-            else
-            {
-                setValue( ModeEnum::other );
-                myCustomValue = value;
-            }
-        }
-        ModeValue parseModeValue( const std::string& value )
-        {
-            return ModeValue( value );
+            return "xx-small";
         }
 
-
-        std::string toString( const ModeValue& value )
-        {
-            return value.getValueString();
-        }
-
-
-        std::ostream& toStream( std::ostream& os, const ModeValue& value )
+        std::ostream& toStream( std::ostream& os, const CssFontSize value )
         {
             return os << toString( value );
         }
 
-
-        std::ostream& operator<<( std::ostream& os, const ModeValue& value )
+        std::ostream& operator<<( std::ostream& os, const CssFontSize value )
         {
             return toStream( os, value );
         }
-        
-        DistanceTypeEnum parseDistanceTypeEnum( const std::string& value, bool& success  )
+
+        /// DegreeSymbolValue //////////////////////////////////////////////////////////////////////
+
+        DegreeSymbolValue parseDegreeSymbolValue( const std::string& value )
+        {
+            if ( value == "major" ) { return DegreeSymbolValue::major; }
+            else if ( value == "minor" ) { return DegreeSymbolValue::minor; }
+            else if ( value == "augmented" ) { return DegreeSymbolValue::augmented; }
+            else if ( value == "diminished" ) { return DegreeSymbolValue::diminished; }
+            else if ( value == "half-diminished" ) { return DegreeSymbolValue::halfDiminished; }
+            return DegreeSymbolValue::major;
+        }
+
+        std::string toString( const DegreeSymbolValue value )
+        {
+            switch ( value )
+            {
+                case DegreeSymbolValue::major: { return "major"; }
+                case DegreeSymbolValue::minor: { return "minor"; }
+                case DegreeSymbolValue::augmented: { return "augmented"; }
+                case DegreeSymbolValue::diminished: { return "diminished"; }
+                case DegreeSymbolValue::halfDiminished: { return "half-diminished"; }
+                default: break;
+            }
+            return "major";
+        }
+
+        std::ostream& toStream( std::ostream& os, const DegreeSymbolValue value )
+        {
+            return os << toString( value );
+        }
+
+        std::ostream& operator<<( std::ostream& os, const DegreeSymbolValue value )
+        {
+            return toStream( os, value );
+        }
+
+        /// DegreeTypeValue ////////////////////////////////////////////////////////////////////////
+
+        DegreeTypeValue parseDegreeTypeValue( const std::string& value )
+        {
+            if ( value == "add" ) { return DegreeTypeValue::add; }
+            else if ( value == "alter" ) { return DegreeTypeValue::alter; }
+            else if ( value == "subtract" ) { return DegreeTypeValue::subtract; }
+            return DegreeTypeValue::add;
+        }
+
+        std::string toString( const DegreeTypeValue value )
+        {
+            switch ( value )
+            {
+                case DegreeTypeValue::add: { return "add"; }
+                case DegreeTypeValue::alter: { return "alter"; }
+                case DegreeTypeValue::subtract: { return "subtract"; }
+                default: break;
+            }
+            return "add";
+        }
+
+        std::ostream& toStream( std::ostream& os, const DegreeTypeValue value )
+        {
+            return os << toString( value );
+        }
+
+        std::ostream& operator<<( std::ostream& os, const DegreeTypeValue value )
+        {
+            return toStream( os, value );
+        }
+
+        /// DistanceTypeEnum ///////////////////////////////////////////////////////////////////////
+
+        DistanceTypeEnum parseDistanceTypeEnum( const std::string& value, bool& success )
         {
             success = true;
             if ( value == "beam" ) { return DistanceTypeEnum::beam; }
             else if ( value == "hyphen" ) { return DistanceTypeEnum::hyphen; }
-            else if ( value == "other" ) { success = false; return DistanceTypeEnum::other; }
+            else if ( value == "other" ) { return DistanceTypeEnum::other; }
             success = false;
             return DistanceTypeEnum::other;
         }
+
         DistanceTypeEnum parseDistanceTypeEnum( const std::string& value )
         {
-            bool temp;
-            return parseDistanceTypeEnum( value, temp );
+            bool success = true;
+            return parseDistanceTypeEnum( value, success );
         }
-
 
         std::string toString( const DistanceTypeEnum value )
         {
             switch ( value )
             {
-                case DistanceTypeEnum::beam: return "beam";
-                case DistanceTypeEnum::hyphen: return "hyphen";
-                case DistanceTypeEnum::other: return "other";
+                case DistanceTypeEnum::beam: { return "beam"; }
+                case DistanceTypeEnum::hyphen: { return "hyphen"; }
+                case DistanceTypeEnum::other: { return "other"; }
                 default: break;
             }
-            return "other";
+            return "default";
         }
-
 
         std::ostream& toStream( std::ostream& os, const DistanceTypeEnum value )
         {
             return os << toString( value );
         }
 
-
         std::ostream& operator<<( std::ostream& os, const DistanceTypeEnum value )
         {
             return toStream( os, value );
         }
-        
+
         DistanceType::DistanceType( const DistanceTypeEnum value )
         :myEnum( value )
         ,myCustomValue( "" )
         {
             setValue( value );
         }
+
         DistanceType::DistanceType( const std::string& value )
         :myEnum( DistanceTypeEnum::other )
         ,myCustomValue( value )
         {
             setValue( value );
         }
+
         DistanceType::DistanceType()
         :myEnum( DistanceTypeEnum::beam )
         ,myCustomValue( "" )
         {
             setValue( DistanceTypeEnum::beam );
         }
+
         DistanceTypeEnum DistanceType::getValue() const
         {
             return myEnum;
         }
-
 
         std::string DistanceType::getValueString() const
         {
@@ -3394,15 +715,18 @@ namespace mx
             {
                 return toString( myEnum );
             }
+
             else
             {
                 return myCustomValue;
             }
         }
+
         void DistanceType::setValue( const DistanceTypeEnum value )
         {
             myEnum = value;
         }
+
         void DistanceType::setValue( const std::string& value )
         {
             bool found = false;
@@ -3417,321 +741,29 @@ namespace mx
                 myCustomValue = value;
             }
         }
+
         DistanceType parseDistanceType( const std::string& value )
         {
             return DistanceType( value );
         }
-
-
+        
         std::string toString( const DistanceType& value )
         {
             return value.getValueString();
         }
-
-
+        
         std::ostream& toStream( std::ostream& os, const DistanceType& value )
         {
             return os << toString( value );
         }
-
-
+        
         std::ostream& operator<<( std::ostream& os, const DistanceType& value )
         {
             return toStream( os, value );
         }
 
-        LineWidthTypeEnum parseLineWidthTypeEnum( const std::string& value, bool& success  )
-        {
-            success = true;
-            if ( value == "beam" ) { return LineWidthTypeEnum::beam; }
-            else if ( value == "bracket" ) { return LineWidthTypeEnum::bracket; }
-            else if ( value == "dashes" ) { return LineWidthTypeEnum::dashes; }
-            else if ( value == "enclosure" ) { return LineWidthTypeEnum::enclosure; }
-            else if ( value == "ending" ) { return LineWidthTypeEnum::ending; }
-            else if ( value == "extend" ) { return LineWidthTypeEnum::extend; }
-            else if ( value == "heavy barline" ) { return LineWidthTypeEnum::heavyBarline; }
-            else if ( value == "leger" ) { return LineWidthTypeEnum::leger; }
-            else if ( value == "light barline" ) { return LineWidthTypeEnum::lightBarline; }
-            else if ( value == "octave shift" ) { return LineWidthTypeEnum::octaveShift; }
-            else if ( value == "pedal" ) { return LineWidthTypeEnum::pedal; }
-            else if ( value == "slur middle" ) { return LineWidthTypeEnum::slurMiddle; }
-            else if ( value == "slur tip" ) { return LineWidthTypeEnum::slurTip; }
-            else if ( value == "staff" ) { return LineWidthTypeEnum::staff; }
-            else if ( value == "stem" ) { return LineWidthTypeEnum::stem; }
-            else if ( value == "tie middle" ) { return LineWidthTypeEnum::tieMiddle; }
-            else if ( value == "tie tip" ) { return LineWidthTypeEnum::tieTip; }
-            else if ( value == "tuplet bracket" ) { return LineWidthTypeEnum::tupletBracket; }
-            else if ( value == "wedge" ) { return LineWidthTypeEnum::wedge; }
-            else if ( value == "other" ) { success = false; return LineWidthTypeEnum::other; }
-            success = false;
-            return LineWidthTypeEnum::other;
-        }
-        LineWidthTypeEnum parseLineWidthTypeEnum( const std::string& value )
-        {
-            bool temp;
-            return parseLineWidthTypeEnum( value, temp );
-        }
+        /// DynamicsEnum ///////////////////////////////////////////////////////////////////////////
 
-
-        std::string toString( const LineWidthTypeEnum value )
-        {
-            switch ( value )
-            {
-                case LineWidthTypeEnum::beam: return "beam";
-                case LineWidthTypeEnum::bracket: return "bracket";
-                case LineWidthTypeEnum::dashes: return "dashes";
-                case LineWidthTypeEnum::enclosure: return "enclosure";
-                case LineWidthTypeEnum::ending: return "ending";
-                case LineWidthTypeEnum::extend: return "extend";
-                case LineWidthTypeEnum::heavyBarline: return "heavy barline";
-                case LineWidthTypeEnum::leger: return "leger";
-                case LineWidthTypeEnum::lightBarline: return "light barline";
-                case LineWidthTypeEnum::octaveShift: return "octave shift";
-                case LineWidthTypeEnum::pedal: return "pedal";
-                case LineWidthTypeEnum::slurMiddle: return "slur middle";
-                case LineWidthTypeEnum::slurTip: return "slur tip";
-                case LineWidthTypeEnum::staff: return "staff";
-                case LineWidthTypeEnum::stem: return "stem";
-                case LineWidthTypeEnum::tieMiddle: return "tie middle";
-                case LineWidthTypeEnum::tieTip: return "tie tip";
-                case LineWidthTypeEnum::tupletBracket: return "tuplet bracket";
-                case LineWidthTypeEnum::wedge: return "wedge";
-                case LineWidthTypeEnum::other: return "other";
-                default: break;
-            }
-            return "other";
-        }
-
-
-        std::ostream& toStream( std::ostream& os, const LineWidthTypeEnum value )
-        {
-            return os << toString( value );
-        }
-
-
-        std::ostream& operator<<( std::ostream& os, const LineWidthTypeEnum value )
-        {
-            return toStream( os, value );
-        }
-        
-        LineWidthType::LineWidthType( const LineWidthTypeEnum value )
-        :myEnum( value )
-        ,myCustomValue( "" )
-        {
-            setValue( value );
-        }
-        LineWidthType::LineWidthType( const std::string& value )
-        :myEnum( LineWidthTypeEnum::other )
-        ,myCustomValue( value )
-        {
-            setValue( value );
-        }
-        LineWidthType::LineWidthType()
-        :myEnum( LineWidthTypeEnum::beam )
-        ,myCustomValue( "" )
-        {
-            setValue( LineWidthTypeEnum::beam );
-        }
-        LineWidthTypeEnum LineWidthType::getValue() const
-        {
-            return myEnum;
-        }
-
-
-        std::string LineWidthType::getValueString() const
-        {
-            if ( myEnum != LineWidthTypeEnum::other )
-            {
-                return toString( myEnum );
-            }
-            else
-            {
-                return myCustomValue;
-            }
-        }
-        void LineWidthType::setValue( const LineWidthTypeEnum value )
-        {
-            myEnum = value;
-        }
-        void LineWidthType::setValue( const std::string& value )
-        {
-            bool found = false;
-            LineWidthTypeEnum temp = parseLineWidthTypeEnum( value, found );
-            if ( found )
-            {
-                myEnum = temp;
-            }
-            else
-            {
-                setValue( LineWidthTypeEnum::other );
-                myCustomValue = value;
-            }
-        }
-        LineWidthType parseLineWidthType( const std::string& value )
-        {
-            return LineWidthType( value );
-        }
-
-
-        std::string toString( const LineWidthType& value )
-        {
-            return value.getValueString();
-        }
-
-
-        std::ostream& toStream( std::ostream& os, const LineWidthType& value )
-        {
-            return os << toString( value );
-        }
-
-
-        std::ostream& operator<<( std::ostream& os, const LineWidthType& value )
-        {
-            return toStream( os, value );
-        }
-
-        XlinkActuate parseXlinkActuate( const std::string& value )
-        {
-            if ( value == "onLoad" ) { return XlinkActuate::onLoad; }
-            else if ( value == "onRequest" ) { return XlinkActuate::onRequest; }
-            else if ( value == "other" ) { return XlinkActuate::other; }
-            else if ( value == "none" ) { return XlinkActuate::none; }
-            return XlinkActuate::onLoad;
-        }
-
-
-        std::string toString( const XlinkActuate value )
-        {
-            switch ( value )
-            {
-                case XlinkActuate::onLoad: return "onLoad";
-                case XlinkActuate::onRequest: return "onRequest";
-                case XlinkActuate::other: return "other";
-                case XlinkActuate::none: return "none";
-                default: break;
-            }
-            return "none";
-        }
-
-
-        std::ostream& toStream( std::ostream& os, const XlinkActuate value )
-        {
-            return os << toString( value );
-        }
-
-
-        std::ostream& operator<<( std::ostream& os, const XlinkActuate value )
-        {
-            return toStream( os, value );
-        }
-        
-        XlinkShow parseXlinkShow( const std::string& value )
-        {
-            if ( value == "new" ) { return XlinkShow::new_; }
-            else if ( value == "replace" ) { return XlinkShow::replace; }
-            else if ( value == "embed" ) { return XlinkShow::embed; }
-            else if ( value == "other" ) { return XlinkShow::other; }
-            else if ( value == "none" ) { return XlinkShow::none; }
-            return XlinkShow::new_;
-        }
-
-
-        std::string toString( const XlinkShow value )
-        {
-            switch ( value )
-            {
-                case XlinkShow::new_: return "new";
-                case XlinkShow::replace: return "replace";
-                case XlinkShow::embed: return "embed";
-                case XlinkShow::other: return "other";
-                case XlinkShow::none: return "none";
-                default: break;
-            }
-            return "none";
-        }
-
-
-        std::ostream& toStream( std::ostream& os, const XlinkShow value )
-        {
-            return os << toString( value );
-        }
-
-
-        std::ostream& operator<<( std::ostream& os, const XlinkShow value )
-        {
-            return toStream( os, value );
-        }
-        
-        XlinkType parseXlinkType( const std::string& value )
-        {
-            if ( value == "simple" ) { return XlinkType::simple; }
-            else if ( value == "extended" ) { return XlinkType::extended; }
-            else if ( value == "title" ) { return XlinkType::title; }
-            else if ( value == "resource" ) { return XlinkType::resource; }
-            else if ( value == "locator" ) { return XlinkType::locator; }
-            else if ( value == "arc" ) { return XlinkType::arc; }
-            return XlinkType::simple;
-        }
-
-
-        std::string toString( const XlinkType value )
-        {
-            switch ( value )
-            {
-                case XlinkType::simple: return "simple";
-                case XlinkType::extended: return "extended";
-                case XlinkType::title: return "title";
-                case XlinkType::resource: return "resource";
-                case XlinkType::locator: return "locator";
-                case XlinkType::arc: return "arc";
-                default: break;
-            }
-            return "simple";
-        }
-
-
-        std::ostream& toStream( std::ostream& os, const XlinkType value )
-        {
-            return os << toString( value );
-        }
-
-
-        std::ostream& operator<<( std::ostream& os, const XlinkType value )
-        {
-            return toStream( os, value );
-        }
-        
-        XmlSpace parseXmlSpace( const std::string& value )
-        {
-            if ( value == "default" ) { return XmlSpace::default_; }
-            else if ( value == "preserve" ) { return XmlSpace::preserve; }
-            return XmlSpace::default_;
-        }
-
-
-        std::string toString( const XmlSpace value )
-        {
-            switch ( value )
-            {
-                case XmlSpace::default_: return "default";
-                case XmlSpace::preserve: return "preserve";
-                default: break;
-            }
-            return "default";
-        }
-
-
-        std::ostream& toStream( std::ostream& os, const XmlSpace value )
-        {
-            return os << toString( value );
-        }
-
-
-        std::ostream& operator<<( std::ostream& os, const XmlSpace value )
-        {
-            return toStream( os, value );
-        }
-        
         DynamicsEnum parseDynamicsEnum( const std::string& value, bool& success )
         {
             success = true;
@@ -3762,12 +794,12 @@ namespace mx
             success = false;
             return DynamicsEnum::otherDynamics;
         }
+
         DynamicsEnum parseDynamicsEnum( const std::string& value )
         {
             bool success = true;
             return parseDynamicsEnum( value, success );
         }
-
 
         std::string toString( const DynamicsEnum value )
         {
@@ -3802,41 +834,41 @@ namespace mx
             return "default";
         }
 
-
         std::ostream& toStream( std::ostream& os, const DynamicsEnum value )
         {
             return os << toString( value );
         }
 
-
         std::ostream& operator<<( std::ostream& os, const DynamicsEnum value )
         {
             return toStream( os, value );
         }
-        
+
         DynamicsValue::DynamicsValue( const DynamicsEnum value )
         :myEnum( value )
         ,myCustomValue( "" )
         {
             setValue( value );
         }
+
         DynamicsValue::DynamicsValue( const std::string& value )
         :myEnum( DynamicsEnum::otherDynamics )
         ,myCustomValue( value )
         {
             setValue( value );
         }
+
         DynamicsValue::DynamicsValue()
-        :myEnum( DynamicsEnum::mf )
+        :myEnum( DynamicsEnum::otherDynamics )
         ,myCustomValue( "" )
         {
-            setValue( DynamicsEnum::mf );
+            setValue( DynamicsEnum::otherDynamics );
         }
+
         DynamicsEnum DynamicsValue::getValue() const
         {
             return myEnum;
         }
-
 
         std::string DynamicsValue::getValueString() const
         {
@@ -3844,15 +876,18 @@ namespace mx
             {
                 return toString( myEnum );
             }
+
             else
             {
                 return myCustomValue;
             }
         }
+
         void DynamicsValue::setValue( const DynamicsEnum value )
         {
             myEnum = value;
         }
+
         void DynamicsValue::setValue( const std::string& value )
         {
             bool found = false;
@@ -3867,29 +902,2773 @@ namespace mx
                 myCustomValue = value;
             }
         }
+
         DynamicsValue parseDynamicsValue( const std::string& value )
         {
             return DynamicsValue( value );
         }
-
-
+        
         std::string toString( const DynamicsValue& value )
         {
             return value.getValueString();
         }
-
-
+        
         std::ostream& toStream( std::ostream& os, const DynamicsValue& value )
         {
             return os << toString( value );
         }
-
-
+        
         std::ostream& operator<<( std::ostream& os, const DynamicsValue& value )
         {
             return toStream( os, value );
         }
 
-    } // namespace core
+        /// EffectEnum /////////////////////////////////////////////////////////////////////////////
 
-} // namespace mx
+        EffectEnum parseEffectEnum( const std::string& value )
+        {
+            if ( value == "anvil" ) { return EffectEnum::anvil; }
+            else if ( value == "auto horn" ) { return EffectEnum::autoHorn; }
+            else if ( value == "bird whistle" ) { return EffectEnum::birdWhistle; }
+            else if ( value == "cannon" ) { return EffectEnum::cannon; }
+            else if ( value == "duck call" ) { return EffectEnum::duckCall; }
+            else if ( value == "gun shot" ) { return EffectEnum::gunShot; }
+            else if ( value == "klaxon horn" ) { return EffectEnum::klaxonHorn; }
+            else if ( value == "lions roar" ) { return EffectEnum::lionsRoar; }
+            else if ( value == "police whistle" ) { return EffectEnum::policeWhistle; }
+            else if ( value == "siren" ) { return EffectEnum::siren; }
+            else if ( value == "slide whistle" ) { return EffectEnum::slideWhistle; }
+            else if ( value == "thunder sheet" ) { return EffectEnum::thunderSheet; }
+            else if ( value == "wind machine" ) { return EffectEnum::windMachine; }
+            else if ( value == "wind whistle" ) { return EffectEnum::windWhistle; }
+            return EffectEnum::anvil;
+        }
+
+        std::string toString( const EffectEnum value )
+        {
+            switch ( value )
+            {
+                case EffectEnum::anvil: { return "anvil"; }
+                case EffectEnum::autoHorn: { return "auto horn"; }
+                case EffectEnum::birdWhistle: { return "bird whistle"; }
+                case EffectEnum::cannon: { return "cannon"; }
+                case EffectEnum::duckCall: { return "duck call"; }
+                case EffectEnum::gunShot: { return "gun shot"; }
+                case EffectEnum::klaxonHorn: { return "klaxon horn"; }
+                case EffectEnum::lionsRoar: { return "lions roar"; }
+                case EffectEnum::policeWhistle: { return "police whistle"; }
+                case EffectEnum::siren: { return "siren"; }
+                case EffectEnum::slideWhistle: { return "slide whistle"; }
+                case EffectEnum::thunderSheet: { return "thunder sheet"; }
+                case EffectEnum::windMachine: { return "wind machine"; }
+                case EffectEnum::windWhistle: { return "wind whistle"; }
+                default: break;
+            }
+            return "anvil";
+        }
+
+        std::ostream& toStream( std::ostream& os, const EffectEnum value )
+        {
+            return os << toString( value );
+        }
+
+        std::ostream& operator<<( std::ostream& os, const EffectEnum value )
+        {
+            return toStream( os, value );
+        }
+
+        /// EnclosureShape /////////////////////////////////////////////////////////////////////////
+
+        EnclosureShape parseEnclosureShape( const std::string& value )
+        {
+            if ( value == "rectangle" ) { return EnclosureShape::rectangle; }
+            else if ( value == "square" ) { return EnclosureShape::square; }
+            else if ( value == "oval" ) { return EnclosureShape::oval; }
+            else if ( value == "circle" ) { return EnclosureShape::circle; }
+            else if ( value == "bracket" ) { return EnclosureShape::bracket; }
+            else if ( value == "triangle" ) { return EnclosureShape::triangle; }
+            else if ( value == "diamond" ) { return EnclosureShape::diamond; }
+            else if ( value == "none" ) { return EnclosureShape::none; }
+            return EnclosureShape::rectangle;
+        }
+
+        std::string toString( const EnclosureShape value )
+        {
+            switch ( value )
+            {
+                case EnclosureShape::rectangle: { return "rectangle"; }
+                case EnclosureShape::square: { return "square"; }
+                case EnclosureShape::oval: { return "oval"; }
+                case EnclosureShape::circle: { return "circle"; }
+                case EnclosureShape::bracket: { return "bracket"; }
+                case EnclosureShape::triangle: { return "triangle"; }
+                case EnclosureShape::diamond: { return "diamond"; }
+                case EnclosureShape::none: { return "none"; }
+                default: break;
+            }
+            return "rectangle";
+        }
+
+        std::ostream& toStream( std::ostream& os, const EnclosureShape value )
+        {
+            return os << toString( value );
+        }
+
+        std::ostream& operator<<( std::ostream& os, const EnclosureShape value )
+        {
+            return toStream( os, value );
+        }
+
+        /// Fan ////////////////////////////////////////////////////////////////////////////////////
+
+        Fan parseFan( const std::string& value )
+        {
+            if ( value == "accel" ) { return Fan::accel; }
+            else if ( value == "rit" ) { return Fan::rit; }
+            else if ( value == "none" ) { return Fan::none; }
+            return Fan::accel;
+        }
+
+        std::string toString( const Fan value )
+        {
+            switch ( value )
+            {
+                case Fan::accel: { return "accel"; }
+                case Fan::rit: { return "rit"; }
+                case Fan::none: { return "none"; }
+                default: break;
+            }
+            return "accel";
+        }
+
+        std::ostream& toStream( std::ostream& os, const Fan value )
+        {
+            return os << toString( value );
+        }
+
+        std::ostream& operator<<( std::ostream& os, const Fan value )
+        {
+            return toStream( os, value );
+        }
+
+        /// FermataShape ///////////////////////////////////////////////////////////////////////////
+
+        FermataShape parseFermataShape( const std::string& value )
+        {
+            if ( value == "normal" ) { return FermataShape::normal; }
+            else if ( value == "angled" ) { return FermataShape::angled; }
+            else if ( value == "square" ) { return FermataShape::square; }
+            else if ( value == "" ) { return FermataShape::emptystring; }
+            return FermataShape::normal;
+        }
+
+        std::string toString( const FermataShape value )
+        {
+            switch ( value )
+            {
+                case FermataShape::normal: { return "normal"; }
+                case FermataShape::angled: { return "angled"; }
+                case FermataShape::square: { return "square"; }
+                case FermataShape::emptystring: { return ""; }
+                default: break;
+            }
+            return "normal";
+        }
+
+        std::ostream& toStream( std::ostream& os, const FermataShape value )
+        {
+            return os << toString( value );
+        }
+
+        std::ostream& operator<<( std::ostream& os, const FermataShape value )
+        {
+            return toStream( os, value );
+        }
+
+        /// FontStyle //////////////////////////////////////////////////////////////////////////////
+
+        FontStyle parseFontStyle( const std::string& value )
+        {
+            if ( value == "normal" ) { return FontStyle::normal; }
+            else if ( value == "italic" ) { return FontStyle::italic; }
+            return FontStyle::normal;
+        }
+
+        std::string toString( const FontStyle value )
+        {
+            switch ( value )
+            {
+                case FontStyle::normal: { return "normal"; }
+                case FontStyle::italic: { return "italic"; }
+                default: break;
+            }
+            return "normal";
+        }
+
+        std::ostream& toStream( std::ostream& os, const FontStyle value )
+        {
+            return os << toString( value );
+        }
+
+        std::ostream& operator<<( std::ostream& os, const FontStyle value )
+        {
+            return toStream( os, value );
+        }
+
+        /// FontWeight /////////////////////////////////////////////////////////////////////////////
+
+        FontWeight parseFontWeight( const std::string& value )
+        {
+            if ( value == "normal" ) { return FontWeight::normal; }
+            else if ( value == "bold" ) { return FontWeight::bold; }
+            return FontWeight::normal;
+        }
+
+        std::string toString( const FontWeight value )
+        {
+            switch ( value )
+            {
+                case FontWeight::normal: { return "normal"; }
+                case FontWeight::bold: { return "bold"; }
+                default: break;
+            }
+            return "normal";
+        }
+
+        std::ostream& toStream( std::ostream& os, const FontWeight value )
+        {
+            return os << toString( value );
+        }
+
+        std::ostream& operator<<( std::ostream& os, const FontWeight value )
+        {
+            return toStream( os, value );
+        }
+
+        /// GlassEnum //////////////////////////////////////////////////////////////////////////////
+
+        GlassEnum parseGlassEnum( const std::string& value )
+        {
+            if ( value == "wind chimes" ) { return GlassEnum::windChimes; }
+            return GlassEnum::windChimes;
+        }
+
+        std::string toString( const GlassEnum value )
+        {
+            switch ( value )
+            {
+                case GlassEnum::windChimes: { return "wind chimes"; }
+                default: break;
+            }
+            return "wind chimes";
+        }
+
+        std::ostream& toStream( std::ostream& os, const GlassEnum value )
+        {
+            return os << toString( value );
+        }
+
+        std::ostream& operator<<( std::ostream& os, const GlassEnum value )
+        {
+            return toStream( os, value );
+        }
+
+        /// GroupBarlineValue //////////////////////////////////////////////////////////////////////
+
+        GroupBarlineValue parseGroupBarlineValue( const std::string& value )
+        {
+            if ( value == "yes" ) { return GroupBarlineValue::yes; }
+            else if ( value == "no" ) { return GroupBarlineValue::no; }
+            else if ( value == "Mensurstrich" ) { return GroupBarlineValue::mensurstrich; }
+            return GroupBarlineValue::yes;
+        }
+
+        std::string toString( const GroupBarlineValue value )
+        {
+            switch ( value )
+            {
+                case GroupBarlineValue::yes: { return "yes"; }
+                case GroupBarlineValue::no: { return "no"; }
+                case GroupBarlineValue::mensurstrich: { return "Mensurstrich"; }
+                default: break;
+            }
+            return "yes";
+        }
+
+        std::ostream& toStream( std::ostream& os, const GroupBarlineValue value )
+        {
+            return os << toString( value );
+        }
+
+        std::ostream& operator<<( std::ostream& os, const GroupBarlineValue value )
+        {
+            return toStream( os, value );
+        }
+
+        /// GroupSymbolValue ///////////////////////////////////////////////////////////////////////
+
+        GroupSymbolValue parseGroupSymbolValue( const std::string& value )
+        {
+            if ( value == "none" ) { return GroupSymbolValue::none; }
+            else if ( value == "brace" ) { return GroupSymbolValue::brace; }
+            else if ( value == "line" ) { return GroupSymbolValue::line; }
+            else if ( value == "bracket" ) { return GroupSymbolValue::bracket; }
+            else if ( value == "square" ) { return GroupSymbolValue::square; }
+            return GroupSymbolValue::none;
+        }
+
+        std::string toString( const GroupSymbolValue value )
+        {
+            switch ( value )
+            {
+                case GroupSymbolValue::none: { return "none"; }
+                case GroupSymbolValue::brace: { return "brace"; }
+                case GroupSymbolValue::line: { return "line"; }
+                case GroupSymbolValue::bracket: { return "bracket"; }
+                case GroupSymbolValue::square: { return "square"; }
+                default: break;
+            }
+            return "none";
+        }
+
+        std::ostream& toStream( std::ostream& os, const GroupSymbolValue value )
+        {
+            return os << toString( value );
+        }
+
+        std::ostream& operator<<( std::ostream& os, const GroupSymbolValue value )
+        {
+            return toStream( os, value );
+        }
+
+        /// HandbellValue //////////////////////////////////////////////////////////////////////////
+
+        HandbellValue parseHandbellValue( const std::string& value )
+        {
+            if ( value == "damp" ) { return HandbellValue::damp; }
+            else if ( value == "echo" ) { return HandbellValue::echo; }
+            else if ( value == "gyro" ) { return HandbellValue::gyro; }
+            else if ( value == "hand martellato" ) { return HandbellValue::handMartellato; }
+            else if ( value == "mallet lift" ) { return HandbellValue::malletLift; }
+            else if ( value == "mallet table" ) { return HandbellValue::malletTable; }
+            else if ( value == "martellato" ) { return HandbellValue::martellato; }
+            else if ( value == "martellato lift" ) { return HandbellValue::martellatoLift; }
+            else if ( value == "muted martellato" ) { return HandbellValue::mutedMartellato; }
+            else if ( value == "pluck lift" ) { return HandbellValue::pluckLift; }
+            else if ( value == "swing" ) { return HandbellValue::swing; }
+            return HandbellValue::damp;
+        }
+
+        std::string toString( const HandbellValue value )
+        {
+            switch ( value )
+            {
+                case HandbellValue::damp: { return "damp"; }
+                case HandbellValue::echo: { return "echo"; }
+                case HandbellValue::gyro: { return "gyro"; }
+                case HandbellValue::handMartellato: { return "hand martellato"; }
+                case HandbellValue::malletLift: { return "mallet lift"; }
+                case HandbellValue::malletTable: { return "mallet table"; }
+                case HandbellValue::martellato: { return "martellato"; }
+                case HandbellValue::martellatoLift: { return "martellato lift"; }
+                case HandbellValue::mutedMartellato: { return "muted martellato"; }
+                case HandbellValue::pluckLift: { return "pluck lift"; }
+                case HandbellValue::swing: { return "swing"; }
+                default: break;
+            }
+            return "damp";
+        }
+
+        std::ostream& toStream( std::ostream& os, const HandbellValue value )
+        {
+            return os << toString( value );
+        }
+
+        std::ostream& operator<<( std::ostream& os, const HandbellValue value )
+        {
+            return toStream( os, value );
+        }
+
+        /// HarmonyType ////////////////////////////////////////////////////////////////////////////
+
+        HarmonyType parseHarmonyType( const std::string& value )
+        {
+            if ( value == "explicit" ) { return HarmonyType::explicit_; }
+            else if ( value == "implied" ) { return HarmonyType::implied; }
+            else if ( value == "alternate" ) { return HarmonyType::alternate; }
+            return HarmonyType::explicit_;
+        }
+
+        std::string toString( const HarmonyType value )
+        {
+            switch ( value )
+            {
+                case HarmonyType::explicit_: { return "explicit"; }
+                case HarmonyType::implied: { return "implied"; }
+                case HarmonyType::alternate: { return "alternate"; }
+                default: break;
+            }
+            return "explicit";
+        }
+
+        std::ostream& toStream( std::ostream& os, const HarmonyType value )
+        {
+            return os << toString( value );
+        }
+
+        std::ostream& operator<<( std::ostream& os, const HarmonyType value )
+        {
+            return toStream( os, value );
+        }
+
+        /// HoleClosedLocation /////////////////////////////////////////////////////////////////////
+
+        HoleClosedLocation parseHoleClosedLocation( const std::string& value )
+        {
+            if ( value == "right" ) { return HoleClosedLocation::right; }
+            else if ( value == "bottom" ) { return HoleClosedLocation::bottom; }
+            else if ( value == "left" ) { return HoleClosedLocation::left; }
+            else if ( value == "top" ) { return HoleClosedLocation::top; }
+            return HoleClosedLocation::right;
+        }
+
+        std::string toString( const HoleClosedLocation value )
+        {
+            switch ( value )
+            {
+                case HoleClosedLocation::right: { return "right"; }
+                case HoleClosedLocation::bottom: { return "bottom"; }
+                case HoleClosedLocation::left: { return "left"; }
+                case HoleClosedLocation::top: { return "top"; }
+                default: break;
+            }
+            return "right";
+        }
+
+        std::ostream& toStream( std::ostream& os, const HoleClosedLocation value )
+        {
+            return os << toString( value );
+        }
+
+        std::ostream& operator<<( std::ostream& os, const HoleClosedLocation value )
+        {
+            return toStream( os, value );
+        }
+
+        /// HoleClosedValue ////////////////////////////////////////////////////////////////////////
+
+        HoleClosedValue parseHoleClosedValue( const std::string& value )
+        {
+            if ( value == "yes" ) { return HoleClosedValue::yes; }
+            else if ( value == "no" ) { return HoleClosedValue::no; }
+            else if ( value == "half" ) { return HoleClosedValue::half; }
+            return HoleClosedValue::yes;
+        }
+
+        std::string toString( const HoleClosedValue value )
+        {
+            switch ( value )
+            {
+                case HoleClosedValue::yes: { return "yes"; }
+                case HoleClosedValue::no: { return "no"; }
+                case HoleClosedValue::half: { return "half"; }
+                default: break;
+            }
+            return "yes";
+        }
+
+        std::ostream& toStream( std::ostream& os, const HoleClosedValue value )
+        {
+            return os << toString( value );
+        }
+
+        std::ostream& operator<<( std::ostream& os, const HoleClosedValue value )
+        {
+            return toStream( os, value );
+        }
+
+        /// KindValue //////////////////////////////////////////////////////////////////////////////
+
+        KindValue parseKindValue( const std::string& value )
+        {
+            if ( value == "major" ) { return KindValue::major; }
+            else if ( value == "minor" ) { return KindValue::minor; }
+            else if ( value == "augmented" ) { return KindValue::augmented; }
+            else if ( value == "diminished" ) { return KindValue::diminished; }
+            else if ( value == "dominant" ) { return KindValue::dominant; }
+            else if ( value == "major-seventh" ) { return KindValue::majorSeventh; }
+            else if ( value == "minor-seventh" ) { return KindValue::minorSeventh; }
+            else if ( value == "diminished-seventh" ) { return KindValue::diminishedSeventh; }
+            else if ( value == "augmented-seventh" ) { return KindValue::augmentedSeventh; }
+            else if ( value == "half-diminished" ) { return KindValue::halfDiminished; }
+            else if ( value == "major-minor" ) { return KindValue::majorMinor; }
+            else if ( value == "major-sixth" ) { return KindValue::majorSixth; }
+            else if ( value == "minor-sixth" ) { return KindValue::minorSixth; }
+            else if ( value == "dominant-ninth" ) { return KindValue::dominantNinth; }
+            else if ( value == "major-ninth" ) { return KindValue::majorNinth; }
+            else if ( value == "minor-ninth" ) { return KindValue::minorNinth; }
+            else if ( value == "dominant-11th" ) { return KindValue::dominant11Th; }
+            else if ( value == "major-11th" ) { return KindValue::major11Th; }
+            else if ( value == "minor-11th" ) { return KindValue::minor11Th; }
+            else if ( value == "dominant-13th" ) { return KindValue::dominant13Th; }
+            else if ( value == "major-13th" ) { return KindValue::major13Th; }
+            else if ( value == "minor-13th" ) { return KindValue::minor13Th; }
+            else if ( value == "suspended-second" ) { return KindValue::suspendedSecond; }
+            else if ( value == "suspended-fourth" ) { return KindValue::suspendedFourth; }
+            else if ( value == "Neapolitan" ) { return KindValue::neapolitan; }
+            else if ( value == "Italian" ) { return KindValue::italian; }
+            else if ( value == "French" ) { return KindValue::french; }
+            else if ( value == "German" ) { return KindValue::german; }
+            else if ( value == "pedal" ) { return KindValue::pedal; }
+            else if ( value == "power" ) { return KindValue::power; }
+            else if ( value == "Tristan" ) { return KindValue::tristan; }
+            else if ( value == "other" ) { return KindValue::other; }
+            else if ( value == "none" ) { return KindValue::none; }
+            return KindValue::major;
+        }
+
+        std::string toString( const KindValue value )
+        {
+            switch ( value )
+            {
+                case KindValue::major: { return "major"; }
+                case KindValue::minor: { return "minor"; }
+                case KindValue::augmented: { return "augmented"; }
+                case KindValue::diminished: { return "diminished"; }
+                case KindValue::dominant: { return "dominant"; }
+                case KindValue::majorSeventh: { return "major-seventh"; }
+                case KindValue::minorSeventh: { return "minor-seventh"; }
+                case KindValue::diminishedSeventh: { return "diminished-seventh"; }
+                case KindValue::augmentedSeventh: { return "augmented-seventh"; }
+                case KindValue::halfDiminished: { return "half-diminished"; }
+                case KindValue::majorMinor: { return "major-minor"; }
+                case KindValue::majorSixth: { return "major-sixth"; }
+                case KindValue::minorSixth: { return "minor-sixth"; }
+                case KindValue::dominantNinth: { return "dominant-ninth"; }
+                case KindValue::majorNinth: { return "major-ninth"; }
+                case KindValue::minorNinth: { return "minor-ninth"; }
+                case KindValue::dominant11Th: { return "dominant-11th"; }
+                case KindValue::major11Th: { return "major-11th"; }
+                case KindValue::minor11Th: { return "minor-11th"; }
+                case KindValue::dominant13Th: { return "dominant-13th"; }
+                case KindValue::major13Th: { return "major-13th"; }
+                case KindValue::minor13Th: { return "minor-13th"; }
+                case KindValue::suspendedSecond: { return "suspended-second"; }
+                case KindValue::suspendedFourth: { return "suspended-fourth"; }
+                case KindValue::neapolitan: { return "Neapolitan"; }
+                case KindValue::italian: { return "Italian"; }
+                case KindValue::french: { return "French"; }
+                case KindValue::german: { return "German"; }
+                case KindValue::pedal: { return "pedal"; }
+                case KindValue::power: { return "power"; }
+                case KindValue::tristan: { return "Tristan"; }
+                case KindValue::other: { return "other"; }
+                case KindValue::none: { return "none"; }
+                default: break;
+            }
+            return "major";
+        }
+
+        std::ostream& toStream( std::ostream& os, const KindValue value )
+        {
+            return os << toString( value );
+        }
+
+        std::ostream& operator<<( std::ostream& os, const KindValue value )
+        {
+            return toStream( os, value );
+        }
+
+        /// LeftCenterRight ////////////////////////////////////////////////////////////////////////
+
+        LeftCenterRight parseLeftCenterRight( const std::string& value )
+        {
+            if ( value == "left" ) { return LeftCenterRight::left; }
+            else if ( value == "center" ) { return LeftCenterRight::center; }
+            else if ( value == "right" ) { return LeftCenterRight::right; }
+            return LeftCenterRight::left;
+        }
+
+        std::string toString( const LeftCenterRight value )
+        {
+            switch ( value )
+            {
+                case LeftCenterRight::left: { return "left"; }
+                case LeftCenterRight::center: { return "center"; }
+                case LeftCenterRight::right: { return "right"; }
+                default: break;
+            }
+            return "left";
+        }
+
+        std::ostream& toStream( std::ostream& os, const LeftCenterRight value )
+        {
+            return os << toString( value );
+        }
+
+        std::ostream& operator<<( std::ostream& os, const LeftCenterRight value )
+        {
+            return toStream( os, value );
+        }
+
+        /// LeftRight //////////////////////////////////////////////////////////////////////////////
+
+        LeftRight parseLeftRight( const std::string& value )
+        {
+            if ( value == "left" ) { return LeftRight::left; }
+            else if ( value == "right" ) { return LeftRight::right; }
+            return LeftRight::left;
+        }
+
+        std::string toString( const LeftRight value )
+        {
+            switch ( value )
+            {
+                case LeftRight::left: { return "left"; }
+                case LeftRight::right: { return "right"; }
+                default: break;
+            }
+            return "left";
+        }
+
+        std::ostream& toStream( std::ostream& os, const LeftRight value )
+        {
+            return os << toString( value );
+        }
+
+        std::ostream& operator<<( std::ostream& os, const LeftRight value )
+        {
+            return toStream( os, value );
+        }
+
+        /// LineEnd ////////////////////////////////////////////////////////////////////////////////
+
+        LineEnd parseLineEnd( const std::string& value )
+        {
+            if ( value == "up" ) { return LineEnd::up; }
+            else if ( value == "down" ) { return LineEnd::down; }
+            else if ( value == "both" ) { return LineEnd::both; }
+            else if ( value == "arrow" ) { return LineEnd::arrow; }
+            else if ( value == "none" ) { return LineEnd::none; }
+            return LineEnd::up;
+        }
+
+        std::string toString( const LineEnd value )
+        {
+            switch ( value )
+            {
+                case LineEnd::up: { return "up"; }
+                case LineEnd::down: { return "down"; }
+                case LineEnd::both: { return "both"; }
+                case LineEnd::arrow: { return "arrow"; }
+                case LineEnd::none: { return "none"; }
+                default: break;
+            }
+            return "up";
+        }
+
+        std::ostream& toStream( std::ostream& os, const LineEnd value )
+        {
+            return os << toString( value );
+        }
+
+        std::ostream& operator<<( std::ostream& os, const LineEnd value )
+        {
+            return toStream( os, value );
+        }
+
+        /// LineShape //////////////////////////////////////////////////////////////////////////////
+
+        LineShape parseLineShape( const std::string& value )
+        {
+            if ( value == "straight" ) { return LineShape::straight; }
+            else if ( value == "curved" ) { return LineShape::curved; }
+            return LineShape::straight;
+        }
+
+        std::string toString( const LineShape value )
+        {
+            switch ( value )
+            {
+                case LineShape::straight: { return "straight"; }
+                case LineShape::curved: { return "curved"; }
+                default: break;
+            }
+            return "straight";
+        }
+
+        std::ostream& toStream( std::ostream& os, const LineShape value )
+        {
+            return os << toString( value );
+        }
+
+        std::ostream& operator<<( std::ostream& os, const LineShape value )
+        {
+            return toStream( os, value );
+        }
+
+        /// LineType ///////////////////////////////////////////////////////////////////////////////
+
+        LineType parseLineType( const std::string& value )
+        {
+            if ( value == "solid" ) { return LineType::solid; }
+            else if ( value == "dashed" ) { return LineType::dashed; }
+            else if ( value == "dotted" ) { return LineType::dotted; }
+            else if ( value == "wavy" ) { return LineType::wavy; }
+            return LineType::solid;
+        }
+
+        std::string toString( const LineType value )
+        {
+            switch ( value )
+            {
+                case LineType::solid: { return "solid"; }
+                case LineType::dashed: { return "dashed"; }
+                case LineType::dotted: { return "dotted"; }
+                case LineType::wavy: { return "wavy"; }
+                default: break;
+            }
+            return "solid";
+        }
+
+        std::ostream& toStream( std::ostream& os, const LineType value )
+        {
+            return os << toString( value );
+        }
+
+        std::ostream& operator<<( std::ostream& os, const LineType value )
+        {
+            return toStream( os, value );
+        }
+
+        /// LineWidthTypeEnum //////////////////////////////////////////////////////////////////////
+
+        LineWidthTypeEnum parseLineWidthTypeEnum( const std::string& value, bool& success )
+        {
+            success = true;
+            if ( value == "beam" ) { return LineWidthTypeEnum::beam; }
+            else if ( value == "bracket" ) { return LineWidthTypeEnum::bracket; }
+            else if ( value == "dashes" ) { return LineWidthTypeEnum::dashes; }
+            else if ( value == "enclosure" ) { return LineWidthTypeEnum::enclosure; }
+            else if ( value == "ending" ) { return LineWidthTypeEnum::ending; }
+            else if ( value == "extend" ) { return LineWidthTypeEnum::extend; }
+            else if ( value == "heavy barline" ) { return LineWidthTypeEnum::heavyBarline; }
+            else if ( value == "leger" ) { return LineWidthTypeEnum::leger; }
+            else if ( value == "light barline" ) { return LineWidthTypeEnum::lightBarline; }
+            else if ( value == "octave shift" ) { return LineWidthTypeEnum::octaveShift; }
+            else if ( value == "pedal" ) { return LineWidthTypeEnum::pedal; }
+            else if ( value == "slur middle" ) { return LineWidthTypeEnum::slurMiddle; }
+            else if ( value == "slur tip" ) { return LineWidthTypeEnum::slurTip; }
+            else if ( value == "staff" ) { return LineWidthTypeEnum::staff; }
+            else if ( value == "stem" ) { return LineWidthTypeEnum::stem; }
+            else if ( value == "tie middle" ) { return LineWidthTypeEnum::tieMiddle; }
+            else if ( value == "tie tip" ) { return LineWidthTypeEnum::tieTip; }
+            else if ( value == "tuplet bracket" ) { return LineWidthTypeEnum::tupletBracket; }
+            else if ( value == "wedge" ) { return LineWidthTypeEnum::wedge; }
+            else if ( value == "other" ) { return LineWidthTypeEnum::other; }
+            success = false;
+            return LineWidthTypeEnum::other;
+        }
+
+        LineWidthTypeEnum parseLineWidthTypeEnum( const std::string& value )
+        {
+            bool success = true;
+            return parseLineWidthTypeEnum( value, success );
+        }
+
+        std::string toString( const LineWidthTypeEnum value )
+        {
+            switch ( value )
+            {
+                case LineWidthTypeEnum::beam: { return "beam"; }
+                case LineWidthTypeEnum::bracket: { return "bracket"; }
+                case LineWidthTypeEnum::dashes: { return "dashes"; }
+                case LineWidthTypeEnum::enclosure: { return "enclosure"; }
+                case LineWidthTypeEnum::ending: { return "ending"; }
+                case LineWidthTypeEnum::extend: { return "extend"; }
+                case LineWidthTypeEnum::heavyBarline: { return "heavy barline"; }
+                case LineWidthTypeEnum::leger: { return "leger"; }
+                case LineWidthTypeEnum::lightBarline: { return "light barline"; }
+                case LineWidthTypeEnum::octaveShift: { return "octave shift"; }
+                case LineWidthTypeEnum::pedal: { return "pedal"; }
+                case LineWidthTypeEnum::slurMiddle: { return "slur middle"; }
+                case LineWidthTypeEnum::slurTip: { return "slur tip"; }
+                case LineWidthTypeEnum::staff: { return "staff"; }
+                case LineWidthTypeEnum::stem: { return "stem"; }
+                case LineWidthTypeEnum::tieMiddle: { return "tie middle"; }
+                case LineWidthTypeEnum::tieTip: { return "tie tip"; }
+                case LineWidthTypeEnum::tupletBracket: { return "tuplet bracket"; }
+                case LineWidthTypeEnum::wedge: { return "wedge"; }
+                case LineWidthTypeEnum::other: { return "other"; }
+                default: break;
+            }
+            return "default";
+        }
+
+        std::ostream& toStream( std::ostream& os, const LineWidthTypeEnum value )
+        {
+            return os << toString( value );
+        }
+
+        std::ostream& operator<<( std::ostream& os, const LineWidthTypeEnum value )
+        {
+            return toStream( os, value );
+        }
+
+        LineWidthType::LineWidthType( const LineWidthTypeEnum value )
+        :myEnum( value )
+        ,myCustomValue( "" )
+        {
+            setValue( value );
+        }
+
+        LineWidthType::LineWidthType( const std::string& value )
+        :myEnum( LineWidthTypeEnum::other )
+        ,myCustomValue( value )
+        {
+            setValue( value );
+        }
+
+        LineWidthType::LineWidthType()
+        :myEnum( LineWidthTypeEnum::beam )
+        ,myCustomValue( "" )
+        {
+            setValue( LineWidthTypeEnum::beam );
+        }
+
+        LineWidthTypeEnum LineWidthType::getValue() const
+        {
+            return myEnum;
+        }
+
+        std::string LineWidthType::getValueString() const
+        {
+            if ( myEnum != LineWidthTypeEnum::other )
+            {
+                return toString( myEnum );
+            }
+
+            else
+            {
+                return myCustomValue;
+            }
+        }
+
+        void LineWidthType::setValue( const LineWidthTypeEnum value )
+        {
+            myEnum = value;
+        }
+
+        void LineWidthType::setValue( const std::string& value )
+        {
+            bool found = false;
+            LineWidthTypeEnum temp = parseLineWidthTypeEnum( value, found );
+            if ( found )
+            {
+                myEnum = temp;
+            }
+            else
+            {
+                setValue( LineWidthTypeEnum::other );
+                myCustomValue = value;
+            }
+        }
+
+        LineWidthType parseLineWidthType( const std::string& value )
+        {
+            return LineWidthType( value );
+        }
+        
+        std::string toString( const LineWidthType& value )
+        {
+            return value.getValueString();
+        }
+        
+        std::ostream& toStream( std::ostream& os, const LineWidthType& value )
+        {
+            return os << toString( value );
+        }
+        
+        std::ostream& operator<<( std::ostream& os, const LineWidthType& value )
+        {
+            return toStream( os, value );
+        }
+
+        /// MarginType /////////////////////////////////////////////////////////////////////////////
+
+        MarginType parseMarginType( const std::string& value )
+        {
+            if ( value == "odd" ) { return MarginType::odd; }
+            else if ( value == "even" ) { return MarginType::even; }
+            else if ( value == "both" ) { return MarginType::both; }
+            return MarginType::odd;
+        }
+
+        std::string toString( const MarginType value )
+        {
+            switch ( value )
+            {
+                case MarginType::odd: { return "odd"; }
+                case MarginType::even: { return "even"; }
+                case MarginType::both: { return "both"; }
+                default: break;
+            }
+            return "odd";
+        }
+
+        std::ostream& toStream( std::ostream& os, const MarginType value )
+        {
+            return os << toString( value );
+        }
+
+        std::ostream& operator<<( std::ostream& os, const MarginType value )
+        {
+            return toStream( os, value );
+        }
+
+        /// MeasureNumberingValue //////////////////////////////////////////////////////////////////
+
+        MeasureNumberingValue parseMeasureNumberingValue( const std::string& value )
+        {
+            if ( value == "none" ) { return MeasureNumberingValue::none; }
+            else if ( value == "measure" ) { return MeasureNumberingValue::measure; }
+            else if ( value == "system" ) { return MeasureNumberingValue::system; }
+            return MeasureNumberingValue::none;
+        }
+
+        std::string toString( const MeasureNumberingValue value )
+        {
+            switch ( value )
+            {
+                case MeasureNumberingValue::none: { return "none"; }
+                case MeasureNumberingValue::measure: { return "measure"; }
+                case MeasureNumberingValue::system: { return "system"; }
+                default: break;
+            }
+            return "none";
+        }
+
+        std::ostream& toStream( std::ostream& os, const MeasureNumberingValue value )
+        {
+            return os << toString( value );
+        }
+
+        std::ostream& operator<<( std::ostream& os, const MeasureNumberingValue value )
+        {
+            return toStream( os, value );
+        }
+
+        /// MembraneEnum ///////////////////////////////////////////////////////////////////////////
+
+        MembraneEnum parseMembraneEnum( const std::string& value )
+        {
+            if ( value == "bass drum" ) { return MembraneEnum::bassDrum; }
+            else if ( value == "bass drum on side" ) { return MembraneEnum::bassDrumOnSide; }
+            else if ( value == "bongos" ) { return MembraneEnum::bongos; }
+            else if ( value == "conga drum" ) { return MembraneEnum::congaDrum; }
+            else if ( value == "goblet drum" ) { return MembraneEnum::gobletDrum; }
+            else if ( value == "military drum" ) { return MembraneEnum::militaryDrum; }
+            else if ( value == "snare drum" ) { return MembraneEnum::snareDrum; }
+            else if ( value == "snare drum snares off" ) { return MembraneEnum::snareDrumSnaresOff; }
+            else if ( value == "tambourine" ) { return MembraneEnum::tambourine; }
+            else if ( value == "tenor drum" ) { return MembraneEnum::tenorDrum; }
+            else if ( value == "timbales" ) { return MembraneEnum::timbales; }
+            else if ( value == "tomtom" ) { return MembraneEnum::tomtom; }
+            return MembraneEnum::bassDrum;
+        }
+
+        std::string toString( const MembraneEnum value )
+        {
+            switch ( value )
+            {
+                case MembraneEnum::bassDrum: { return "bass drum"; }
+                case MembraneEnum::bassDrumOnSide: { return "bass drum on side"; }
+                case MembraneEnum::bongos: { return "bongos"; }
+                case MembraneEnum::congaDrum: { return "conga drum"; }
+                case MembraneEnum::gobletDrum: { return "goblet drum"; }
+                case MembraneEnum::militaryDrum: { return "military drum"; }
+                case MembraneEnum::snareDrum: { return "snare drum"; }
+                case MembraneEnum::snareDrumSnaresOff: { return "snare drum snares off"; }
+                case MembraneEnum::tambourine: { return "tambourine"; }
+                case MembraneEnum::tenorDrum: { return "tenor drum"; }
+                case MembraneEnum::timbales: { return "timbales"; }
+                case MembraneEnum::tomtom: { return "tomtom"; }
+                default: break;
+            }
+            return "bass drum";
+        }
+
+        std::ostream& toStream( std::ostream& os, const MembraneEnum value )
+        {
+            return os << toString( value );
+        }
+
+        std::ostream& operator<<( std::ostream& os, const MembraneEnum value )
+        {
+            return toStream( os, value );
+        }
+
+        /// MetalEnum //////////////////////////////////////////////////////////////////////////////
+
+        MetalEnum parseMetalEnum( const std::string& value )
+        {
+            if ( value == "almglocken" ) { return MetalEnum::almglocken; }
+            else if ( value == "bell" ) { return MetalEnum::bell; }
+            else if ( value == "bell plate" ) { return MetalEnum::bellPlate; }
+            else if ( value == "brake drum" ) { return MetalEnum::brakeDrum; }
+            else if ( value == "Chinese cymbal" ) { return MetalEnum::chineseCymbal; }
+            else if ( value == "cowbell" ) { return MetalEnum::cowbell; }
+            else if ( value == "crash cymbals" ) { return MetalEnum::crashCymbals; }
+            else if ( value == "crotale" ) { return MetalEnum::crotale; }
+            else if ( value == "cymbal tongs" ) { return MetalEnum::cymbalTongs; }
+            else if ( value == "domed gong" ) { return MetalEnum::domedGong; }
+            else if ( value == "finger cymbals" ) { return MetalEnum::fingerCymbals; }
+            else if ( value == "flexatone" ) { return MetalEnum::flexatone; }
+            else if ( value == "gong" ) { return MetalEnum::gong; }
+            else if ( value == "hi-hat" ) { return MetalEnum::hiHat; }
+            else if ( value == "high-hat cymbals" ) { return MetalEnum::highHatCymbals; }
+            else if ( value == "handbell" ) { return MetalEnum::handbell; }
+            else if ( value == "sistrum" ) { return MetalEnum::sistrum; }
+            else if ( value == "sizzle cymbal" ) { return MetalEnum::sizzleCymbal; }
+            else if ( value == "sleigh bells" ) { return MetalEnum::sleighBells; }
+            else if ( value == "suspended cymbal" ) { return MetalEnum::suspendedCymbal; }
+            else if ( value == "tam tam" ) { return MetalEnum::tamTam; }
+            else if ( value == "triangle" ) { return MetalEnum::triangle; }
+            else if ( value == "Vietnamese hat" ) { return MetalEnum::vietnameseHat; }
+            return MetalEnum::almglocken;
+        }
+
+        std::string toString( const MetalEnum value )
+        {
+            switch ( value )
+            {
+                case MetalEnum::almglocken: { return "almglocken"; }
+                case MetalEnum::bell: { return "bell"; }
+                case MetalEnum::bellPlate: { return "bell plate"; }
+                case MetalEnum::brakeDrum: { return "brake drum"; }
+                case MetalEnum::chineseCymbal: { return "Chinese cymbal"; }
+                case MetalEnum::cowbell: { return "cowbell"; }
+                case MetalEnum::crashCymbals: { return "crash cymbals"; }
+                case MetalEnum::crotale: { return "crotale"; }
+                case MetalEnum::cymbalTongs: { return "cymbal tongs"; }
+                case MetalEnum::domedGong: { return "domed gong"; }
+                case MetalEnum::fingerCymbals: { return "finger cymbals"; }
+                case MetalEnum::flexatone: { return "flexatone"; }
+                case MetalEnum::gong: { return "gong"; }
+                case MetalEnum::hiHat: { return "hi-hat"; }
+                case MetalEnum::highHatCymbals: { return "high-hat cymbals"; }
+                case MetalEnum::handbell: { return "handbell"; }
+                case MetalEnum::sistrum: { return "sistrum"; }
+                case MetalEnum::sizzleCymbal: { return "sizzle cymbal"; }
+                case MetalEnum::sleighBells: { return "sleigh bells"; }
+                case MetalEnum::suspendedCymbal: { return "suspended cymbal"; }
+                case MetalEnum::tamTam: { return "tam tam"; }
+                case MetalEnum::triangle: { return "triangle"; }
+                case MetalEnum::vietnameseHat: { return "Vietnamese hat"; }
+                default: break;
+            }
+            return "almglocken";
+        }
+
+        std::ostream& toStream( std::ostream& os, const MetalEnum value )
+        {
+            return os << toString( value );
+        }
+
+        std::ostream& operator<<( std::ostream& os, const MetalEnum value )
+        {
+            return toStream( os, value );
+        }
+
+        /// ModeEnum ///////////////////////////////////////////////////////////////////////////////
+
+        ModeEnum parseModeEnum( const std::string& value, bool& success )
+        {
+            success = true;
+            if ( value == "major" ) { return ModeEnum::major; }
+            else if ( value == "minor" ) { return ModeEnum::minor; }
+            else if ( value == "dorian" ) { return ModeEnum::dorian; }
+            else if ( value == "phrygian" ) { return ModeEnum::phrygian; }
+            else if ( value == "lydian" ) { return ModeEnum::lydian; }
+            else if ( value == "mixolydian" ) { return ModeEnum::mixolydian; }
+            else if ( value == "aeolian" ) { return ModeEnum::aeolian; }
+            else if ( value == "ionian" ) { return ModeEnum::ionian; }
+            else if ( value == "locrian" ) { return ModeEnum::locrian; }
+            else if ( value == "none" ) { return ModeEnum::none; }
+            else if ( value == "other" ) { return ModeEnum::other; }
+            success = false;
+            return ModeEnum::other;
+        }
+
+        ModeEnum parseModeEnum( const std::string& value )
+        {
+            bool success = true;
+            return parseModeEnum( value, success );
+        }
+
+        std::string toString( const ModeEnum value )
+        {
+            switch ( value )
+            {
+                case ModeEnum::major: { return "major"; }
+                case ModeEnum::minor: { return "minor"; }
+                case ModeEnum::dorian: { return "dorian"; }
+                case ModeEnum::phrygian: { return "phrygian"; }
+                case ModeEnum::lydian: { return "lydian"; }
+                case ModeEnum::mixolydian: { return "mixolydian"; }
+                case ModeEnum::aeolian: { return "aeolian"; }
+                case ModeEnum::ionian: { return "ionian"; }
+                case ModeEnum::locrian: { return "locrian"; }
+                case ModeEnum::none: { return "none"; }
+                case ModeEnum::other: { return "other"; }
+                default: break;
+            }
+            return "default";
+        }
+
+        std::ostream& toStream( std::ostream& os, const ModeEnum value )
+        {
+            return os << toString( value );
+        }
+
+        std::ostream& operator<<( std::ostream& os, const ModeEnum value )
+        {
+            return toStream( os, value );
+        }
+
+        ModeValue::ModeValue( const ModeEnum value )
+        :myEnum( value )
+        ,myCustomValue( "" )
+        {
+            setValue( value );
+        }
+
+        ModeValue::ModeValue( const std::string& value )
+        :myEnum( ModeEnum::other )
+        ,myCustomValue( value )
+        {
+            setValue( value );
+        }
+
+        ModeValue::ModeValue()
+        :myEnum( ModeEnum::major )
+        ,myCustomValue( "" )
+        {
+            setValue( ModeEnum::major );
+        }
+
+        ModeEnum ModeValue::getValue() const
+        {
+            return myEnum;
+        }
+
+        std::string ModeValue::getValueString() const
+        {
+            if ( myEnum != ModeEnum::other )
+            {
+                return toString( myEnum );
+            }
+
+            else
+            {
+                return myCustomValue;
+            }
+        }
+
+        void ModeValue::setValue( const ModeEnum value )
+        {
+            myEnum = value;
+        }
+
+        void ModeValue::setValue( const std::string& value )
+        {
+            bool found = false;
+            ModeEnum temp = parseModeEnum( value, found );
+            if ( found )
+            {
+                myEnum = temp;
+            }
+            else
+            {
+                setValue( ModeEnum::other );
+                myCustomValue = value;
+            }
+        }
+
+        ModeValue parseModeValue( const std::string& value )
+        {
+            return ModeValue( value );
+        }
+        
+        std::string toString( const ModeValue& value )
+        {
+            return value.getValueString();
+        }
+        
+        std::ostream& toStream( std::ostream& os, const ModeValue& value )
+        {
+            return os << toString( value );
+        }
+        
+        std::ostream& operator<<( std::ostream& os, const ModeValue& value )
+        {
+            return toStream( os, value );
+        }
+
+        /// MuteEnum ///////////////////////////////////////////////////////////////////////////////
+
+        MuteEnum parseMuteEnum( const std::string& value )
+        {
+            if ( value == "on" ) { return MuteEnum::on; }
+            else if ( value == "off" ) { return MuteEnum::off; }
+            else if ( value == "straight" ) { return MuteEnum::straight; }
+            else if ( value == "cup" ) { return MuteEnum::cup; }
+            else if ( value == "harmon-no-stem" ) { return MuteEnum::harmonNoStem; }
+            else if ( value == "harmon-stem" ) { return MuteEnum::harmonStem; }
+            else if ( value == "bucket" ) { return MuteEnum::bucket; }
+            else if ( value == "plunger" ) { return MuteEnum::plunger; }
+            else if ( value == "hat" ) { return MuteEnum::hat; }
+            else if ( value == "solotone" ) { return MuteEnum::solotone; }
+            else if ( value == "practice" ) { return MuteEnum::practice; }
+            else if ( value == "stop-mute" ) { return MuteEnum::stopMute; }
+            else if ( value == "stop-hand" ) { return MuteEnum::stopHand; }
+            else if ( value == "echo" ) { return MuteEnum::echo; }
+            else if ( value == "palm" ) { return MuteEnum::palm; }
+            return MuteEnum::on;
+        }
+
+        std::string toString( const MuteEnum value )
+        {
+            switch ( value )
+            {
+                case MuteEnum::on: { return "on"; }
+                case MuteEnum::off: { return "off"; }
+                case MuteEnum::straight: { return "straight"; }
+                case MuteEnum::cup: { return "cup"; }
+                case MuteEnum::harmonNoStem: { return "harmon-no-stem"; }
+                case MuteEnum::harmonStem: { return "harmon-stem"; }
+                case MuteEnum::bucket: { return "bucket"; }
+                case MuteEnum::plunger: { return "plunger"; }
+                case MuteEnum::hat: { return "hat"; }
+                case MuteEnum::solotone: { return "solotone"; }
+                case MuteEnum::practice: { return "practice"; }
+                case MuteEnum::stopMute: { return "stop-mute"; }
+                case MuteEnum::stopHand: { return "stop-hand"; }
+                case MuteEnum::echo: { return "echo"; }
+                case MuteEnum::palm: { return "palm"; }
+                default: break;
+            }
+            return "on";
+        }
+
+        std::ostream& toStream( std::ostream& os, const MuteEnum value )
+        {
+            return os << toString( value );
+        }
+
+        std::ostream& operator<<( std::ostream& os, const MuteEnum value )
+        {
+            return toStream( os, value );
+        }
+
+        /// NoteSizeType ///////////////////////////////////////////////////////////////////////////
+
+        NoteSizeType parseNoteSizeType( const std::string& value )
+        {
+            if ( value == "cue" ) { return NoteSizeType::cue; }
+            else if ( value == "grace" ) { return NoteSizeType::grace; }
+            else if ( value == "large" ) { return NoteSizeType::large; }
+            return NoteSizeType::cue;
+        }
+
+        std::string toString( const NoteSizeType value )
+        {
+            switch ( value )
+            {
+                case NoteSizeType::cue: { return "cue"; }
+                case NoteSizeType::grace: { return "grace"; }
+                case NoteSizeType::large: { return "large"; }
+                default: break;
+            }
+            return "cue";
+        }
+
+        std::ostream& toStream( std::ostream& os, const NoteSizeType value )
+        {
+            return os << toString( value );
+        }
+
+        std::ostream& operator<<( std::ostream& os, const NoteSizeType value )
+        {
+            return toStream( os, value );
+        }
+
+        /// NoteTypeValue //////////////////////////////////////////////////////////////////////////
+
+        NoteTypeValue parseNoteTypeValue( const std::string& value )
+        {
+            if ( value == "1024th" ) { return NoteTypeValue::oneThousandTwentyFourth; }
+            else if ( value == "512th" ) { return NoteTypeValue::fiveHundredTwelfth; }
+            else if ( value == "256th" ) { return NoteTypeValue::twoHundredFifthySixth; }
+            else if ( value == "128th" ) { return NoteTypeValue::oneHundredTwentyEighth; }
+            else if ( value == "64th" ) { return NoteTypeValue::sixtyFourth; }
+            else if ( value == "32nd" ) { return NoteTypeValue::thirtySecond; }
+            else if ( value == "16th" ) { return NoteTypeValue::sixteenth; }
+            else if ( value == "eighth" ) { return NoteTypeValue::eighth; }
+            else if ( value == "quarter" ) { return NoteTypeValue::quarter; }
+            else if ( value == "half" ) { return NoteTypeValue::half; }
+            else if ( value == "whole" ) { return NoteTypeValue::whole; }
+            else if ( value == "breve" ) { return NoteTypeValue::breve; }
+            else if ( value == "long" ) { return NoteTypeValue::long_; }
+            else if ( value == "maxima" ) { return NoteTypeValue::maxima; }
+            return NoteTypeValue::oneThousandTwentyFourth;
+        }
+
+        std::string toString( const NoteTypeValue value )
+        {
+            switch ( value )
+            {
+                case NoteTypeValue::oneThousandTwentyFourth: { return "1024th"; }
+                case NoteTypeValue::fiveHundredTwelfth: { return "512th"; }
+                case NoteTypeValue::twoHundredFifthySixth: { return "256th"; }
+                case NoteTypeValue::oneHundredTwentyEighth: { return "128th"; }
+                case NoteTypeValue::sixtyFourth: { return "64th"; }
+                case NoteTypeValue::thirtySecond: { return "32nd"; }
+                case NoteTypeValue::sixteenth: { return "16th"; }
+                case NoteTypeValue::eighth: { return "eighth"; }
+                case NoteTypeValue::quarter: { return "quarter"; }
+                case NoteTypeValue::half: { return "half"; }
+                case NoteTypeValue::whole: { return "whole"; }
+                case NoteTypeValue::breve: { return "breve"; }
+                case NoteTypeValue::long_: { return "long"; }
+                case NoteTypeValue::maxima: { return "maxima"; }
+                default: break;
+            }
+            return "1024th";
+        }
+
+        std::ostream& toStream( std::ostream& os, const NoteTypeValue value )
+        {
+            return os << toString( value );
+        }
+
+        std::ostream& operator<<( std::ostream& os, const NoteTypeValue value )
+        {
+            return toStream( os, value );
+        }
+
+        /// NoteheadValue //////////////////////////////////////////////////////////////////////////
+
+        NoteheadValue parseNoteheadValue( const std::string& value )
+        {
+            if ( value == "slash" ) { return NoteheadValue::slash; }
+            else if ( value == "triangle" ) { return NoteheadValue::triangle; }
+            else if ( value == "diamond" ) { return NoteheadValue::diamond; }
+            else if ( value == "square" ) { return NoteheadValue::square; }
+            else if ( value == "cross" ) { return NoteheadValue::cross; }
+            else if ( value == "x" ) { return NoteheadValue::x; }
+            else if ( value == "circle-x" ) { return NoteheadValue::circleX; }
+            else if ( value == "inverted triangle" ) { return NoteheadValue::invertedTriangle; }
+            else if ( value == "arrow down" ) { return NoteheadValue::arrowDown; }
+            else if ( value == "arrow up" ) { return NoteheadValue::arrowUp; }
+            else if ( value == "slashed" ) { return NoteheadValue::slashed; }
+            else if ( value == "back slashed" ) { return NoteheadValue::backSlashed; }
+            else if ( value == "normal" ) { return NoteheadValue::normal; }
+            else if ( value == "cluster" ) { return NoteheadValue::cluster; }
+            else if ( value == "circle dot" ) { return NoteheadValue::circleDot; }
+            else if ( value == "left triangle" ) { return NoteheadValue::leftTriangle; }
+            else if ( value == "rectangle" ) { return NoteheadValue::rectangle; }
+            else if ( value == "none" ) { return NoteheadValue::none; }
+            else if ( value == "do" ) { return NoteheadValue::do_; }
+            else if ( value == "re" ) { return NoteheadValue::re; }
+            else if ( value == "mi" ) { return NoteheadValue::mi; }
+            else if ( value == "fa" ) { return NoteheadValue::fa; }
+            else if ( value == "fa up" ) { return NoteheadValue::faUp; }
+            else if ( value == "so" ) { return NoteheadValue::so; }
+            else if ( value == "la" ) { return NoteheadValue::la; }
+            else if ( value == "ti" ) { return NoteheadValue::ti; }
+            return NoteheadValue::slash;
+        }
+
+        std::string toString( const NoteheadValue value )
+        {
+            switch ( value )
+            {
+                case NoteheadValue::slash: { return "slash"; }
+                case NoteheadValue::triangle: { return "triangle"; }
+                case NoteheadValue::diamond: { return "diamond"; }
+                case NoteheadValue::square: { return "square"; }
+                case NoteheadValue::cross: { return "cross"; }
+                case NoteheadValue::x: { return "x"; }
+                case NoteheadValue::circleX: { return "circle-x"; }
+                case NoteheadValue::invertedTriangle: { return "inverted triangle"; }
+                case NoteheadValue::arrowDown: { return "arrow down"; }
+                case NoteheadValue::arrowUp: { return "arrow up"; }
+                case NoteheadValue::slashed: { return "slashed"; }
+                case NoteheadValue::backSlashed: { return "back slashed"; }
+                case NoteheadValue::normal: { return "normal"; }
+                case NoteheadValue::cluster: { return "cluster"; }
+                case NoteheadValue::circleDot: { return "circle dot"; }
+                case NoteheadValue::leftTriangle: { return "left triangle"; }
+                case NoteheadValue::rectangle: { return "rectangle"; }
+                case NoteheadValue::none: { return "none"; }
+                case NoteheadValue::do_: { return "do"; }
+                case NoteheadValue::re: { return "re"; }
+                case NoteheadValue::mi: { return "mi"; }
+                case NoteheadValue::fa: { return "fa"; }
+                case NoteheadValue::faUp: { return "fa up"; }
+                case NoteheadValue::so: { return "so"; }
+                case NoteheadValue::la: { return "la"; }
+                case NoteheadValue::ti: { return "ti"; }
+                default: break;
+            }
+            return "slash";
+        }
+
+        std::ostream& toStream( std::ostream& os, const NoteheadValue value )
+        {
+            return os << toString( value );
+        }
+
+        std::ostream& operator<<( std::ostream& os, const NoteheadValue value )
+        {
+            return toStream( os, value );
+        }
+
+        /// OnOff //////////////////////////////////////////////////////////////////////////////////
+
+        OnOff parseOnOff( const std::string& value )
+        {
+            if ( value == "on" ) { return OnOff::on; }
+            else if ( value == "off" ) { return OnOff::off; }
+            return OnOff::on;
+        }
+
+        std::string toString( const OnOff value )
+        {
+            switch ( value )
+            {
+                case OnOff::on: { return "on"; }
+                case OnOff::off: { return "off"; }
+                default: break;
+            }
+            return "on";
+        }
+
+        std::ostream& toStream( std::ostream& os, const OnOff value )
+        {
+            return os << toString( value );
+        }
+
+        std::ostream& operator<<( std::ostream& os, const OnOff value )
+        {
+            return toStream( os, value );
+        }
+
+        /// OverUnder //////////////////////////////////////////////////////////////////////////////
+
+        OverUnder parseOverUnder( const std::string& value )
+        {
+            if ( value == "over" ) { return OverUnder::over; }
+            else if ( value == "under" ) { return OverUnder::under; }
+            return OverUnder::over;
+        }
+
+        std::string toString( const OverUnder value )
+        {
+            switch ( value )
+            {
+                case OverUnder::over: { return "over"; }
+                case OverUnder::under: { return "under"; }
+                default: break;
+            }
+            return "over";
+        }
+
+        std::ostream& toStream( std::ostream& os, const OverUnder value )
+        {
+            return os << toString( value );
+        }
+
+        std::ostream& operator<<( std::ostream& os, const OverUnder value )
+        {
+            return toStream( os, value );
+        }
+
+        /// PitchedEnum ////////////////////////////////////////////////////////////////////////////
+
+        PitchedEnum parsePitchedEnum( const std::string& value )
+        {
+            if ( value == "chimes" ) { return PitchedEnum::chimes; }
+            else if ( value == "glockenspiel" ) { return PitchedEnum::glockenspiel; }
+            else if ( value == "mallet" ) { return PitchedEnum::mallet; }
+            else if ( value == "marimba" ) { return PitchedEnum::marimba; }
+            else if ( value == "tubular chimes" ) { return PitchedEnum::tubularChimes; }
+            else if ( value == "vibraphone" ) { return PitchedEnum::vibraphone; }
+            else if ( value == "xylophone" ) { return PitchedEnum::xylophone; }
+            return PitchedEnum::chimes;
+        }
+
+        std::string toString( const PitchedEnum value )
+        {
+            switch ( value )
+            {
+                case PitchedEnum::chimes: { return "chimes"; }
+                case PitchedEnum::glockenspiel: { return "glockenspiel"; }
+                case PitchedEnum::mallet: { return "mallet"; }
+                case PitchedEnum::marimba: { return "marimba"; }
+                case PitchedEnum::tubularChimes: { return "tubular chimes"; }
+                case PitchedEnum::vibraphone: { return "vibraphone"; }
+                case PitchedEnum::xylophone: { return "xylophone"; }
+                default: break;
+            }
+            return "chimes";
+        }
+
+        std::ostream& toStream( std::ostream& os, const PitchedEnum value )
+        {
+            return os << toString( value );
+        }
+
+        std::ostream& operator<<( std::ostream& os, const PitchedEnum value )
+        {
+            return toStream( os, value );
+        }
+
+        /// PrincipalVoiceSymbol ///////////////////////////////////////////////////////////////////
+
+        PrincipalVoiceSymbol parsePrincipalVoiceSymbol( const std::string& value )
+        {
+            if ( value == "Hauptstimme" ) { return PrincipalVoiceSymbol::hauptstimme; }
+            else if ( value == "Nebenstimme" ) { return PrincipalVoiceSymbol::nebenstimme; }
+            else if ( value == "plain" ) { return PrincipalVoiceSymbol::plain; }
+            else if ( value == "none" ) { return PrincipalVoiceSymbol::none; }
+            return PrincipalVoiceSymbol::hauptstimme;
+        }
+
+        std::string toString( const PrincipalVoiceSymbol value )
+        {
+            switch ( value )
+            {
+                case PrincipalVoiceSymbol::hauptstimme: { return "Hauptstimme"; }
+                case PrincipalVoiceSymbol::nebenstimme: { return "Nebenstimme"; }
+                case PrincipalVoiceSymbol::plain: { return "plain"; }
+                case PrincipalVoiceSymbol::none: { return "none"; }
+                default: break;
+            }
+            return "Hauptstimme";
+        }
+
+        std::ostream& toStream( std::ostream& os, const PrincipalVoiceSymbol value )
+        {
+            return os << toString( value );
+        }
+
+        std::ostream& operator<<( std::ostream& os, const PrincipalVoiceSymbol value )
+        {
+            return toStream( os, value );
+        }
+
+        /// RightLeftMiddle ////////////////////////////////////////////////////////////////////////
+
+        RightLeftMiddle parseRightLeftMiddle( const std::string& value )
+        {
+            if ( value == "right" ) { return RightLeftMiddle::right; }
+            else if ( value == "left" ) { return RightLeftMiddle::left; }
+            else if ( value == "middle" ) { return RightLeftMiddle::middle; }
+            return RightLeftMiddle::right;
+        }
+
+        std::string toString( const RightLeftMiddle value )
+        {
+            switch ( value )
+            {
+                case RightLeftMiddle::right: { return "right"; }
+                case RightLeftMiddle::left: { return "left"; }
+                case RightLeftMiddle::middle: { return "middle"; }
+                default: break;
+            }
+            return "right";
+        }
+
+        std::ostream& toStream( std::ostream& os, const RightLeftMiddle value )
+        {
+            return os << toString( value );
+        }
+
+        std::ostream& operator<<( std::ostream& os, const RightLeftMiddle value )
+        {
+            return toStream( os, value );
+        }
+
+        /// SemiPitchedEnum ////////////////////////////////////////////////////////////////////////
+
+        SemiPitchedEnum parseSemiPitchedEnum( const std::string& value )
+        {
+            if ( value == "high" ) { return SemiPitchedEnum::high; }
+            else if ( value == "medium-high" ) { return SemiPitchedEnum::mediumHigh; }
+            else if ( value == "medium" ) { return SemiPitchedEnum::medium; }
+            else if ( value == "medium-low" ) { return SemiPitchedEnum::mediumLow; }
+            else if ( value == "low" ) { return SemiPitchedEnum::low; }
+            else if ( value == "very-low" ) { return SemiPitchedEnum::veryLow; }
+            return SemiPitchedEnum::high;
+        }
+
+        std::string toString( const SemiPitchedEnum value )
+        {
+            switch ( value )
+            {
+                case SemiPitchedEnum::high: { return "high"; }
+                case SemiPitchedEnum::mediumHigh: { return "medium-high"; }
+                case SemiPitchedEnum::medium: { return "medium"; }
+                case SemiPitchedEnum::mediumLow: { return "medium-low"; }
+                case SemiPitchedEnum::low: { return "low"; }
+                case SemiPitchedEnum::veryLow: { return "very-low"; }
+                default: break;
+            }
+            return "high";
+        }
+
+        std::ostream& toStream( std::ostream& os, const SemiPitchedEnum value )
+        {
+            return os << toString( value );
+        }
+
+        std::ostream& operator<<( std::ostream& os, const SemiPitchedEnum value )
+        {
+            return toStream( os, value );
+        }
+
+        /// ShowFrets //////////////////////////////////////////////////////////////////////////////
+
+        ShowFrets parseShowFrets( const std::string& value )
+        {
+            if ( value == "numbers" ) { return ShowFrets::numbers; }
+            else if ( value == "letters" ) { return ShowFrets::letters; }
+            return ShowFrets::numbers;
+        }
+
+        std::string toString( const ShowFrets value )
+        {
+            switch ( value )
+            {
+                case ShowFrets::numbers: { return "numbers"; }
+                case ShowFrets::letters: { return "letters"; }
+                default: break;
+            }
+            return "numbers";
+        }
+
+        std::ostream& toStream( std::ostream& os, const ShowFrets value )
+        {
+            return os << toString( value );
+        }
+
+        std::ostream& operator<<( std::ostream& os, const ShowFrets value )
+        {
+            return toStream( os, value );
+        }
+
+        /// ShowTuplet /////////////////////////////////////////////////////////////////////////////
+
+        ShowTuplet parseShowTuplet( const std::string& value )
+        {
+            if ( value == "actual" ) { return ShowTuplet::actual; }
+            else if ( value == "both" ) { return ShowTuplet::both; }
+            else if ( value == "none" ) { return ShowTuplet::none; }
+            return ShowTuplet::actual;
+        }
+
+        std::string toString( const ShowTuplet value )
+        {
+            switch ( value )
+            {
+                case ShowTuplet::actual: { return "actual"; }
+                case ShowTuplet::both: { return "both"; }
+                case ShowTuplet::none: { return "none"; }
+                default: break;
+            }
+            return "actual";
+        }
+
+        std::ostream& toStream( std::ostream& os, const ShowTuplet value )
+        {
+            return os << toString( value );
+        }
+
+        std::ostream& operator<<( std::ostream& os, const ShowTuplet value )
+        {
+            return toStream( os, value );
+        }
+
+        /// StaffTypeEnum //////////////////////////////////////////////////////////////////////////
+
+        StaffTypeEnum parseStaffTypeEnum( const std::string& value )
+        {
+            if ( value == "ossia" ) { return StaffTypeEnum::ossia; }
+            else if ( value == "cue" ) { return StaffTypeEnum::cue; }
+            else if ( value == "editorial" ) { return StaffTypeEnum::editorial; }
+            else if ( value == "regular" ) { return StaffTypeEnum::regular; }
+            else if ( value == "alternate" ) { return StaffTypeEnum::alternate; }
+            return StaffTypeEnum::ossia;
+        }
+
+        std::string toString( const StaffTypeEnum value )
+        {
+            switch ( value )
+            {
+                case StaffTypeEnum::ossia: { return "ossia"; }
+                case StaffTypeEnum::cue: { return "cue"; }
+                case StaffTypeEnum::editorial: { return "editorial"; }
+                case StaffTypeEnum::regular: { return "regular"; }
+                case StaffTypeEnum::alternate: { return "alternate"; }
+                default: break;
+            }
+            return "ossia";
+        }
+
+        std::ostream& toStream( std::ostream& os, const StaffTypeEnum value )
+        {
+            return os << toString( value );
+        }
+
+        std::ostream& operator<<( std::ostream& os, const StaffTypeEnum value )
+        {
+            return toStream( os, value );
+        }
+
+        /// StartNote //////////////////////////////////////////////////////////////////////////////
+
+        StartNote parseStartNote( const std::string& value )
+        {
+            if ( value == "upper" ) { return StartNote::upper; }
+            else if ( value == "main" ) { return StartNote::main; }
+            else if ( value == "below" ) { return StartNote::below; }
+            return StartNote::upper;
+        }
+
+        std::string toString( const StartNote value )
+        {
+            switch ( value )
+            {
+                case StartNote::upper: { return "upper"; }
+                case StartNote::main: { return "main"; }
+                case StartNote::below: { return "below"; }
+                default: break;
+            }
+            return "upper";
+        }
+
+        std::ostream& toStream( std::ostream& os, const StartNote value )
+        {
+            return os << toString( value );
+        }
+
+        std::ostream& operator<<( std::ostream& os, const StartNote value )
+        {
+            return toStream( os, value );
+        }
+
+        /// StartStop //////////////////////////////////////////////////////////////////////////////
+
+        StartStop parseStartStop( const std::string& value )
+        {
+            if ( value == "start" ) { return StartStop::start; }
+            else if ( value == "stop" ) { return StartStop::stop; }
+            return StartStop::start;
+        }
+
+        std::string toString( const StartStop value )
+        {
+            switch ( value )
+            {
+                case StartStop::start: { return "start"; }
+                case StartStop::stop: { return "stop"; }
+                default: break;
+            }
+            return "start";
+        }
+
+        std::ostream& toStream( std::ostream& os, const StartStop value )
+        {
+            return os << toString( value );
+        }
+
+        std::ostream& operator<<( std::ostream& os, const StartStop value )
+        {
+            return toStream( os, value );
+        }
+
+        /// StartStopChangeContinue ////////////////////////////////////////////////////////////////
+
+        StartStopChangeContinue parseStartStopChangeContinue( const std::string& value )
+        {
+            if ( value == "start" ) { return StartStopChangeContinue::start; }
+            else if ( value == "stop" ) { return StartStopChangeContinue::stop; }
+            else if ( value == "change" ) { return StartStopChangeContinue::change; }
+            else if ( value == "continue" ) { return StartStopChangeContinue::continue_; }
+            return StartStopChangeContinue::start;
+        }
+
+        std::string toString( const StartStopChangeContinue value )
+        {
+            switch ( value )
+            {
+                case StartStopChangeContinue::start: { return "start"; }
+                case StartStopChangeContinue::stop: { return "stop"; }
+                case StartStopChangeContinue::change: { return "change"; }
+                case StartStopChangeContinue::continue_: { return "continue"; }
+                default: break;
+            }
+            return "start";
+        }
+
+        std::ostream& toStream( std::ostream& os, const StartStopChangeContinue value )
+        {
+            return os << toString( value );
+        }
+
+        std::ostream& operator<<( std::ostream& os, const StartStopChangeContinue value )
+        {
+            return toStream( os, value );
+        }
+
+        /// StartStopContinue //////////////////////////////////////////////////////////////////////
+
+        StartStopContinue parseStartStopContinue( const std::string& value )
+        {
+            if ( value == "start" ) { return StartStopContinue::start; }
+            else if ( value == "stop" ) { return StartStopContinue::stop; }
+            else if ( value == "continue" ) { return StartStopContinue::continue_; }
+            return StartStopContinue::start;
+        }
+
+        std::string toString( const StartStopContinue value )
+        {
+            switch ( value )
+            {
+                case StartStopContinue::start: { return "start"; }
+                case StartStopContinue::stop: { return "stop"; }
+                case StartStopContinue::continue_: { return "continue"; }
+                default: break;
+            }
+            return "start";
+        }
+
+        std::ostream& toStream( std::ostream& os, const StartStopContinue value )
+        {
+            return os << toString( value );
+        }
+
+        std::ostream& operator<<( std::ostream& os, const StartStopContinue value )
+        {
+            return toStream( os, value );
+        }
+
+        /// StartStopDiscontinue ///////////////////////////////////////////////////////////////////
+
+        StartStopDiscontinue parseStartStopDiscontinue( const std::string& value )
+        {
+            if ( value == "start" ) { return StartStopDiscontinue::start; }
+            else if ( value == "stop" ) { return StartStopDiscontinue::stop; }
+            else if ( value == "discontinue" ) { return StartStopDiscontinue::discontinue; }
+            return StartStopDiscontinue::start;
+        }
+
+        std::string toString( const StartStopDiscontinue value )
+        {
+            switch ( value )
+            {
+                case StartStopDiscontinue::start: { return "start"; }
+                case StartStopDiscontinue::stop: { return "stop"; }
+                case StartStopDiscontinue::discontinue: { return "discontinue"; }
+                default: break;
+            }
+            return "start";
+        }
+
+        std::ostream& toStream( std::ostream& os, const StartStopDiscontinue value )
+        {
+            return os << toString( value );
+        }
+
+        std::ostream& operator<<( std::ostream& os, const StartStopDiscontinue value )
+        {
+            return toStream( os, value );
+        }
+
+        /// StartStopSingle ////////////////////////////////////////////////////////////////////////
+
+        StartStopSingle parseStartStopSingle( const std::string& value )
+        {
+            if ( value == "start" ) { return StartStopSingle::start; }
+            else if ( value == "stop" ) { return StartStopSingle::stop; }
+            else if ( value == "single" ) { return StartStopSingle::single; }
+            return StartStopSingle::start;
+        }
+
+        std::string toString( const StartStopSingle value )
+        {
+            switch ( value )
+            {
+                case StartStopSingle::start: { return "start"; }
+                case StartStopSingle::stop: { return "stop"; }
+                case StartStopSingle::single: { return "single"; }
+                default: break;
+            }
+            return "start";
+        }
+
+        std::ostream& toStream( std::ostream& os, const StartStopSingle value )
+        {
+            return os << toString( value );
+        }
+
+        std::ostream& operator<<( std::ostream& os, const StartStopSingle value )
+        {
+            return toStream( os, value );
+        }
+
+        /// StemValue //////////////////////////////////////////////////////////////////////////////
+
+        StemValue parseStemValue( const std::string& value )
+        {
+            if ( value == "down" ) { return StemValue::down; }
+            else if ( value == "up" ) { return StemValue::up; }
+            else if ( value == "double" ) { return StemValue::double_; }
+            else if ( value == "none" ) { return StemValue::none; }
+            return StemValue::down;
+        }
+
+        std::string toString( const StemValue value )
+        {
+            switch ( value )
+            {
+                case StemValue::down: { return "down"; }
+                case StemValue::up: { return "up"; }
+                case StemValue::double_: { return "double"; }
+                case StemValue::none: { return "none"; }
+                default: break;
+            }
+            return "down";
+        }
+
+        std::ostream& toStream( std::ostream& os, const StemValue value )
+        {
+            return os << toString( value );
+        }
+
+        std::ostream& operator<<( std::ostream& os, const StemValue value )
+        {
+            return toStream( os, value );
+        }
+
+        /// StepEnum ///////////////////////////////////////////////////////////////////////////////
+
+        StepEnum parseStepEnum( const std::string& value )
+        {
+            if ( value == "A" ) { return StepEnum::a; }
+            else if ( value == "B" ) { return StepEnum::b; }
+            else if ( value == "C" ) { return StepEnum::c; }
+            else if ( value == "D" ) { return StepEnum::d; }
+            else if ( value == "E" ) { return StepEnum::e; }
+            else if ( value == "F" ) { return StepEnum::f; }
+            else if ( value == "G" ) { return StepEnum::g; }
+            return StepEnum::a;
+        }
+
+        std::string toString( const StepEnum value )
+        {
+            switch ( value )
+            {
+                case StepEnum::a: { return "A"; }
+                case StepEnum::b: { return "B"; }
+                case StepEnum::c: { return "C"; }
+                case StepEnum::d: { return "D"; }
+                case StepEnum::e: { return "E"; }
+                case StepEnum::f: { return "F"; }
+                case StepEnum::g: { return "G"; }
+                default: break;
+            }
+            return "A";
+        }
+
+        std::ostream& toStream( std::ostream& os, const StepEnum value )
+        {
+            return os << toString( value );
+        }
+
+        std::ostream& operator<<( std::ostream& os, const StepEnum value )
+        {
+            return toStream( os, value );
+        }
+
+        /// StickLocationEnum //////////////////////////////////////////////////////////////////////
+
+        StickLocationEnum parseStickLocationEnum( const std::string& value )
+        {
+            if ( value == "center" ) { return StickLocationEnum::center; }
+            else if ( value == "rim" ) { return StickLocationEnum::rim; }
+            else if ( value == "cymbal bell" ) { return StickLocationEnum::cymbalBell; }
+            else if ( value == "cymbal edge" ) { return StickLocationEnum::cymbalEdge; }
+            return StickLocationEnum::center;
+        }
+
+        std::string toString( const StickLocationEnum value )
+        {
+            switch ( value )
+            {
+                case StickLocationEnum::center: { return "center"; }
+                case StickLocationEnum::rim: { return "rim"; }
+                case StickLocationEnum::cymbalBell: { return "cymbal bell"; }
+                case StickLocationEnum::cymbalEdge: { return "cymbal edge"; }
+                default: break;
+            }
+            return "center";
+        }
+
+        std::ostream& toStream( std::ostream& os, const StickLocationEnum value )
+        {
+            return os << toString( value );
+        }
+
+        std::ostream& operator<<( std::ostream& os, const StickLocationEnum value )
+        {
+            return toStream( os, value );
+        }
+
+        /// StickMaterialEnum //////////////////////////////////////////////////////////////////////
+
+        StickMaterialEnum parseStickMaterialEnum( const std::string& value )
+        {
+            if ( value == "soft" ) { return StickMaterialEnum::soft; }
+            else if ( value == "medium" ) { return StickMaterialEnum::medium; }
+            else if ( value == "hard" ) { return StickMaterialEnum::hard; }
+            else if ( value == "shaded" ) { return StickMaterialEnum::shaded; }
+            else if ( value == "x" ) { return StickMaterialEnum::x; }
+            return StickMaterialEnum::soft;
+        }
+
+        std::string toString( const StickMaterialEnum value )
+        {
+            switch ( value )
+            {
+                case StickMaterialEnum::soft: { return "soft"; }
+                case StickMaterialEnum::medium: { return "medium"; }
+                case StickMaterialEnum::hard: { return "hard"; }
+                case StickMaterialEnum::shaded: { return "shaded"; }
+                case StickMaterialEnum::x: { return "x"; }
+                default: break;
+            }
+            return "soft";
+        }
+
+        std::ostream& toStream( std::ostream& os, const StickMaterialEnum value )
+        {
+            return os << toString( value );
+        }
+
+        std::ostream& operator<<( std::ostream& os, const StickMaterialEnum value )
+        {
+            return toStream( os, value );
+        }
+
+        /// StickTypeEnum //////////////////////////////////////////////////////////////////////////
+
+        StickTypeEnum parseStickTypeEnum( const std::string& value )
+        {
+            if ( value == "bass drum" ) { return StickTypeEnum::bassDrum; }
+            else if ( value == "double bass drum" ) { return StickTypeEnum::doubleBassDrum; }
+            else if ( value == "timpani" ) { return StickTypeEnum::timpani; }
+            else if ( value == "xylophone" ) { return StickTypeEnum::xylophone; }
+            else if ( value == "yarn" ) { return StickTypeEnum::yarn; }
+            return StickTypeEnum::bassDrum;
+        }
+
+        std::string toString( const StickTypeEnum value )
+        {
+            switch ( value )
+            {
+                case StickTypeEnum::bassDrum: { return "bass drum"; }
+                case StickTypeEnum::doubleBassDrum: { return "double bass drum"; }
+                case StickTypeEnum::timpani: { return "timpani"; }
+                case StickTypeEnum::xylophone: { return "xylophone"; }
+                case StickTypeEnum::yarn: { return "yarn"; }
+                default: break;
+            }
+            return "bass drum";
+        }
+
+        std::ostream& toStream( std::ostream& os, const StickTypeEnum value )
+        {
+            return os << toString( value );
+        }
+
+        std::ostream& operator<<( std::ostream& os, const StickTypeEnum value )
+        {
+            return toStream( os, value );
+        }
+
+        /// SyllabicEnum ///////////////////////////////////////////////////////////////////////////
+
+        SyllabicEnum parseSyllabicEnum( const std::string& value )
+        {
+            if ( value == "single" ) { return SyllabicEnum::single; }
+            else if ( value == "begin" ) { return SyllabicEnum::begin; }
+            else if ( value == "end" ) { return SyllabicEnum::end; }
+            else if ( value == "middle" ) { return SyllabicEnum::middle; }
+            return SyllabicEnum::single;
+        }
+
+        std::string toString( const SyllabicEnum value )
+        {
+            switch ( value )
+            {
+                case SyllabicEnum::single: { return "single"; }
+                case SyllabicEnum::begin: { return "begin"; }
+                case SyllabicEnum::end: { return "end"; }
+                case SyllabicEnum::middle: { return "middle"; }
+                default: break;
+            }
+            return "single";
+        }
+
+        std::ostream& toStream( std::ostream& os, const SyllabicEnum value )
+        {
+            return os << toString( value );
+        }
+
+        std::ostream& operator<<( std::ostream& os, const SyllabicEnum value )
+        {
+            return toStream( os, value );
+        }
+
+        /// SymbolSize /////////////////////////////////////////////////////////////////////////////
+
+        SymbolSize parseSymbolSize( const std::string& value )
+        {
+            if ( value == "full" ) { return SymbolSize::full; }
+            else if ( value == "cue" ) { return SymbolSize::cue; }
+            else if ( value == "large" ) { return SymbolSize::large; }
+            return SymbolSize::full;
+        }
+
+        std::string toString( const SymbolSize value )
+        {
+            switch ( value )
+            {
+                case SymbolSize::full: { return "full"; }
+                case SymbolSize::cue: { return "cue"; }
+                case SymbolSize::large: { return "large"; }
+                default: break;
+            }
+            return "full";
+        }
+
+        std::ostream& toStream( std::ostream& os, const SymbolSize value )
+        {
+            return os << toString( value );
+        }
+
+        std::ostream& operator<<( std::ostream& os, const SymbolSize value )
+        {
+            return toStream( os, value );
+        }
+
+        /// TextDirection //////////////////////////////////////////////////////////////////////////
+
+        TextDirection parseTextDirection( const std::string& value )
+        {
+            if ( value == "ltr" ) { return TextDirection::ltr; }
+            else if ( value == "rtl" ) { return TextDirection::rtl; }
+            else if ( value == "lro" ) { return TextDirection::lro; }
+            else if ( value == "rlo" ) { return TextDirection::rlo; }
+            return TextDirection::ltr;
+        }
+
+        std::string toString( const TextDirection value )
+        {
+            switch ( value )
+            {
+                case TextDirection::ltr: { return "ltr"; }
+                case TextDirection::rtl: { return "rtl"; }
+                case TextDirection::lro: { return "lro"; }
+                case TextDirection::rlo: { return "rlo"; }
+                default: break;
+            }
+            return "ltr";
+        }
+
+        std::ostream& toStream( std::ostream& os, const TextDirection value )
+        {
+            return os << toString( value );
+        }
+
+        std::ostream& operator<<( std::ostream& os, const TextDirection value )
+        {
+            return toStream( os, value );
+        }
+
+        /// TimeRelationEnum ///////////////////////////////////////////////////////////////////////
+
+        TimeRelationEnum parseTimeRelationEnum( const std::string& value )
+        {
+            if ( value == "parentheses" ) { return TimeRelationEnum::parentheses; }
+            else if ( value == "bracket" ) { return TimeRelationEnum::bracket; }
+            else if ( value == "equals" ) { return TimeRelationEnum::equals; }
+            else if ( value == "slash" ) { return TimeRelationEnum::slash; }
+            else if ( value == "space" ) { return TimeRelationEnum::space; }
+            else if ( value == "hyphen" ) { return TimeRelationEnum::hyphen; }
+            return TimeRelationEnum::parentheses;
+        }
+
+        std::string toString( const TimeRelationEnum value )
+        {
+            switch ( value )
+            {
+                case TimeRelationEnum::parentheses: { return "parentheses"; }
+                case TimeRelationEnum::bracket: { return "bracket"; }
+                case TimeRelationEnum::equals: { return "equals"; }
+                case TimeRelationEnum::slash: { return "slash"; }
+                case TimeRelationEnum::space: { return "space"; }
+                case TimeRelationEnum::hyphen: { return "hyphen"; }
+                default: break;
+            }
+            return "parentheses";
+        }
+
+        std::ostream& toStream( std::ostream& os, const TimeRelationEnum value )
+        {
+            return os << toString( value );
+        }
+
+        std::ostream& operator<<( std::ostream& os, const TimeRelationEnum value )
+        {
+            return toStream( os, value );
+        }
+
+        /// TimeSeparator //////////////////////////////////////////////////////////////////////////
+
+        TimeSeparator parseTimeSeparator( const std::string& value )
+        {
+            if ( value == "none" ) { return TimeSeparator::none; }
+            else if ( value == "horizontal" ) { return TimeSeparator::horizontal; }
+            else if ( value == "diagonal" ) { return TimeSeparator::diagonal; }
+            else if ( value == "vertical" ) { return TimeSeparator::vertical; }
+            else if ( value == "adjacent" ) { return TimeSeparator::adjacent; }
+            return TimeSeparator::none;
+        }
+
+        std::string toString( const TimeSeparator value )
+        {
+            switch ( value )
+            {
+                case TimeSeparator::none: { return "none"; }
+                case TimeSeparator::horizontal: { return "horizontal"; }
+                case TimeSeparator::diagonal: { return "diagonal"; }
+                case TimeSeparator::vertical: { return "vertical"; }
+                case TimeSeparator::adjacent: { return "adjacent"; }
+                default: break;
+            }
+            return "none";
+        }
+
+        std::ostream& toStream( std::ostream& os, const TimeSeparator value )
+        {
+            return os << toString( value );
+        }
+
+        std::ostream& operator<<( std::ostream& os, const TimeSeparator value )
+        {
+            return toStream( os, value );
+        }
+
+        /// TimeSymbol /////////////////////////////////////////////////////////////////////////////
+
+        TimeSymbol parseTimeSymbol( const std::string& value )
+        {
+            if ( value == "common" ) { return TimeSymbol::common; }
+            else if ( value == "cut" ) { return TimeSymbol::cut; }
+            else if ( value == "single-number" ) { return TimeSymbol::singleNumber; }
+            else if ( value == "note" ) { return TimeSymbol::note; }
+            else if ( value == "dotted-note" ) { return TimeSymbol::dottedNote; }
+            else if ( value == "normal" ) { return TimeSymbol::normal; }
+            return TimeSymbol::common;
+        }
+
+        std::string toString( const TimeSymbol value )
+        {
+            switch ( value )
+            {
+                case TimeSymbol::common: { return "common"; }
+                case TimeSymbol::cut: { return "cut"; }
+                case TimeSymbol::singleNumber: { return "single-number"; }
+                case TimeSymbol::note: { return "note"; }
+                case TimeSymbol::dottedNote: { return "dotted-note"; }
+                case TimeSymbol::normal: { return "normal"; }
+                default: break;
+            }
+            return "common";
+        }
+
+        std::ostream& toStream( std::ostream& os, const TimeSymbol value )
+        {
+            return os << toString( value );
+        }
+
+        std::ostream& operator<<( std::ostream& os, const TimeSymbol value )
+        {
+            return toStream( os, value );
+        }
+
+        /// TipDirection ///////////////////////////////////////////////////////////////////////////
+
+        TipDirection parseTipDirection( const std::string& value )
+        {
+            if ( value == "up" ) { return TipDirection::up; }
+            else if ( value == "down" ) { return TipDirection::down; }
+            else if ( value == "left" ) { return TipDirection::left; }
+            else if ( value == "right" ) { return TipDirection::right; }
+            else if ( value == "northwest" ) { return TipDirection::northwest; }
+            else if ( value == "northeast" ) { return TipDirection::northeast; }
+            else if ( value == "southeast" ) { return TipDirection::southeast; }
+            else if ( value == "southwest" ) { return TipDirection::southwest; }
+            return TipDirection::up;
+        }
+
+        std::string toString( const TipDirection value )
+        {
+            switch ( value )
+            {
+                case TipDirection::up: { return "up"; }
+                case TipDirection::down: { return "down"; }
+                case TipDirection::left: { return "left"; }
+                case TipDirection::right: { return "right"; }
+                case TipDirection::northwest: { return "northwest"; }
+                case TipDirection::northeast: { return "northeast"; }
+                case TipDirection::southeast: { return "southeast"; }
+                case TipDirection::southwest: { return "southwest"; }
+                default: break;
+            }
+            return "up";
+        }
+
+        std::ostream& toStream( std::ostream& os, const TipDirection value )
+        {
+            return os << toString( value );
+        }
+
+        std::ostream& operator<<( std::ostream& os, const TipDirection value )
+        {
+            return toStream( os, value );
+        }
+
+        /// TopBottom //////////////////////////////////////////////////////////////////////////////
+
+        TopBottom parseTopBottom( const std::string& value )
+        {
+            if ( value == "top" ) { return TopBottom::top; }
+            else if ( value == "bottom" ) { return TopBottom::bottom; }
+            return TopBottom::top;
+        }
+
+        std::string toString( const TopBottom value )
+        {
+            switch ( value )
+            {
+                case TopBottom::top: { return "top"; }
+                case TopBottom::bottom: { return "bottom"; }
+                default: break;
+            }
+            return "top";
+        }
+
+        std::ostream& toStream( std::ostream& os, const TopBottom value )
+        {
+            return os << toString( value );
+        }
+
+        std::ostream& operator<<( std::ostream& os, const TopBottom value )
+        {
+            return toStream( os, value );
+        }
+
+        /// TrillStep //////////////////////////////////////////////////////////////////////////////
+
+        TrillStep parseTrillStep( const std::string& value )
+        {
+            if ( value == "whole" ) { return TrillStep::whole; }
+            else if ( value == "half" ) { return TrillStep::half; }
+            else if ( value == "unison" ) { return TrillStep::unison; }
+            return TrillStep::whole;
+        }
+
+        std::string toString( const TrillStep value )
+        {
+            switch ( value )
+            {
+                case TrillStep::whole: { return "whole"; }
+                case TrillStep::half: { return "half"; }
+                case TrillStep::unison: { return "unison"; }
+                default: break;
+            }
+            return "whole";
+        }
+
+        std::ostream& toStream( std::ostream& os, const TrillStep value )
+        {
+            return os << toString( value );
+        }
+
+        std::ostream& operator<<( std::ostream& os, const TrillStep value )
+        {
+            return toStream( os, value );
+        }
+
+        /// TwoNoteTurn ////////////////////////////////////////////////////////////////////////////
+
+        TwoNoteTurn parseTwoNoteTurn( const std::string& value )
+        {
+            if ( value == "whole" ) { return TwoNoteTurn::whole; }
+            else if ( value == "half" ) { return TwoNoteTurn::half; }
+            else if ( value == "none" ) { return TwoNoteTurn::none; }
+            return TwoNoteTurn::whole;
+        }
+
+        std::string toString( const TwoNoteTurn value )
+        {
+            switch ( value )
+            {
+                case TwoNoteTurn::whole: { return "whole"; }
+                case TwoNoteTurn::half: { return "half"; }
+                case TwoNoteTurn::none: { return "none"; }
+                default: break;
+            }
+            return "whole";
+        }
+
+        std::ostream& toStream( std::ostream& os, const TwoNoteTurn value )
+        {
+            return os << toString( value );
+        }
+
+        std::ostream& operator<<( std::ostream& os, const TwoNoteTurn value )
+        {
+            return toStream( os, value );
+        }
+
+        /// UpDown /////////////////////////////////////////////////////////////////////////////////
+
+        UpDown parseUpDown( const std::string& value )
+        {
+            if ( value == "up" ) { return UpDown::up; }
+            else if ( value == "down" ) { return UpDown::down; }
+            return UpDown::up;
+        }
+
+        std::string toString( const UpDown value )
+        {
+            switch ( value )
+            {
+                case UpDown::up: { return "up"; }
+                case UpDown::down: { return "down"; }
+                default: break;
+            }
+            return "up";
+        }
+
+        std::ostream& toStream( std::ostream& os, const UpDown value )
+        {
+            return os << toString( value );
+        }
+
+        std::ostream& operator<<( std::ostream& os, const UpDown value )
+        {
+            return toStream( os, value );
+        }
+
+        /// UpDownStopContinue /////////////////////////////////////////////////////////////////////
+
+        UpDownStopContinue parseUpDownStopContinue( const std::string& value )
+        {
+            if ( value == "up" ) { return UpDownStopContinue::up; }
+            else if ( value == "down" ) { return UpDownStopContinue::down; }
+            else if ( value == "stop" ) { return UpDownStopContinue::stop; }
+            else if ( value == "continue" ) { return UpDownStopContinue::continue_; }
+            return UpDownStopContinue::up;
+        }
+
+        std::string toString( const UpDownStopContinue value )
+        {
+            switch ( value )
+            {
+                case UpDownStopContinue::up: { return "up"; }
+                case UpDownStopContinue::down: { return "down"; }
+                case UpDownStopContinue::stop: { return "stop"; }
+                case UpDownStopContinue::continue_: { return "continue"; }
+                default: break;
+            }
+            return "up";
+        }
+
+        std::ostream& toStream( std::ostream& os, const UpDownStopContinue value )
+        {
+            return os << toString( value );
+        }
+
+        std::ostream& operator<<( std::ostream& os, const UpDownStopContinue value )
+        {
+            return toStream( os, value );
+        }
+
+        /// UprightInverted ////////////////////////////////////////////////////////////////////////
+
+        UprightInverted parseUprightInverted( const std::string& value )
+        {
+            if ( value == "upright" ) { return UprightInverted::upright; }
+            else if ( value == "inverted" ) { return UprightInverted::inverted; }
+            return UprightInverted::upright;
+        }
+
+        std::string toString( const UprightInverted value )
+        {
+            switch ( value )
+            {
+                case UprightInverted::upright: { return "upright"; }
+                case UprightInverted::inverted: { return "inverted"; }
+                default: break;
+            }
+            return "upright";
+        }
+
+        std::ostream& toStream( std::ostream& os, const UprightInverted value )
+        {
+            return os << toString( value );
+        }
+
+        std::ostream& operator<<( std::ostream& os, const UprightInverted value )
+        {
+            return toStream( os, value );
+        }
+
+        /// Valign /////////////////////////////////////////////////////////////////////////////////
+
+        Valign parseValign( const std::string& value )
+        {
+            if ( value == "top" ) { return Valign::top; }
+            else if ( value == "middle" ) { return Valign::middle; }
+            else if ( value == "bottom" ) { return Valign::bottom; }
+            else if ( value == "baseline" ) { return Valign::baseline; }
+            return Valign::top;
+        }
+
+        std::string toString( const Valign value )
+        {
+            switch ( value )
+            {
+                case Valign::top: { return "top"; }
+                case Valign::middle: { return "middle"; }
+                case Valign::bottom: { return "bottom"; }
+                case Valign::baseline: { return "baseline"; }
+                default: break;
+            }
+            return "top";
+        }
+
+        std::ostream& toStream( std::ostream& os, const Valign value )
+        {
+            return os << toString( value );
+        }
+
+        std::ostream& operator<<( std::ostream& os, const Valign value )
+        {
+            return toStream( os, value );
+        }
+
+        /// ValignImage ////////////////////////////////////////////////////////////////////////////
+
+        ValignImage parseValignImage( const std::string& value )
+        {
+            if ( value == "top" ) { return ValignImage::top; }
+            else if ( value == "middle" ) { return ValignImage::middle; }
+            else if ( value == "bottom" ) { return ValignImage::bottom; }
+            return ValignImage::top;
+        }
+
+        std::string toString( const ValignImage value )
+        {
+            switch ( value )
+            {
+                case ValignImage::top: { return "top"; }
+                case ValignImage::middle: { return "middle"; }
+                case ValignImage::bottom: { return "bottom"; }
+                default: break;
+            }
+            return "top";
+        }
+
+        std::ostream& toStream( std::ostream& os, const ValignImage value )
+        {
+            return os << toString( value );
+        }
+
+        std::ostream& operator<<( std::ostream& os, const ValignImage value )
+        {
+            return toStream( os, value );
+        }
+
+        /// WedgeType //////////////////////////////////////////////////////////////////////////////
+
+        WedgeType parseWedgeType( const std::string& value )
+        {
+            if ( value == "crescendo" ) { return WedgeType::crescendo; }
+            else if ( value == "diminuendo" ) { return WedgeType::diminuendo; }
+            else if ( value == "stop" ) { return WedgeType::stop; }
+            else if ( value == "continue" ) { return WedgeType::continue_; }
+            return WedgeType::crescendo;
+        }
+
+        std::string toString( const WedgeType value )
+        {
+            switch ( value )
+            {
+                case WedgeType::crescendo: { return "crescendo"; }
+                case WedgeType::diminuendo: { return "diminuendo"; }
+                case WedgeType::stop: { return "stop"; }
+                case WedgeType::continue_: { return "continue"; }
+                default: break;
+            }
+            return "crescendo";
+        }
+
+        std::ostream& toStream( std::ostream& os, const WedgeType value )
+        {
+            return os << toString( value );
+        }
+
+        std::ostream& operator<<( std::ostream& os, const WedgeType value )
+        {
+            return toStream( os, value );
+        }
+
+        /// Winged /////////////////////////////////////////////////////////////////////////////////
+
+        Winged parseWinged( const std::string& value )
+        {
+            if ( value == "none" ) { return Winged::none; }
+            else if ( value == "straight" ) { return Winged::straight; }
+            else if ( value == "curved" ) { return Winged::curved; }
+            else if ( value == "double-straight" ) { return Winged::doubleStraight; }
+            else if ( value == "double-curved" ) { return Winged::doubleCurved; }
+            return Winged::none;
+        }
+
+        std::string toString( const Winged value )
+        {
+            switch ( value )
+            {
+                case Winged::none: { return "none"; }
+                case Winged::straight: { return "straight"; }
+                case Winged::curved: { return "curved"; }
+                case Winged::doubleStraight: { return "double-straight"; }
+                case Winged::doubleCurved: { return "double-curved"; }
+                default: break;
+            }
+            return "none";
+        }
+
+        std::ostream& toStream( std::ostream& os, const Winged value )
+        {
+            return os << toString( value );
+        }
+
+        std::ostream& operator<<( std::ostream& os, const Winged value )
+        {
+            return toStream( os, value );
+        }
+
+        /// WoodEnum ///////////////////////////////////////////////////////////////////////////////
+
+        WoodEnum parseWoodEnum( const std::string& value )
+        {
+            if ( value == "board clapper" ) { return WoodEnum::boardClapper; }
+            else if ( value == "cabasa" ) { return WoodEnum::cabasa; }
+            else if ( value == "castanets" ) { return WoodEnum::castanets; }
+            else if ( value == "claves" ) { return WoodEnum::claves; }
+            else if ( value == "guiro" ) { return WoodEnum::guiro; }
+            else if ( value == "log drum" ) { return WoodEnum::logDrum; }
+            else if ( value == "maraca" ) { return WoodEnum::maraca; }
+            else if ( value == "maracas" ) { return WoodEnum::maracas; }
+            else if ( value == "ratchet" ) { return WoodEnum::ratchet; }
+            else if ( value == "sandpaper blocks" ) { return WoodEnum::sandpaperBlocks; }
+            else if ( value == "slit drum" ) { return WoodEnum::slitDrum; }
+            else if ( value == "temple block" ) { return WoodEnum::templeBlock; }
+            else if ( value == "vibraslap" ) { return WoodEnum::vibraslap; }
+            else if ( value == "wood block" ) { return WoodEnum::woodBlock; }
+            return WoodEnum::boardClapper;
+        }
+
+        std::string toString( const WoodEnum value )
+        {
+            switch ( value )
+            {
+                case WoodEnum::boardClapper: { return "board clapper"; }
+                case WoodEnum::cabasa: { return "cabasa"; }
+                case WoodEnum::castanets: { return "castanets"; }
+                case WoodEnum::claves: { return "claves"; }
+                case WoodEnum::guiro: { return "guiro"; }
+                case WoodEnum::logDrum: { return "log drum"; }
+                case WoodEnum::maraca: { return "maraca"; }
+                case WoodEnum::maracas: { return "maracas"; }
+                case WoodEnum::ratchet: { return "ratchet"; }
+                case WoodEnum::sandpaperBlocks: { return "sandpaper blocks"; }
+                case WoodEnum::slitDrum: { return "slit drum"; }
+                case WoodEnum::templeBlock: { return "temple block"; }
+                case WoodEnum::vibraslap: { return "vibraslap"; }
+                case WoodEnum::woodBlock: { return "wood block"; }
+                default: break;
+            }
+            return "board clapper";
+        }
+
+        std::ostream& toStream( std::ostream& os, const WoodEnum value )
+        {
+            return os << toString( value );
+        }
+
+        std::ostream& operator<<( std::ostream& os, const WoodEnum value )
+        {
+            return toStream( os, value );
+        }
+
+        /// YesNo //////////////////////////////////////////////////////////////////////////////////
+
+        YesNo parseYesNo( const std::string& value )
+        {
+            if ( value == "yes" ) { return YesNo::yes; }
+            else if ( value == "no" ) { return YesNo::no; }
+            return YesNo::yes;
+        }
+
+        std::string toString( const YesNo value )
+        {
+            switch ( value )
+            {
+                case YesNo::yes: { return "yes"; }
+                case YesNo::no: { return "no"; }
+                default: break;
+            }
+            return "yes";
+        }
+
+        std::ostream& toStream( std::ostream& os, const YesNo value )
+        {
+            return os << toString( value );
+        }
+
+        std::ostream& operator<<( std::ostream& os, const YesNo value )
+        {
+            return toStream( os, value );
+        }
+    }
+}

--- a/Sourcecode/private/mx/core/Enums.h
+++ b/Sourcecode/private/mx/core/Enums.h
@@ -4,1205 +4,383 @@
 
 #pragma once
 
-#include <iostream>
-#include <string>
+#include "mx/core/EnumsBuiltin.h"
 
 namespace mx
 {
-	namespace core
-	{
-		enum class AboveBelow
-		{
-			above = 0,
-			below = 1
-		};
-		AboveBelow parseAboveBelow( const std::string& value );
-		std::string toString( const AboveBelow value );
-		std::ostream& toStream( std::ostream& os, const AboveBelow value );
-		std::ostream& operator<<( std::ostream& os, const AboveBelow value );
-
-		enum class CssFontSize
-		{
-			xxSmall = 0,
-			xSmall = 1,
-			small = 2,
-			medium = 3,
-			large = 4,
-			xLarge = 5,
-			xxLarge = 6
-		};
-		CssFontSize parseCssFontSize( const std::string& value );
-		std::string toString( const CssFontSize value );
-		std::ostream& toStream( std::ostream& os, const CssFontSize value );
-		std::ostream& operator<<( std::ostream& os, const CssFontSize value );
-
-		enum class EnclosureShape
-		{
-			rectangle = 0,
-			square = 1,
-			oval = 2,
-			circle = 3,
-			bracket = 4,
-			triangle = 5,
-			diamond = 6,
-			none = 7
-		};
-		EnclosureShape parseEnclosureShape( const std::string& value );
-		std::string toString( const EnclosureShape value );
-		std::ostream& toStream( std::ostream& os, const EnclosureShape value );
-		std::ostream& operator<<( std::ostream& os, const EnclosureShape value );
-
-		enum class FermataShape
-		{
-			normal = 0,
-			angled = 1,
-			square = 2,
-			emptystring = 3
-		};
-		FermataShape parseFermataShape( const std::string& value );
-		std::string toString( const FermataShape value );
-		std::ostream& toStream( std::ostream& os, const FermataShape value );
-		std::ostream& operator<<( std::ostream& os, const FermataShape value );
-
-		enum class FontStyle
-		{
-			normal = 0,
-			italic = 1
-		};
-		FontStyle parseFontStyle( const std::string& value );
-		std::string toString( const FontStyle value );
-		std::ostream& toStream( std::ostream& os, const FontStyle value );
-		std::ostream& operator<<( std::ostream& os, const FontStyle value );
-
-		enum class FontWeight
-		{
-			normal = 0,
-			bold = 1
-		};
-		FontWeight parseFontWeight( const std::string& value );
-		std::string toString( const FontWeight value );
-		std::ostream& toStream( std::ostream& os, const FontWeight value );
-		std::ostream& operator<<( std::ostream& os, const FontWeight value );
-
-		enum class LeftCenterRight
-		{
-			left = 0,
-			center = 1,
-			right = 2
-		};
-		LeftCenterRight parseLeftCenterRight( const std::string& value );
-		std::string toString( const LeftCenterRight value );
-		std::ostream& toStream( std::ostream& os, const LeftCenterRight value );
-		std::ostream& operator<<( std::ostream& os, const LeftCenterRight value );
-
-		enum class LeftRight
-		{
-			left = 0,
-			right = 1
-		};
-		LeftRight parseLeftRight( const std::string& value );
-		std::string toString( const LeftRight value );
-		std::ostream& toStream( std::ostream& os, const LeftRight value );
-		std::ostream& operator<<( std::ostream& os, const LeftRight value );
-
-		enum class LineShape
-		{
-			straight = 0,
-			curved = 1
-		};
-		LineShape parseLineShape( const std::string& value );
-		std::string toString( const LineShape value );
-		std::ostream& toStream( std::ostream& os, const LineShape value );
-		std::ostream& operator<<( std::ostream& os, const LineShape value );
-
-		enum class LineType
-		{
-			solid = 0,
-			dashed = 1,
-			dotted = 2,
-			wavy = 3
-		};
-		LineType parseLineType( const std::string& value );
-		std::string toString( const LineType value );
-		std::ostream& toStream( std::ostream& os, const LineType value );
-		std::ostream& operator<<( std::ostream& os, const LineType value );
-
-		enum class MuteEnum
-		{
-			on = 0,
-			off = 1,
-			straight = 2,
-			cup = 3,
-			harmonNoStem = 4,
-			harmonStem = 5,
-			bucket = 6,
-			plunger = 7,
-			hat = 8,
-			solotone = 9,
-			practice = 10,
-			stopMute = 11,
-			stopHand = 12,
-			echo = 13,
-			palm = 14
-		};
-		MuteEnum parseMuteEnum( const std::string& value );
-		std::string toString( const MuteEnum value );
-		std::ostream& toStream( std::ostream& os, const MuteEnum value );
-		std::ostream& operator<<( std::ostream& os, const MuteEnum value );
-
-		enum class OverUnder
-		{
-			over = 0,
-			under = 1
-		};
-		OverUnder parseOverUnder( const std::string& value );
-		std::string toString( const OverUnder value );
-		std::ostream& toStream( std::ostream& os, const OverUnder value );
-		std::ostream& operator<<( std::ostream& os, const OverUnder value );
-
-		enum class SemiPitchedEnum
-		{
-			high = 0,
-			mediumHigh = 1,
-			medium = 2,
-			mediumLow = 3,
-			low = 4,
-			veryLow = 5
-		};
-		SemiPitchedEnum parseSemiPitchedEnum( const std::string& value );
-		std::string toString( const SemiPitchedEnum value );
-		std::ostream& toStream( std::ostream& os, const SemiPitchedEnum value );
-		std::ostream& operator<<( std::ostream& os, const SemiPitchedEnum value );
-
-		enum class StartNote
-		{
-			upper = 0,
-			main = 1,
-			below = 2
-		};
-		StartNote parseStartNote( const std::string& value );
-		std::string toString( const StartNote value );
-		std::ostream& toStream( std::ostream& os, const StartNote value );
-		std::ostream& operator<<( std::ostream& os, const StartNote value );
-
-		enum class StartStop
-		{
-			start = 0,
-			stop = 1
-		};
-		StartStop parseStartStop( const std::string& value );
-		std::string toString( const StartStop value );
-		std::ostream& toStream( std::ostream& os, const StartStop value );
-		std::ostream& operator<<( std::ostream& os, const StartStop value );
-
-		enum class StartStopContinue
-		{
-			start = 0,
-			stop = 1,
-			continue_ = 2
-		};
-		StartStopContinue parseStartStopContinue( const std::string& value );
-		std::string toString( const StartStopContinue value );
-		std::ostream& toStream( std::ostream& os, const StartStopContinue value );
-		std::ostream& operator<<( std::ostream& os, const StartStopContinue value );
-
-		enum class StartStopSingle
-		{
-			start = 0,
-			stop = 1,
-			single = 2
-		};
-		StartStopSingle parseStartStopSingle( const std::string& value );
-		std::string toString( const StartStopSingle value );
-		std::ostream& toStream( std::ostream& os, const StartStopSingle value );
-		std::ostream& operator<<( std::ostream& os, const StartStopSingle value );
-
-		enum class SymbolSize
-		{
-			full = 0,
-			cue = 1,
-			large = 2
-		};
-		SymbolSize parseSymbolSize( const std::string& value );
-		std::string toString( const SymbolSize value );
-		std::ostream& toStream( std::ostream& os, const SymbolSize value );
-		std::ostream& operator<<( std::ostream& os, const SymbolSize value );
-
-		enum class TextDirection
-		{
-			ltr = 0,
-			rtl = 1,
-			lro = 2,
-			rlo = 3
-		};
-		TextDirection parseTextDirection( const std::string& value );
-		std::string toString( const TextDirection value );
-		std::ostream& toStream( std::ostream& os, const TextDirection value );
-		std::ostream& operator<<( std::ostream& os, const TextDirection value );
-
-		enum class TopBottom
-		{
-			top = 0,
-			bottom = 1
-		};
-		TopBottom parseTopBottom( const std::string& value );
-		std::string toString( const TopBottom value );
-		std::ostream& toStream( std::ostream& os, const TopBottom value );
-		std::ostream& operator<<( std::ostream& os, const TopBottom value );
-
-		enum class TrillStep
-		{
-			whole = 0,
-			half = 1,
-			unison = 2
-		};
-		TrillStep parseTrillStep( const std::string& value );
-		std::string toString( const TrillStep value );
-		std::ostream& toStream( std::ostream& os, const TrillStep value );
-		std::ostream& operator<<( std::ostream& os, const TrillStep value );
-
-		enum class TwoNoteTurn
-		{
-			whole = 0,
-			half = 1,
-			none = 2
-		};
-		TwoNoteTurn parseTwoNoteTurn( const std::string& value );
-		std::string toString( const TwoNoteTurn value );
-		std::ostream& toStream( std::ostream& os, const TwoNoteTurn value );
-		std::ostream& operator<<( std::ostream& os, const TwoNoteTurn value );
-
-		enum class UpDown
-		{
-			up = 0,
-			down = 1
-		};
-		UpDown parseUpDown( const std::string& value );
-		std::string toString( const UpDown value );
-		std::ostream& toStream( std::ostream& os, const UpDown value );
-		std::ostream& operator<<( std::ostream& os, const UpDown value );
-
-		enum class UprightInverted
-		{
-			upright = 0,
-			inverted = 1
-		};
-		UprightInverted parseUprightInverted( const std::string& value );
-		std::string toString( const UprightInverted value );
-		std::ostream& toStream( std::ostream& os, const UprightInverted value );
-		std::ostream& operator<<( std::ostream& os, const UprightInverted value );
-
-		enum class Valign
-		{
-			top = 0,
-			middle = 1,
-			bottom = 2,
-			baseline = 3
-		};
-		Valign parseValign( const std::string& value );
-		std::string toString( const Valign value );
-		std::ostream& toStream( std::ostream& os, const Valign value );
-		std::ostream& operator<<( std::ostream& os, const Valign value );
-
-		enum class ValignImage
-		{
-			top = 0,
-			middle = 1,
-			bottom = 2
-		};
-		ValignImage parseValignImage( const std::string& value );
-		std::string toString( const ValignImage value );
-		std::ostream& toStream( std::ostream& os, const ValignImage value );
-		std::ostream& operator<<( std::ostream& os, const ValignImage value );
-
-		enum class YesNo
-		{
-			yes = 0,
-			no = 1
-		};
-		YesNo parseYesNo( const std::string& value );
-		std::string toString( const YesNo value );
-		std::ostream& toStream( std::ostream& os, const YesNo value );
-		std::ostream& operator<<( std::ostream& os, const YesNo value );
-
-		enum class CancelLocation
-		{
-			left = 0,
-			right = 1,
-			beforeBarline = 2
-		};
-		CancelLocation parseCancelLocation( const std::string& value );
-		std::string toString( const CancelLocation value );
-		std::ostream& toStream( std::ostream& os, const CancelLocation value );
-		std::ostream& operator<<( std::ostream& os, const CancelLocation value );
-
-		enum class ClefSign
-		{
-			g = 0,
-			f = 1,
-			c = 2,
-			percussion = 3,
-			tab = 4,
-			jianpu = 5,
-			none = 6
-		};
-		ClefSign parseClefSign( const std::string& value );
-		std::string toString( const ClefSign value );
-		std::ostream& toStream( std::ostream& os, const ClefSign value );
-		std::ostream& operator<<( std::ostream& os, const ClefSign value );
-
-		enum class ShowFrets
-		{
-			numbers = 0,
-			letters = 1
-		};
-		ShowFrets parseShowFrets( const std::string& value );
-		std::string toString( const ShowFrets value );
-		std::ostream& toStream( std::ostream& os, const ShowFrets value );
-		std::ostream& operator<<( std::ostream& os, const ShowFrets value );
-
-		enum class StaffTypeEnum
-		{
-			ossia = 0,
-			cue = 1,
-			editorial = 2,
-			regular = 3,
-			alternate = 4
-		};
-		StaffTypeEnum parseStaffTypeEnum( const std::string& value );
-		std::string toString( const StaffTypeEnum value );
-		std::ostream& toStream( std::ostream& os, const StaffTypeEnum value );
-		std::ostream& operator<<( std::ostream& os, const StaffTypeEnum value );
-
-		enum class TimeRelationEnum
-		{
-			parentheses = 0,
-			bracket = 1,
-			equals = 2,
-			slash = 3,
-			space = 4,
-			hyphen = 5
-		};
-		TimeRelationEnum parseTimeRelationEnum( const std::string& value );
-		std::string toString( const TimeRelationEnum value );
-		std::ostream& toStream( std::ostream& os, const TimeRelationEnum value );
-		std::ostream& operator<<( std::ostream& os, const TimeRelationEnum value );
-
-		enum class TimeSeparator
-		{
-			none = 0,
-			horizontal = 1,
-			diagonal = 2,
-			vertical = 3,
-			adjacent = 4
-		};
-		TimeSeparator parseTimeSeparator( const std::string& value );
-		std::string toString( const TimeSeparator value );
-		std::ostream& toStream( std::ostream& os, const TimeSeparator value );
-		std::ostream& operator<<( std::ostream& os, const TimeSeparator value );
-
-		enum class TimeSymbol
-		{
-			common = 0,
-			cut = 1,
-			singleNumber = 2,
-			note = 3,
-			dottedNote = 4,
-			normal = 5
-		};
-		TimeSymbol parseTimeSymbol( const std::string& value );
-		std::string toString( const TimeSymbol value );
-		std::ostream& toStream( std::ostream& os, const TimeSymbol value );
-		std::ostream& operator<<( std::ostream& os, const TimeSymbol value );
-
-		enum class BackwardForward
-		{
-			backward = 0,
-			forward = 1
-		};
-		BackwardForward parseBackwardForward( const std::string& value );
-		std::string toString( const BackwardForward value );
-		std::ostream& toStream( std::ostream& os, const BackwardForward value );
-		std::ostream& operator<<( std::ostream& os, const BackwardForward value );
-
-		enum class BarStyleEnum
-		{
-			regular = 0,
-			dotted = 1,
-			dashed = 2,
-			heavy = 3,
-			lightLight = 4,
-			lightHeavy = 5,
-			heavyLight = 6,
-			heavyHeavy = 7,
-			tick = 8,
-			short_ = 9,
-			none = 10
-		};
-		BarStyleEnum parseBarStyleEnum( const std::string& value );
-		std::string toString( const BarStyleEnum value );
-		std::ostream& toStream( std::ostream& os, const BarStyleEnum value );
-		std::ostream& operator<<( std::ostream& os, const BarStyleEnum value );
-
-		enum class RightLeftMiddle
-		{
-			right = 0,
-			left = 1,
-			middle = 2
-		};
-		RightLeftMiddle parseRightLeftMiddle( const std::string& value );
-		std::string toString( const RightLeftMiddle value );
-		std::ostream& toStream( std::ostream& os, const RightLeftMiddle value );
-		std::ostream& operator<<( std::ostream& os, const RightLeftMiddle value );
-
-		enum class StartStopDiscontinue
-		{
-			start = 0,
-			stop = 1,
-			discontinue = 2
-		};
-		StartStopDiscontinue parseStartStopDiscontinue( const std::string& value );
-		std::string toString( const StartStopDiscontinue value );
-		std::ostream& toStream( std::ostream& os, const StartStopDiscontinue value );
-		std::ostream& operator<<( std::ostream& os, const StartStopDiscontinue value );
-
-		enum class Winged
-		{
-			none = 0,
-			straight = 1,
-			curved = 2,
-			doubleStraight = 3,
-			doubleCurved = 4
-		};
-		Winged parseWinged( const std::string& value );
-		std::string toString( const Winged value );
-		std::ostream& toStream( std::ostream& os, const Winged value );
-		std::ostream& operator<<( std::ostream& os, const Winged value );
-
-		enum class BeaterValue
-		{
-			bow = 0,
-			chimeHammer = 1,
-			coin = 2,
-			finger = 3,
-			fingernail = 4,
-			fist = 5,
-			guiroScraper = 6,
-			hammer = 7,
-			hand = 8,
-			jazzStick = 9,
-			knittingNeedle = 10,
-			metalHammer = 11,
-			snareStick = 12,
-			spoonMallet = 13,
-			triangleBeater = 14,
-			triangleBeaterPlain = 15,
-			wireBrush = 16
-		};
-		BeaterValue parseBeaterValue( const std::string& value );
-		std::string toString( const BeaterValue value );
-		std::ostream& toStream( std::ostream& os, const BeaterValue value );
-		std::ostream& operator<<( std::ostream& os, const BeaterValue value );
-
-		enum class DegreeSymbolValue
-		{
-			major = 0,
-			minor = 1,
-			augmented = 2,
-			diminished = 3,
-			halfDiminished = 4
-		};
-		DegreeSymbolValue parseDegreeSymbolValue( const std::string& value );
-		std::string toString( const DegreeSymbolValue value );
-		std::ostream& toStream( std::ostream& os, const DegreeSymbolValue value );
-		std::ostream& operator<<( std::ostream& os, const DegreeSymbolValue value );
-
-		enum class DegreeTypeValue
-		{
-			add = 0,
-			alter = 1,
-			subtract = 2
-		};
-		DegreeTypeValue parseDegreeTypeValue( const std::string& value );
-		std::string toString( const DegreeTypeValue value );
-		std::ostream& toStream( std::ostream& os, const DegreeTypeValue value );
-		std::ostream& operator<<( std::ostream& os, const DegreeTypeValue value );
-
-		enum class EffectEnum
-		{
-			anvil = 0,
-			autoHorn = 1,
-			birdWhistle = 2,
-			cannon = 3,
-			duckCall = 4,
-			gunShot = 5,
-			klaxonHorn = 6,
-			lionsRoar = 7,
-			policeWhistle = 8,
-			siren = 9,
-			slideWhistle = 10,
-			thunderSheet = 11,
-			windMachine = 12,
-			windWhistle = 13
-		};
-		EffectEnum parseEffectEnum( const std::string& value );
-		std::string toString( const EffectEnum value );
-		std::ostream& toStream( std::ostream& os, const EffectEnum value );
-		std::ostream& operator<<( std::ostream& os, const EffectEnum value );
-
-		enum class GlassEnum
-		{
-			windChimes = 0
-		};
-		GlassEnum parseGlassEnum( const std::string& value );
-		std::string toString( const GlassEnum value );
-		std::ostream& toStream( std::ostream& os, const GlassEnum value );
-		std::ostream& operator<<( std::ostream& os, const GlassEnum value );
-
-		enum class HarmonyType
-		{
-			explicit_ = 0,
-			implied = 1,
-			alternate = 2
-		};
-		HarmonyType parseHarmonyType( const std::string& value );
-		std::string toString( const HarmonyType value );
-		std::ostream& toStream( std::ostream& os, const HarmonyType value );
-		std::ostream& operator<<( std::ostream& os, const HarmonyType value );
-
-		enum class KindValue
-		{
-			major = 0,
-			minor = 1,
-			augmented = 2,
-			diminished = 3,
-			dominant = 4,
-			majorSeventh = 5,
-			minorSeventh = 6,
-			diminishedSeventh = 7,
-			augmentedSeventh = 8,
-			halfDiminished = 9,
-			majorMinor = 10,
-			majorSixth = 11,
-			minorSixth = 12,
-			dominantNinth = 13,
-			majorNinth = 14,
-			minorNinth = 15,
-			dominant11Th = 16,
-			major11Th = 17,
-			minor11Th = 18,
-			dominant13Th = 19,
-			major13Th = 20,
-			minor13Th = 21,
-			suspendedSecond = 22,
-			suspendedFourth = 23,
-			neapolitan = 24,
-			italian = 25,
-			french = 26,
-			german = 27,
-			pedal = 28,
-			power = 29,
-			tristan = 30,
-			other = 31,
-			none = 32
-		};
-		KindValue parseKindValue( const std::string& value );
-		std::string toString( const KindValue value );
-		std::ostream& toStream( std::ostream& os, const KindValue value );
-		std::ostream& operator<<( std::ostream& os, const KindValue value );
-
-		enum class LineEnd
-		{
-			up = 0,
-			down = 1,
-			both = 2,
-			arrow = 3,
-			none = 4
-		};
-		LineEnd parseLineEnd( const std::string& value );
-		std::string toString( const LineEnd value );
-		std::ostream& toStream( std::ostream& os, const LineEnd value );
-		std::ostream& operator<<( std::ostream& os, const LineEnd value );
-
-		enum class MeasureNumberingValue
-		{
-			none = 0,
-			measure = 1,
-			system = 2
-		};
-		MeasureNumberingValue parseMeasureNumberingValue( const std::string& value );
-		std::string toString( const MeasureNumberingValue value );
-		std::ostream& toStream( std::ostream& os, const MeasureNumberingValue value );
-		std::ostream& operator<<( std::ostream& os, const MeasureNumberingValue value );
-
-		enum class MembraneEnum
-		{
-			bassDrum = 0,
-			bassDrumOnSide = 1,
-			bongos = 2,
-			congaDrum = 3,
-			gobletDrum = 4,
-			militaryDrum = 5,
-			snareDrum = 6,
-			snareDrumSnaresOff = 7,
-			tambourine = 8,
-			tenorDrum = 9,
-			timbales = 10,
-			tomtom = 11
-		};
-		MembraneEnum parseMembraneEnum( const std::string& value );
-		std::string toString( const MembraneEnum value );
-		std::ostream& toStream( std::ostream& os, const MembraneEnum value );
-		std::ostream& operator<<( std::ostream& os, const MembraneEnum value );
-
-		enum class MetalEnum
-		{
-			almglocken = 0,
-			bell = 1,
-			bellPlate = 2,
-			brakeDrum = 3,
-			chineseCymbal = 4,
-			cowbell = 5,
-			crashCymbals = 6,
-			crotale = 7,
-			cymbalTongs = 8,
-			domedGong = 9,
-			fingerCymbals = 10,
-			flexatone = 11,
-			gong = 12,
-			hiHat = 13,
-			highHatCymbals = 14,
-			handbell = 15,
-			sistrum = 16,
-			sizzleCymbal = 17,
-			sleighBells = 18,
-			suspendedCymbal = 19,
-			tamTam = 20,
-			triangle = 21,
-			vietnameseHat = 22
-		};
-		MetalEnum parseMetalEnum( const std::string& value );
-		std::string toString( const MetalEnum value );
-		std::ostream& toStream( std::ostream& os, const MetalEnum value );
-		std::ostream& operator<<( std::ostream& os, const MetalEnum value );
-
-		enum class OnOff
-		{
-			on = 0,
-			off = 1
-		};
-		OnOff parseOnOff( const std::string& value );
-		std::string toString( const OnOff value );
-		std::ostream& toStream( std::ostream& os, const OnOff value );
-		std::ostream& operator<<( std::ostream& os, const OnOff value );
-
-		enum class PitchedEnum
-		{
-			chimes = 0,
-			glockenspiel = 1,
-			mallet = 2,
-			marimba = 3,
-			tubularChimes = 4,
-			vibraphone = 5,
-			xylophone = 6
-		};
-		PitchedEnum parsePitchedEnum( const std::string& value );
-		std::string toString( const PitchedEnum value );
-		std::ostream& toStream( std::ostream& os, const PitchedEnum value );
-		std::ostream& operator<<( std::ostream& os, const PitchedEnum value );
-
-		enum class PrincipalVoiceSymbol
-		{
-			hauptstimme = 0,
-			nebenstimme = 1,
-			plain = 2,
-			none = 3
-		};
-		PrincipalVoiceSymbol parsePrincipalVoiceSymbol( const std::string& value );
-		std::string toString( const PrincipalVoiceSymbol value );
-		std::ostream& toStream( std::ostream& os, const PrincipalVoiceSymbol value );
-		std::ostream& operator<<( std::ostream& os, const PrincipalVoiceSymbol value );
-
-		enum class StartStopChangeContinue
-		{
-			start = 0,
-			stop = 1,
-			change = 2,
-			continue_ = 3
-		};
-		StartStopChangeContinue parseStartStopChangeContinue( const std::string& value );
-		std::string toString( const StartStopChangeContinue value );
-		std::ostream& toStream( std::ostream& os, const StartStopChangeContinue value );
-		std::ostream& operator<<( std::ostream& os, const StartStopChangeContinue value );
-
-		enum class TipDirection
-		{
-			up = 0,
-			down = 1,
-			left = 2,
-			right = 3,
-			northwest = 4,
-			northeast = 5,
-			southeast = 6,
-			southwest = 7
-		};
-		TipDirection parseTipDirection( const std::string& value );
-		std::string toString( const TipDirection value );
-		std::ostream& toStream( std::ostream& os, const TipDirection value );
-		std::ostream& operator<<( std::ostream& os, const TipDirection value );
-
-		enum class StickLocationEnum
-		{
-			center = 0,
-			rim = 1,
-			cymbalBell = 2,
-			cymbalEdge = 3
-		};
-		StickLocationEnum parseStickLocationEnum( const std::string& value );
-		std::string toString( const StickLocationEnum value );
-		std::ostream& toStream( std::ostream& os, const StickLocationEnum value );
-		std::ostream& operator<<( std::ostream& os, const StickLocationEnum value );
-
-		enum class StickMaterialEnum
-		{
-			soft = 0,
-			medium = 1,
-			hard = 2,
-			shaded = 3,
-			x = 4
-		};
-		StickMaterialEnum parseStickMaterialEnum( const std::string& value );
-		std::string toString( const StickMaterialEnum value );
-		std::ostream& toStream( std::ostream& os, const StickMaterialEnum value );
-		std::ostream& operator<<( std::ostream& os, const StickMaterialEnum value );
-
-		enum class StickTypeEnum
-		{
-			bassDrum = 0,
-			doubleBassDrum = 1,
-			timpani = 2,
-			xylophone = 3,
-			yarn = 4
-		};
-		StickTypeEnum parseStickTypeEnum( const std::string& value );
-		std::string toString( const StickTypeEnum value );
-		std::ostream& toStream( std::ostream& os, const StickTypeEnum value );
-		std::ostream& operator<<( std::ostream& os, const StickTypeEnum value );
-
-		enum class UpDownStopContinue
-		{
-			up = 0,
-			down = 1,
-			stop = 2,
-			continue_ = 3
-		};
-		UpDownStopContinue parseUpDownStopContinue( const std::string& value );
-		std::string toString( const UpDownStopContinue value );
-		std::ostream& toStream( std::ostream& os, const UpDownStopContinue value );
-		std::ostream& operator<<( std::ostream& os, const UpDownStopContinue value );
-
-		enum class WedgeType
-		{
-			crescendo = 0,
-			diminuendo = 1,
-			stop = 2,
-			continue_ = 3
-		};
-		WedgeType parseWedgeType( const std::string& value );
-		std::string toString( const WedgeType value );
-		std::ostream& toStream( std::ostream& os, const WedgeType value );
-		std::ostream& operator<<( std::ostream& os, const WedgeType value );
-
-		enum class WoodEnum
-		{
-			boardClapper = 0,
-			cabasa = 1,
-			castanets = 2,
-			claves = 3,
-			guiro = 4,
-			logDrum = 5,
-			maraca = 6,
-			maracas = 7,
-			ratchet = 8,
-			sandpaperBlocks = 9,
-			slitDrum = 10,
-			templeBlock = 11,
-			vibraslap = 12,
-			woodBlock = 13
-		};
-		WoodEnum parseWoodEnum( const std::string& value );
-		std::string toString( const WoodEnum value );
-		std::ostream& toStream( std::ostream& os, const WoodEnum value );
-		std::ostream& operator<<( std::ostream& os, const WoodEnum value );
-
-		enum class MarginType
-		{
-			odd = 0,
-			even = 1,
-			both = 2
-		};
-		MarginType parseMarginType( const std::string& value );
-		std::string toString( const MarginType value );
-		std::ostream& toStream( std::ostream& os, const MarginType value );
-		std::ostream& operator<<( std::ostream& os, const MarginType value );
-
-		enum class NoteSizeType
-		{
-			cue = 0,
-			grace = 1,
-			large = 2
-		};
-		NoteSizeType parseNoteSizeType( const std::string& value );
-		std::string toString( const NoteSizeType value );
-		std::ostream& toStream( std::ostream& os, const NoteSizeType value );
-		std::ostream& operator<<( std::ostream& os, const NoteSizeType value );
-
-		enum class AccidentalValue
-		{
-			sharp = 0,
-			natural = 1,
-			flat = 2,
-			doubleSharp = 3,
-			sharpSharp = 4,
-			flatFlat = 5,
-			naturalSharp = 6,
-			naturalFlat = 7,
-			quarterFlat = 8,
-			quarterSharp = 9,
-			threeQuartersFlat = 10,
-			threeQuartersSharp = 11,
-			sharpDown = 12,
-			sharpUp = 13,
-			naturalDown = 14,
-			naturalUp = 15,
-			flatDown = 16,
-			flatUp = 17,
-			tripleSharp = 18,
-			tripleFlat = 19,
-			slashQuarterSharp = 20,
-			slashSharp = 21,
-			slashFlat = 22,
-			doubleSlashFlat = 23,
-			sharp1 = 24,
-			sharp2 = 25,
-			sharp3 = 26,
-			sharp5 = 27,
-			flat1 = 28,
-			flat2 = 29,
-			flat3 = 30,
-			flat4 = 31,
-			sori = 32,
-			koron = 33
-		};
-		AccidentalValue parseAccidentalValue( const std::string& value );
-		std::string toString( const AccidentalValue value );
-		std::ostream& toStream( std::ostream& os, const AccidentalValue value );
-		std::ostream& operator<<( std::ostream& os, const AccidentalValue value );
-
-		enum class ArrowDirectionEnum
-		{
-			left = 0,
-			up = 1,
-			right = 2,
-			down = 3,
-			northwest = 4,
-			northeast = 5,
-			southeast = 6,
-			southwest = 7,
-			leftRight = 8,
-			upDown = 9,
-			northwestSoutheast = 10,
-			northeastSouthwest = 11,
-			other = 12
-		};
-		ArrowDirectionEnum parseArrowDirectionEnum( const std::string& value );
-		std::string toString( const ArrowDirectionEnum value );
-		std::ostream& toStream( std::ostream& os, const ArrowDirectionEnum value );
-		std::ostream& operator<<( std::ostream& os, const ArrowDirectionEnum value );
-
-		enum class ArrowStyleEnum
-		{
-			single = 0,
-			double_ = 1,
-			filled = 2,
-			hollow = 3,
-			paired = 4,
-			combined = 5,
-			other = 6
-		};
-		ArrowStyleEnum parseArrowStyleEnum( const std::string& value );
-		std::string toString( const ArrowStyleEnum value );
-		std::ostream& toStream( std::ostream& os, const ArrowStyleEnum value );
-		std::ostream& operator<<( std::ostream& os, const ArrowStyleEnum value );
-
-		enum class BeamValue
-		{
-			begin = 0,
-			continue_ = 1,
-			end = 2,
-			forwardHook = 3,
-			backwardHook = 4
-		};
-		BeamValue parseBeamValue( const std::string& value );
-		std::string toString( const BeamValue value );
-		std::ostream& toStream( std::ostream& os, const BeamValue value );
-		std::ostream& operator<<( std::ostream& os, const BeamValue value );
-
-		enum class BreathMarkValue
-		{
-			emptystring = 0,
-			comma = 1,
-			tick = 2
-		};
-		BreathMarkValue parseBreathMarkValue( const std::string& value );
-		std::string toString( const BreathMarkValue value );
-		std::ostream& toStream( std::ostream& os, const BreathMarkValue value );
-		std::ostream& operator<<( std::ostream& os, const BreathMarkValue value );
-
-		enum class CircularArrowEnum
-		{
-			clockwise = 0,
-			anticlockwise = 1
-		};
-		CircularArrowEnum parseCircularArrowEnum( const std::string& value );
-		std::string toString( const CircularArrowEnum value );
-		std::ostream& toStream( std::ostream& os, const CircularArrowEnum value );
-		std::ostream& operator<<( std::ostream& os, const CircularArrowEnum value );
-
-		enum class Fan
-		{
-			accel = 0,
-			rit = 1,
-			none = 2
-		};
-		Fan parseFan( const std::string& value );
-		std::string toString( const Fan value );
-		std::ostream& toStream( std::ostream& os, const Fan value );
-		std::ostream& operator<<( std::ostream& os, const Fan value );
-
-		enum class HandbellValue
-		{
-			damp = 0,
-			echo = 1,
-			gyro = 2,
-			handMartellato = 3,
-			malletLift = 4,
-			malletTable = 5,
-			martellato = 6,
-			martellatoLift = 7,
-			mutedMartellato = 8,
-			pluckLift = 9,
-			swing = 10
-		};
-		HandbellValue parseHandbellValue( const std::string& value );
-		std::string toString( const HandbellValue value );
-		std::ostream& toStream( std::ostream& os, const HandbellValue value );
-		std::ostream& operator<<( std::ostream& os, const HandbellValue value );
-
-		enum class HoleClosedLocation
-		{
-			right = 0,
-			bottom = 1,
-			left = 2,
-			top = 3
-		};
-		HoleClosedLocation parseHoleClosedLocation( const std::string& value );
-		std::string toString( const HoleClosedLocation value );
-		std::ostream& toStream( std::ostream& os, const HoleClosedLocation value );
-		std::ostream& operator<<( std::ostream& os, const HoleClosedLocation value );
-
-		enum class HoleClosedValue
-		{
-			yes = 0,
-			no = 1,
-			half = 2
-		};
-		HoleClosedValue parseHoleClosedValue( const std::string& value );
-		std::string toString( const HoleClosedValue value );
-		std::ostream& toStream( std::ostream& os, const HoleClosedValue value );
-		std::ostream& operator<<( std::ostream& os, const HoleClosedValue value );
-
-		enum class NoteTypeValue
-		{
-			oneThousandTwentyFourth = 0,
-			fiveHundredTwelfth = 1,
-			twoHundredFifthySixth = 2,
-			oneHundredTwentyEighth = 3,
-			sixtyFourth = 4,
-			thirtySecond = 5,
-			sixteenth = 6,
-			eighth = 7,
-			quarter = 8,
-			half = 9,
-			whole = 10,
-			breve = 11,
-			long_ = 12,
-			maxima = 13
-		};
-		NoteTypeValue parseNoteTypeValue( const std::string& value );
-		std::string toString( const NoteTypeValue value );
-		std::ostream& toStream( std::ostream& os, const NoteTypeValue value );
-		std::ostream& operator<<( std::ostream& os, const NoteTypeValue value );
-
-		enum class NoteheadValue
-		{
-			slash = 0,
-			triangle = 1,
-			diamond = 2,
-			square = 3,
-			cross = 4,
-			x = 5,
-			circleX = 6,
-			invertedTriangle = 7,
-			arrowDown = 8,
-			arrowUp = 9,
-			slashed = 10,
-			backSlashed = 11,
-			normal = 12,
-			cluster = 13,
-			circleDot = 14,
-			leftTriangle = 15,
-			rectangle = 16,
-			none = 17,
-			do_ = 18,
-			re = 19,
-			mi = 20,
-			fa = 21,
-			faUp = 22,
-			so = 23,
-			la = 24,
-			ti = 25
-		};
-		NoteheadValue parseNoteheadValue( const std::string& value );
-		std::string toString( const NoteheadValue value );
-		std::ostream& toStream( std::ostream& os, const NoteheadValue value );
-		std::ostream& operator<<( std::ostream& os, const NoteheadValue value );
-
-		enum class ShowTuplet
-		{
-			actual = 0,
-			both = 1,
-			none = 2
-		};
-		ShowTuplet parseShowTuplet( const std::string& value );
-		std::string toString( const ShowTuplet value );
-		std::ostream& toStream( std::ostream& os, const ShowTuplet value );
-		std::ostream& operator<<( std::ostream& os, const ShowTuplet value );
-
-		enum class StemValue
-		{
-			down = 0,
-			up = 1,
-			double_ = 2,
-			none = 3
-		};
-		StemValue parseStemValue( const std::string& value );
-		std::string toString( const StemValue value );
-		std::ostream& toStream( std::ostream& os, const StemValue value );
-		std::ostream& operator<<( std::ostream& os, const StemValue value );
-
-		enum class StepEnum
-		{
-			a = 0,
-			b = 1,
-			c = 2,
-			d = 3,
-			e = 4,
-			f = 5,
-			g = 6
-		};
-		StepEnum parseStepEnum( const std::string& value );
-		std::string toString( const StepEnum value );
-		std::ostream& toStream( std::ostream& os, const StepEnum value );
-		std::ostream& operator<<( std::ostream& os, const StepEnum value );
-
-		enum class SyllabicEnum
-		{
-			single = 0,
-			begin = 1,
-			end = 2,
-			middle = 3
-		};
-		SyllabicEnum parseSyllabicEnum( const std::string& value );
-		std::string toString( const SyllabicEnum value );
-		std::ostream& toStream( std::ostream& os, const SyllabicEnum value );
-		std::ostream& operator<<( std::ostream& os, const SyllabicEnum value );
-
-		enum class GroupBarlineValue
-		{
-			yes = 0,
-			no = 1,
-			mensurstrich = 2
-		};
-		GroupBarlineValue parseGroupBarlineValue( const std::string& value );
-		std::string toString( const GroupBarlineValue value );
-		std::ostream& toStream( std::ostream& os, const GroupBarlineValue value );
-		std::ostream& operator<<( std::ostream& os, const GroupBarlineValue value );
-
-		enum class GroupSymbolValue
-		{
-			none = 0,
-			brace = 1,
-			line = 2,
-			bracket = 3,
-			square = 4
-		};
-		GroupSymbolValue parseGroupSymbolValue( const std::string& value );
-		std::string toString( const GroupSymbolValue value );
-		std::ostream& toStream( std::ostream& os, const GroupSymbolValue value );
-		std::ostream& operator<<( std::ostream& os, const GroupSymbolValue value );
-
-        enum class ModeEnum
-		{
-			major = 0,
-			minor = 1,
-			dorian = 2,
-			phrygian = 3,
-			lydian = 4,
-			mixolydian = 5,
-			aeolian = 6,
-			ionian = 7,
-			locrian = 8,
-			none = 9,
-			other = 10
-		};
-        ModeEnum parseModeEnum( const std::string& value );
-        ModeEnum parseModeEnum( const std::string& value, bool& success );
-		std::string toString( const ModeEnum value );
-		std::ostream& toStream( std::ostream& os, const ModeEnum value );
-		std::ostream& operator<<( std::ostream& os, const ModeEnum value );
-        
-        class ModeValue
+    namespace core
+    {
+        /// AboveBelow /////////////////////////////////////////////////////////////////////////////
+        ///
+        /// The above-below type is used to indicate whether one element appears above or
+        /// below another element.
+        ///
+        enum class AboveBelow
         {
-        public:
-            explicit ModeValue( const ModeEnum value );
-            explicit ModeValue( const std::string& value );
-            ModeValue();
-            ModeEnum getValue() const;
-            std::string getValueString() const;
-            void setValue( const ModeEnum value );
-            void setValue( const std::string& value );
-        private:
-            ModeEnum myEnum;
-            std::string myCustomValue;
+            above = 0,
+            below = 1
         };
-        ModeValue parseModeValue( const std::string& value );
-		std::string toString( const ModeValue& value );
-		std::ostream& toStream( std::ostream& os, const ModeValue& value );
-		std::ostream& operator<<( std::ostream& os, const ModeValue& value );
-        
+
+        AboveBelow parseAboveBelow( const std::string& value );
+        std::string toString( const AboveBelow value );
+        std::ostream& toStream( std::ostream& os, const AboveBelow value );
+        std::ostream& operator<<( std::ostream& os, const AboveBelow value );
+
+        /// AccidentalValue ////////////////////////////////////////////////////////////////////////
+        ///
+        /// The accidental-value type represents notated accidentals supported by MusicXML.
+        /// In the MusicXML 2.0 DTD this was a string with values that could be included.
+        /// The XSD strengthens the data typing to an enumerated list. The quarter- and
+        /// three-quarters- accidentals are Tartini-style quarter-tone accidentals. The
+        /// -down and -up accidentals are quarter-tone accidentals that include arrows
+        /// pointing down or up. The slash- accidentals are used in Turkish classical
+        /// music. The numbered sharp and flat accidentals are superscripted versions of
+        /// the accidental signs, used in Turkish folk music. The sori and koron
+        /// accidentals are microtonal sharp and flat accidentals used in Iranian and
+        /// Persian music.
+        ///
+        enum class AccidentalValue
+        {
+            sharp = 0,
+            natural = 1,
+            flat = 2,
+            doubleSharp = 3,
+            sharpSharp = 4,
+            flatFlat = 5,
+            naturalSharp = 6,
+            naturalFlat = 7,
+            quarterFlat = 8,
+            quarterSharp = 9,
+            threeQuartersFlat = 10,
+            threeQuartersSharp = 11,
+            sharpDown = 12,
+            sharpUp = 13,
+            naturalDown = 14,
+            naturalUp = 15,
+            flatDown = 16,
+            flatUp = 17,
+            tripleSharp = 18,
+            tripleFlat = 19,
+            slashQuarterSharp = 20,
+            slashSharp = 21,
+            slashFlat = 22,
+            doubleSlashFlat = 23,
+            sharp1 = 24,
+            sharp2 = 25,
+            sharp3 = 26,
+            sharp5 = 27,
+            flat1 = 28,
+            flat2 = 29,
+            flat3 = 30,
+            flat4 = 31,
+            sori = 32,
+            koron = 33
+        };
+
+        AccidentalValue parseAccidentalValue( const std::string& value );
+        std::string toString( const AccidentalValue value );
+        std::ostream& toStream( std::ostream& os, const AccidentalValue value );
+        std::ostream& operator<<( std::ostream& os, const AccidentalValue value );
+
+        /// ArrowDirectionEnum /////////////////////////////////////////////////////////////////////
+        ///
+        /// The arrow-direction type represents the direction in which an arrow points,
+        /// using Unicode arrow terminology.
+        ///
+        enum class ArrowDirectionEnum
+        {
+            left = 0,
+            up = 1,
+            right = 2,
+            down = 3,
+            northwest = 4,
+            northeast = 5,
+            southeast = 6,
+            southwest = 7,
+            leftRight = 8,
+            upDown = 9,
+            northwestSoutheast = 10,
+            northeastSouthwest = 11,
+            other = 12
+        };
+
+        ArrowDirectionEnum parseArrowDirectionEnum( const std::string& value );
+        std::string toString( const ArrowDirectionEnum value );
+        std::ostream& toStream( std::ostream& os, const ArrowDirectionEnum value );
+        std::ostream& operator<<( std::ostream& os, const ArrowDirectionEnum value );
+
+        /// ArrowStyleEnum /////////////////////////////////////////////////////////////////////////
+        ///
+        /// The arrow-style type represents the style of an arrow, using Unicode arrow
+        /// terminology. Filled and hollow arrows indicate polygonal single arrows. Paired
+        /// arrows are duplicate single arrows in the same direction. Combined arrows apply
+        /// to double direction arrows like left right, indicating that an arrow in one
+        /// direction should be combined with an arrow in the other direction.
+        ///
+        enum class ArrowStyleEnum
+        {
+            single = 0,
+            double_ = 1,
+            filled = 2,
+            hollow = 3,
+            paired = 4,
+            combined = 5,
+            other = 6
+        };
+
+        ArrowStyleEnum parseArrowStyleEnum( const std::string& value );
+        std::string toString( const ArrowStyleEnum value );
+        std::ostream& toStream( std::ostream& os, const ArrowStyleEnum value );
+        std::ostream& operator<<( std::ostream& os, const ArrowStyleEnum value );
+
+        /// BackwardForward ////////////////////////////////////////////////////////////////////////
+        ///
+        /// The backward-forward type is used to specify repeat directions. The start of
+        /// the repeat has a forward direction while the end of the repeat has a backward
+        /// direction.
+        ///
+        enum class BackwardForward
+        {
+            backward = 0,
+            forward = 1
+        };
+
+        BackwardForward parseBackwardForward( const std::string& value );
+        std::string toString( const BackwardForward value );
+        std::ostream& toStream( std::ostream& os, const BackwardForward value );
+        std::ostream& operator<<( std::ostream& os, const BackwardForward value );
+
+        /// BarStyleEnum ///////////////////////////////////////////////////////////////////////////
+        ///
+        /// The bar-style type represents barline style information. Choices are regular,
+        /// dotted, dashed, heavy, light-light, light-heavy, heavy-light, heavy-heavy, tick
+        /// (a short stroke through the top line), short (a partial barline between the 2nd
+        /// and 4th lines), and none.
+        ///
+        enum class BarStyleEnum
+        {
+            regular = 0,
+            dotted = 1,
+            dashed = 2,
+            heavy = 3,
+            lightLight = 4,
+            lightHeavy = 5,
+            heavyLight = 6,
+            heavyHeavy = 7,
+            tick = 8,
+            short_ = 9,
+            none = 10
+        };
+
+        BarStyleEnum parseBarStyleEnum( const std::string& value );
+        std::string toString( const BarStyleEnum value );
+        std::ostream& toStream( std::ostream& os, const BarStyleEnum value );
+        std::ostream& operator<<( std::ostream& os, const BarStyleEnum value );
+
+        /// BeamValue //////////////////////////////////////////////////////////////////////////////
+        ///
+        /// The beam-value type represents the type of beam associated with each of 8 beam
+        /// levels (up to 1024th notes) available for each note.
+        ///
+        enum class BeamValue
+        {
+            begin = 0,
+            continue_ = 1,
+            end = 2,
+            forwardHook = 3,
+            backwardHook = 4
+        };
+
+        BeamValue parseBeamValue( const std::string& value );
+        std::string toString( const BeamValue value );
+        std::ostream& toStream( std::ostream& os, const BeamValue value );
+        std::ostream& operator<<( std::ostream& os, const BeamValue value );
+
+        /// BeaterValue ////////////////////////////////////////////////////////////////////////////
+        ///
+        /// The beater-value type represents pictograms for beaters, mallets, and sticks
+        /// that do not have different materials represented in the pictogram. The finger
+        /// and hammer values are in addition to Stone's list.
+        ///
+        enum class BeaterValue
+        {
+            bow = 0,
+            chimeHammer = 1,
+            coin = 2,
+            finger = 3,
+            fingernail = 4,
+            fist = 5,
+            guiroScraper = 6,
+            hammer = 7,
+            hand = 8,
+            jazzStick = 9,
+            knittingNeedle = 10,
+            metalHammer = 11,
+            snareStick = 12,
+            spoonMallet = 13,
+            triangleBeater = 14,
+            triangleBeaterPlain = 15,
+            wireBrush = 16
+        };
+
+        BeaterValue parseBeaterValue( const std::string& value );
+        std::string toString( const BeaterValue value );
+        std::ostream& toStream( std::ostream& os, const BeaterValue value );
+        std::ostream& operator<<( std::ostream& os, const BeaterValue value );
+
+        /// BreathMarkValue ////////////////////////////////////////////////////////////////////////
+        ///
+        /// The breath-mark-value type represents the symbol used for a breath mark.
+        ///
+        enum class BreathMarkValue
+        {
+            emptystring = 0,
+            comma = 1,
+            tick = 2
+        };
+
+        BreathMarkValue parseBreathMarkValue( const std::string& value );
+        std::string toString( const BreathMarkValue value );
+        std::ostream& toStream( std::ostream& os, const BreathMarkValue value );
+        std::ostream& operator<<( std::ostream& os, const BreathMarkValue value );
+
+        /// CancelLocation /////////////////////////////////////////////////////////////////////////
+        ///
+        /// The cancel-location type is used to indicate where a key signature cancellation
+        /// appears relative to a new key signature: to the left, to the right, or before
+        /// the barline and to the left. It is left by default. For mid-measure key
+        /// elements, a cancel-location of before-barline should be treated like a
+        /// cancel-location of left.
+        ///
+        enum class CancelLocation
+        {
+            left = 0,
+            right = 1,
+            beforeBarline = 2
+        };
+
+        CancelLocation parseCancelLocation( const std::string& value );
+        std::string toString( const CancelLocation value );
+        std::ostream& toStream( std::ostream& os, const CancelLocation value );
+        std::ostream& operator<<( std::ostream& os, const CancelLocation value );
+
+        /// CircularArrowEnum //////////////////////////////////////////////////////////////////////
+        ///
+        /// The circular-arrow type represents the direction in which a circular arrow
+        /// points, using Unicode arrow terminology.
+        ///
+        enum class CircularArrowEnum
+        {
+            clockwise = 0,
+            anticlockwise = 1
+        };
+
+        CircularArrowEnum parseCircularArrowEnum( const std::string& value );
+        std::string toString( const CircularArrowEnum value );
+        std::ostream& toStream( std::ostream& os, const CircularArrowEnum value );
+        std::ostream& operator<<( std::ostream& os, const CircularArrowEnum value );
+
+        /// ClefSign ///////////////////////////////////////////////////////////////////////////////
+        ///
+        /// The clef-sign element represents the different clef symbols. The jianpu sign
+        /// indicates that the music that follows should be in jianpu numbered notation,
+        /// just as the TAB sign indicates that the music that follows should be in
+        /// tablature notation. Unlike TAB, a jianpu sign does not correspond to a visual
+        /// clef notation.
+        ///
+        enum class ClefSign
+        {
+            g = 0,
+            f = 1,
+            c = 2,
+            percussion = 3,
+            tab = 4,
+            jianpu = 5,
+            none = 6
+        };
+
+        ClefSign parseClefSign( const std::string& value );
+        std::string toString( const ClefSign value );
+        std::ostream& toStream( std::ostream& os, const ClefSign value );
+        std::ostream& operator<<( std::ostream& os, const ClefSign value );
+
+        /// CssFontSize ////////////////////////////////////////////////////////////////////////////
+        ///
+        /// The css-font-size type includes the CSS font sizes used as an alternative to a
+        /// numeric point size.
+        ///
+        enum class CssFontSize
+        {
+            xxSmall = 0,
+            xSmall = 1,
+            small = 2,
+            medium = 3,
+            large = 4,
+            xLarge = 5,
+            xxLarge = 6
+        };
+
+        CssFontSize parseCssFontSize( const std::string& value );
+        std::string toString( const CssFontSize value );
+        std::ostream& toStream( std::ostream& os, const CssFontSize value );
+        std::ostream& operator<<( std::ostream& os, const CssFontSize value );
+
+        /// DegreeSymbolValue //////////////////////////////////////////////////////////////////////
+        ///
+        /// The degree-symbol-value type indicates indicates that a symbol should be used
+        /// in specifying the degree.
+        ///
+        enum class DegreeSymbolValue
+        {
+            major = 0,
+            minor = 1,
+            augmented = 2,
+            diminished = 3,
+            halfDiminished = 4
+        };
+
+        DegreeSymbolValue parseDegreeSymbolValue( const std::string& value );
+        std::string toString( const DegreeSymbolValue value );
+        std::ostream& toStream( std::ostream& os, const DegreeSymbolValue value );
+        std::ostream& operator<<( std::ostream& os, const DegreeSymbolValue value );
+
+        /// DegreeTypeValue ////////////////////////////////////////////////////////////////////////
+        ///
+        /// The degree-type-value type indicates whether the current degree element is an
+        /// addition, alteration, or subtraction to the kind of the current chord in the
+        /// harmony element.
+        ///
+        enum class DegreeTypeValue
+        {
+            add = 0,
+            alter = 1,
+            subtract = 2
+        };
+
+        DegreeTypeValue parseDegreeTypeValue( const std::string& value );
+        std::string toString( const DegreeTypeValue value );
+        std::ostream& toStream( std::ostream& os, const DegreeTypeValue value );
+        std::ostream& operator<<( std::ostream& os, const DegreeTypeValue value );
+
+        /// DistanceTypeEnum ///////////////////////////////////////////////////////////////////////
+        ///
+        /// The distance-type defines what type of distance is being defined in a distance
+        /// element. Values include beam and hyphen. This is left as a string so that other
+        /// application-specific types can be defined, but it is made a separate type so
+        /// that it can be redefined more strictly.
+        ///
         enum class DistanceTypeEnum
-		{
-			beam = 0,
-			hyphen = 1,
-			other = 2
-		};
+        {
+            beam = 0,
+            hyphen = 1,
+            other = 2
+        };
+
         DistanceTypeEnum parseDistanceTypeEnum( const std::string& value );
-        DistanceTypeEnum parseDistanceTypeEnum( const std::string& value, bool& success );
-		std::string toString( const DistanceTypeEnum value );
-		std::ostream& toStream( std::ostream& os, const DistanceTypeEnum value );
-		std::ostream& operator<<( std::ostream& os, const DistanceTypeEnum value );
-        
+        std::string toString( const DistanceTypeEnum value );
+        std::ostream& toStream( std::ostream& os, const DistanceTypeEnum value );
+        std::ostream& operator<<( std::ostream& os, const DistanceTypeEnum value );
+
         class DistanceType
         {
         public:
@@ -1217,109 +395,33 @@ namespace mx
             DistanceTypeEnum myEnum;
             std::string myCustomValue;
         };
-        DistanceType parseDistanceType( const std::string& value );
-		std::string toString( const DistanceType& value );
-		std::ostream& toStream( std::ostream& os, const DistanceType& value );
-		std::ostream& operator<<( std::ostream& os, const DistanceType& value );
-        
-        enum class LineWidthTypeEnum
-		{
-			beam = 0,
-			bracket = 1,
-			dashes = 2,
-			enclosure = 3,
-			ending = 4,
-			extend = 5,
-			heavyBarline = 6,
-			leger = 7,
-			lightBarline = 8,
-			octaveShift = 9,
-			pedal = 10,
-			slurMiddle = 11,
-			slurTip = 12,
-			staff = 13,
-			stem = 14,
-			tieMiddle = 15,
-			tieTip = 16,
-			tupletBracket = 17,
-			wedge = 18,
-			other = 19
-		};
-        LineWidthTypeEnum parseLineWidthTypeEnum( const std::string& value );
-        LineWidthTypeEnum parseLineWidthTypeEnum( const std::string& value, bool& success );
-		std::string toString( const LineWidthTypeEnum value );
-		std::ostream& toStream( std::ostream& os, const LineWidthTypeEnum value );
-		std::ostream& operator<<( std::ostream& os, const LineWidthTypeEnum value );
-        
-        class LineWidthType
-        {
-        public:
-            explicit LineWidthType( const LineWidthTypeEnum value );
-            explicit LineWidthType( const std::string& value );
-            LineWidthType();
-            LineWidthTypeEnum getValue() const;
-            std::string getValueString() const;
-            void setValue( const LineWidthTypeEnum value );
-            void setValue( const std::string& value );
-        private:
-            LineWidthTypeEnum myEnum;
-            std::string myCustomValue;
-        };
-        LineWidthType parseLineWidthType( const std::string& value );
-		std::string toString( const LineWidthType& value );
-		std::ostream& toStream( std::ostream& os, const LineWidthType& value );
-		std::ostream& operator<<( std::ostream& os, const LineWidthType& value );
-        
-        enum class XlinkActuate
-        {
-            onLoad = 0,
-			onRequest = 1,
-            other = 2,
-            none = 3
-        };
-        XlinkActuate parseXlinkActuate( const std::string& value );
-		std::string toString( const XlinkActuate value );
-		std::ostream& toStream( std::ostream& os, const XlinkActuate value );
-		std::ostream& operator<<( std::ostream& os, const XlinkActuate value );
-        
-        enum class XlinkShow
-        {
-            new_ = 0,
-			replace = 1,
-            embed = 2,
-            other = 3,
-            none = 4
-        };
-        XlinkShow parseXlinkShow( const std::string& value );
-		std::string toString( const XlinkShow value );
-		std::ostream& toStream( std::ostream& os, const XlinkShow value );
-		std::ostream& operator<<( std::ostream& os, const XlinkShow value );
-        
-        enum class XlinkType
-        {
-            simple = 0,
-			extended = 1,
-            title = 2,
-            resource = 3,
-            locator = 4,
-            arc = 5
-        };
-        XlinkType parseXlinkType( const std::string& value );
-		std::string toString( const XlinkType value );
-		std::ostream& toStream( std::ostream& os, const XlinkType value );
-		std::ostream& operator<<( std::ostream& os, const XlinkType value );
-        
-        
-        enum class XmlSpace
-        {
-            default_ = 0,
-			preserve = 1
-        };
-        XmlSpace parseXmlSpace( const std::string& value );
-		std::string toString( const XmlSpace value );
-		std::ostream& toStream( std::ostream& os, const XmlSpace value );
-		std::ostream& operator<<( std::ostream& os, const XmlSpace value );
 
+        DistanceType parseDistanceType( const std::string& value );
+        std::string toString( const DistanceType& value );
+        std::ostream& toStream( std::ostream& os, const DistanceType& value );
+        std::ostream& operator<<( std::ostream& os, const DistanceType& value );
+
+        /// DynamicsEnum ///////////////////////////////////////////////////////////////////////////
+        ///
+        /// Dynamics can be associated either with a note or a general musical direction.
+        /// To avoid inconsistencies between and amongst the letter abbreviations for
+        /// dynamics (what is sf vs. sfz, standing alone or with a trailing dynamic that is
+        /// not always piano), we use the actual letters as the names of these dynamic
+        /// elements. The other-dynamics element allows other dynamic marks that are not
+        /// covered here, but many of those should perhaps be included in a more general
+        /// musical direction element. Dynamics elements may also be combined to create
+        /// marks not covered by a single element, such as sfmp.
+        ///
+        ///
+        ///
+        /// These letter dynamic symbols are separated from crescendo, decrescendo, and
+        /// wedge indications. Dynamic representation is inconsistent in scores. Many
+        /// things are assumed by the composer and left out, such as returns to original
+        /// dynamics. Systematic representations are quite complex: for example, Humdrum
+        /// has at least 3 representation formats related to dynamics. The MusicXML format
+        /// captures what is in the score, but does not try to be optimal for analysis or
+        /// synthesis of dynamics.
+        ///
         enum class DynamicsEnum
         {
             p = 0,
@@ -1347,12 +449,12 @@ namespace mx
             fz = 22,
             otherDynamics = 23
         };
+
         DynamicsEnum parseDynamicsEnum( const std::string& value );
-        DynamicsEnum parseDynamicsEnum( const std::string& value, bool& success );
-		std::string toString( const DynamicsEnum value );
-		std::ostream& toStream( std::ostream& os, const DynamicsEnum value );
-		std::ostream& operator<<( std::ostream& os, const DynamicsEnum value );
-        
+        std::string toString( const DynamicsEnum value );
+        std::ostream& toStream( std::ostream& os, const DynamicsEnum value );
+        std::ostream& operator<<( std::ostream& os, const DynamicsEnum value );
+
         class DynamicsValue
         {
         public:
@@ -1367,9 +469,1571 @@ namespace mx
             DynamicsEnum myEnum;
             std::string myCustomValue;
         };
+
         DynamicsValue parseDynamicsValue( const std::string& value );
-		std::string toString( const DynamicsValue& value );
-		std::ostream& toStream( std::ostream& os, const DynamicsValue& value );
-		std::ostream& operator<<( std::ostream& os, const DynamicsValue& value );
-	}
+        std::string toString( const DynamicsValue& value );
+        std::ostream& toStream( std::ostream& os, const DynamicsValue& value );
+        std::ostream& operator<<( std::ostream& os, const DynamicsValue& value );
+
+        /// EffectEnum /////////////////////////////////////////////////////////////////////////////
+        ///
+        /// The effect type represents pictograms for sound effect percussion instruments.
+        /// The cannon value is in addition to Stone's list.
+        ///
+        enum class EffectEnum
+        {
+            anvil = 0,
+            autoHorn = 1,
+            birdWhistle = 2,
+            cannon = 3,
+            duckCall = 4,
+            gunShot = 5,
+            klaxonHorn = 6,
+            lionsRoar = 7,
+            policeWhistle = 8,
+            siren = 9,
+            slideWhistle = 10,
+            thunderSheet = 11,
+            windMachine = 12,
+            windWhistle = 13
+        };
+
+        EffectEnum parseEffectEnum( const std::string& value );
+        std::string toString( const EffectEnum value );
+        std::ostream& toStream( std::ostream& os, const EffectEnum value );
+        std::ostream& operator<<( std::ostream& os, const EffectEnum value );
+
+        /// EnclosureShape /////////////////////////////////////////////////////////////////////////
+        ///
+        /// The enclosure-shape type describes the shape and presence / absence of an
+        /// enclosure around text or symbols. A bracket enclosure is similar to a rectangle
+        /// with the bottom line missing, as is common in jazz notation.
+        ///
+        enum class EnclosureShape
+        {
+            rectangle = 0,
+            square = 1,
+            oval = 2,
+            circle = 3,
+            bracket = 4,
+            triangle = 5,
+            diamond = 6,
+            none = 7
+        };
+
+        EnclosureShape parseEnclosureShape( const std::string& value );
+        std::string toString( const EnclosureShape value );
+        std::ostream& toStream( std::ostream& os, const EnclosureShape value );
+        std::ostream& operator<<( std::ostream& os, const EnclosureShape value );
+
+        /// Fan ////////////////////////////////////////////////////////////////////////////////////
+        ///
+        /// The fan type represents the type of beam fanning present on a note, used to
+        /// represent accelerandos and ritardandos.
+        ///
+        enum class Fan
+        {
+            accel = 0,
+            rit = 1,
+            none = 2
+        };
+
+        Fan parseFan( const std::string& value );
+        std::string toString( const Fan value );
+        std::ostream& toStream( std::ostream& os, const Fan value );
+        std::ostream& operator<<( std::ostream& os, const Fan value );
+
+        /// FermataShape ///////////////////////////////////////////////////////////////////////////
+        ///
+        /// The fermata-shape type represents the shape of the fermata sign. The empty
+        /// value is equivalent to the normal value.
+        ///
+        enum class FermataShape
+        {
+            normal = 0,
+            angled = 1,
+            square = 2,
+            emptystring = 3
+        };
+
+        FermataShape parseFermataShape( const std::string& value );
+        std::string toString( const FermataShape value );
+        std::ostream& toStream( std::ostream& os, const FermataShape value );
+        std::ostream& operator<<( std::ostream& os, const FermataShape value );
+
+        /// FontStyle //////////////////////////////////////////////////////////////////////////////
+        ///
+        /// The font-style type represents a simplified version of the CSS font-style
+        /// property.
+        ///
+        enum class FontStyle
+        {
+            normal = 0,
+            italic = 1
+        };
+
+        FontStyle parseFontStyle( const std::string& value );
+        std::string toString( const FontStyle value );
+        std::ostream& toStream( std::ostream& os, const FontStyle value );
+        std::ostream& operator<<( std::ostream& os, const FontStyle value );
+
+        /// FontWeight /////////////////////////////////////////////////////////////////////////////
+        ///
+        /// The font-weight type represents a simplified version of the CSS font-weight
+        /// property.
+        ///
+        enum class FontWeight
+        {
+            normal = 0,
+            bold = 1
+        };
+
+        FontWeight parseFontWeight( const std::string& value );
+        std::string toString( const FontWeight value );
+        std::ostream& toStream( std::ostream& os, const FontWeight value );
+        std::ostream& operator<<( std::ostream& os, const FontWeight value );
+
+        /// GlassEnum //////////////////////////////////////////////////////////////////////////////
+        ///
+        /// The glass type represents pictograms for glass percussion instruments.
+        ///
+        enum class GlassEnum
+        {
+            windChimes = 0
+        };
+
+        GlassEnum parseGlassEnum( const std::string& value );
+        std::string toString( const GlassEnum value );
+        std::ostream& toStream( std::ostream& os, const GlassEnum value );
+        std::ostream& operator<<( std::ostream& os, const GlassEnum value );
+
+        /// GroupBarlineValue //////////////////////////////////////////////////////////////////////
+        ///
+        /// The group-barline-value type indicates if the group should have common
+        /// barlines.
+        ///
+        enum class GroupBarlineValue
+        {
+            yes = 0,
+            no = 1,
+            mensurstrich = 2
+        };
+
+        GroupBarlineValue parseGroupBarlineValue( const std::string& value );
+        std::string toString( const GroupBarlineValue value );
+        std::ostream& toStream( std::ostream& os, const GroupBarlineValue value );
+        std::ostream& operator<<( std::ostream& os, const GroupBarlineValue value );
+
+        /// GroupSymbolValue ///////////////////////////////////////////////////////////////////////
+        ///
+        /// The group-symbol-value type indicates how the symbol for a group is indicated
+        /// in the score. The default value is none.
+        ///
+        enum class GroupSymbolValue
+        {
+            none = 0,
+            brace = 1,
+            line = 2,
+            bracket = 3,
+            square = 4
+        };
+
+        GroupSymbolValue parseGroupSymbolValue( const std::string& value );
+        std::string toString( const GroupSymbolValue value );
+        std::ostream& toStream( std::ostream& os, const GroupSymbolValue value );
+        std::ostream& operator<<( std::ostream& os, const GroupSymbolValue value );
+
+        /// HandbellValue //////////////////////////////////////////////////////////////////////////
+        ///
+        /// The handbell-value type represents the type of handbell technique being
+        /// notated.
+        ///
+        enum class HandbellValue
+        {
+            damp = 0,
+            echo = 1,
+            gyro = 2,
+            handMartellato = 3,
+            malletLift = 4,
+            malletTable = 5,
+            martellato = 6,
+            martellatoLift = 7,
+            mutedMartellato = 8,
+            pluckLift = 9,
+            swing = 10
+        };
+
+        HandbellValue parseHandbellValue( const std::string& value );
+        std::string toString( const HandbellValue value );
+        std::ostream& toStream( std::ostream& os, const HandbellValue value );
+        std::ostream& operator<<( std::ostream& os, const HandbellValue value );
+
+        /// HarmonyType ////////////////////////////////////////////////////////////////////////////
+        ///
+        /// The harmony-type type differentiates different types of harmonies when
+        /// alternate harmonies are possible. Explicit harmonies have all note present in
+        /// the music; implied have some notes missing but implied; alternate represents
+        /// alternate analyses.
+        ///
+        enum class HarmonyType
+        {
+            explicit_ = 0,
+            implied = 1,
+            alternate = 2
+        };
+
+        HarmonyType parseHarmonyType( const std::string& value );
+        std::string toString( const HarmonyType value );
+        std::ostream& toStream( std::ostream& os, const HarmonyType value );
+        std::ostream& operator<<( std::ostream& os, const HarmonyType value );
+
+        /// HoleClosedLocation /////////////////////////////////////////////////////////////////////
+        ///
+        /// The hole-closed-location type indicates which portion of the hole is filled in
+        /// when the corresponding hole-closed-value is half.
+        ///
+        enum class HoleClosedLocation
+        {
+            right = 0,
+            bottom = 1,
+            left = 2,
+            top = 3
+        };
+
+        HoleClosedLocation parseHoleClosedLocation( const std::string& value );
+        std::string toString( const HoleClosedLocation value );
+        std::ostream& toStream( std::ostream& os, const HoleClosedLocation value );
+        std::ostream& operator<<( std::ostream& os, const HoleClosedLocation value );
+
+        /// HoleClosedValue ////////////////////////////////////////////////////////////////////////
+        ///
+        /// The hole-closed-value type represents whether the hole is closed, open, or
+        /// half-open.
+        ///
+        enum class HoleClosedValue
+        {
+            yes = 0,
+            no = 1,
+            half = 2
+        };
+
+        HoleClosedValue parseHoleClosedValue( const std::string& value );
+        std::string toString( const HoleClosedValue value );
+        std::ostream& toStream( std::ostream& os, const HoleClosedValue value );
+        std::ostream& operator<<( std::ostream& os, const HoleClosedValue value );
+
+        /// KindValue //////////////////////////////////////////////////////////////////////////////
+        ///
+        /// A kind-value indicates the type of chord. Degree elements can then add,
+        /// subtract, or alter from these starting points. Values include:
+        ///
+        ///
+        ///
+        /// Triads:
+        ///
+        /// major (major third, perfect fifth)
+        ///
+        /// minor (minor third, perfect fifth)
+        ///
+        /// augmented (major third, augmented fifth)
+        ///
+        /// diminished (minor third, diminished fifth)
+        ///
+        /// Sevenths:
+        ///
+        /// dominant (major triad, minor seventh)
+        ///
+        /// major-seventh (major triad, major seventh)
+        ///
+        /// minor-seventh (minor triad, minor seventh)
+        ///
+        /// diminished-seventh (diminished triad, diminished seventh)
+        ///
+        /// augmented-seventh (augmented triad, minor seventh)
+        ///
+        /// half-diminished (diminished triad, minor seventh)
+        ///
+        /// major-minor (minor triad, major seventh)
+        ///
+        /// Sixths:
+        ///
+        /// major-sixth (major triad, added sixth)
+        ///
+        /// minor-sixth (minor triad, added sixth)
+        ///
+        /// Ninths:
+        ///
+        /// dominant-ninth (dominant-seventh, major ninth)
+        ///
+        /// major-ninth (major-seventh, major ninth)
+        ///
+        /// minor-ninth (minor-seventh, major ninth)
+        ///
+        /// 11ths (usually as the basis for alteration):
+        ///
+        /// dominant-11th (dominant-ninth, perfect 11th)
+        ///
+        /// major-11th (major-ninth, perfect 11th)
+        ///
+        /// minor-11th (minor-ninth, perfect 11th)
+        ///
+        /// 13ths (usually as the basis for alteration):
+        ///
+        /// dominant-13th (dominant-11th, major 13th)
+        ///
+        /// major-13th (major-11th, major 13th)
+        ///
+        /// minor-13th (minor-11th, major 13th)
+        ///
+        /// Suspended:
+        ///
+        /// suspended-second (major second, perfect fifth)
+        ///
+        /// suspended-fourth (perfect fourth, perfect fifth)
+        ///
+        /// Functional sixths:
+        ///
+        /// Neapolitan
+        ///
+        /// Italian
+        ///
+        /// French
+        ///
+        /// German
+        ///
+        /// Other:
+        ///
+        /// pedal (pedal-point bass)
+        ///
+        /// power (perfect fifth)
+        ///
+        /// Tristan
+        ///
+        ///
+        ///
+        /// The "other" kind is used when the harmony is entirely composed of add elements.
+        /// The "none" kind is used to explicitly encode absence of chords or functional
+        /// harmony.
+        ///
+        enum class KindValue
+        {
+            major = 0,
+            minor = 1,
+            augmented = 2,
+            diminished = 3,
+            dominant = 4,
+            majorSeventh = 5,
+            minorSeventh = 6,
+            diminishedSeventh = 7,
+            augmentedSeventh = 8,
+            halfDiminished = 9,
+            majorMinor = 10,
+            majorSixth = 11,
+            minorSixth = 12,
+            dominantNinth = 13,
+            majorNinth = 14,
+            minorNinth = 15,
+            dominant11Th = 16,
+            major11Th = 17,
+            minor11Th = 18,
+            dominant13Th = 19,
+            major13Th = 20,
+            minor13Th = 21,
+            suspendedSecond = 22,
+            suspendedFourth = 23,
+            neapolitan = 24,
+            italian = 25,
+            french = 26,
+            german = 27,
+            pedal = 28,
+            power = 29,
+            tristan = 30,
+            other = 31,
+            none = 32
+        };
+
+        KindValue parseKindValue( const std::string& value );
+        std::string toString( const KindValue value );
+        std::ostream& toStream( std::ostream& os, const KindValue value );
+        std::ostream& operator<<( std::ostream& os, const KindValue value );
+
+        /// LeftCenterRight ////////////////////////////////////////////////////////////////////////
+        ///
+        /// The left-center-right type is used to define horizontal alignment and text
+        /// justification.
+        ///
+        enum class LeftCenterRight
+        {
+            left = 0,
+            center = 1,
+            right = 2
+        };
+
+        LeftCenterRight parseLeftCenterRight( const std::string& value );
+        std::string toString( const LeftCenterRight value );
+        std::ostream& toStream( std::ostream& os, const LeftCenterRight value );
+        std::ostream& operator<<( std::ostream& os, const LeftCenterRight value );
+
+        /// LeftRight //////////////////////////////////////////////////////////////////////////////
+        ///
+        /// The left-right type is used to indicate whether one element appears to the left
+        /// or the right of another element.
+        ///
+        enum class LeftRight
+        {
+            left = 0,
+            right = 1
+        };
+
+        LeftRight parseLeftRight( const std::string& value );
+        std::string toString( const LeftRight value );
+        std::ostream& toStream( std::ostream& os, const LeftRight value );
+        std::ostream& operator<<( std::ostream& os, const LeftRight value );
+
+        /// LineEnd ////////////////////////////////////////////////////////////////////////////////
+        ///
+        /// The line-end type specifies if there is a jog up or down (or both), an arrow,
+        /// or nothing at the start or end of a bracket.
+        ///
+        enum class LineEnd
+        {
+            up = 0,
+            down = 1,
+            both = 2,
+            arrow = 3,
+            none = 4
+        };
+
+        LineEnd parseLineEnd( const std::string& value );
+        std::string toString( const LineEnd value );
+        std::ostream& toStream( std::ostream& os, const LineEnd value );
+        std::ostream& operator<<( std::ostream& os, const LineEnd value );
+
+        /// LineShape //////////////////////////////////////////////////////////////////////////////
+        ///
+        /// The line-shape type distinguishes between straight and curved lines.
+        ///
+        enum class LineShape
+        {
+            straight = 0,
+            curved = 1
+        };
+
+        LineShape parseLineShape( const std::string& value );
+        std::string toString( const LineShape value );
+        std::ostream& toStream( std::ostream& os, const LineShape value );
+        std::ostream& operator<<( std::ostream& os, const LineShape value );
+
+        /// LineType ///////////////////////////////////////////////////////////////////////////////
+        ///
+        /// The line-type type distinguishes between solid, dashed, dotted, and wavy lines.
+        ///
+        enum class LineType
+        {
+            solid = 0,
+            dashed = 1,
+            dotted = 2,
+            wavy = 3
+        };
+
+        LineType parseLineType( const std::string& value );
+        std::string toString( const LineType value );
+        std::ostream& toStream( std::ostream& os, const LineType value );
+        std::ostream& operator<<( std::ostream& os, const LineType value );
+
+        /// LineWidthTypeEnum //////////////////////////////////////////////////////////////////////
+        ///
+        /// The line-width-type defines what type of line is being defined in a line-width
+        /// element. Values include beam, bracket, dashes, enclosure, ending, extend, heavy
+        /// barline, leger, light barline, octave shift, pedal, slur middle, slur tip,
+        /// staff, stem, tie middle, tie tip, tuplet bracket, and wedge. This is left as a
+        /// string so that other application-specific types can be defined, but it is made
+        /// a separate type so that it can be redefined more strictly.
+        ///
+        enum class LineWidthTypeEnum
+        {
+            beam = 0,
+            bracket = 1,
+            dashes = 2,
+            enclosure = 3,
+            ending = 4,
+            extend = 5,
+            heavyBarline = 6,
+            leger = 7,
+            lightBarline = 8,
+            octaveShift = 9,
+            pedal = 10,
+            slurMiddle = 11,
+            slurTip = 12,
+            staff = 13,
+            stem = 14,
+            tieMiddle = 15,
+            tieTip = 16,
+            tupletBracket = 17,
+            wedge = 18,
+            other = 19
+        };
+
+        LineWidthTypeEnum parseLineWidthTypeEnum( const std::string& value );
+        std::string toString( const LineWidthTypeEnum value );
+        std::ostream& toStream( std::ostream& os, const LineWidthTypeEnum value );
+        std::ostream& operator<<( std::ostream& os, const LineWidthTypeEnum value );
+
+        class LineWidthType
+        {
+        public:
+            explicit LineWidthType( const LineWidthTypeEnum value );
+            explicit LineWidthType( const std::string& value );
+            LineWidthType();
+            LineWidthTypeEnum getValue() const;
+            std::string getValueString() const;
+            void setValue( const LineWidthTypeEnum value );
+            void setValue( const std::string& value );
+        private:
+            LineWidthTypeEnum myEnum;
+            std::string myCustomValue;
+        };
+
+        LineWidthType parseLineWidthType( const std::string& value );
+        std::string toString( const LineWidthType& value );
+        std::ostream& toStream( std::ostream& os, const LineWidthType& value );
+        std::ostream& operator<<( std::ostream& os, const LineWidthType& value );
+
+        /// MarginType /////////////////////////////////////////////////////////////////////////////
+        ///
+        /// The margin-type type specifies whether margins apply to even page, odd pages,
+        /// or both.
+        ///
+        enum class MarginType
+        {
+            odd = 0,
+            even = 1,
+            both = 2
+        };
+
+        MarginType parseMarginType( const std::string& value );
+        std::string toString( const MarginType value );
+        std::ostream& toStream( std::ostream& os, const MarginType value );
+        std::ostream& operator<<( std::ostream& os, const MarginType value );
+
+        /// MeasureNumberingValue //////////////////////////////////////////////////////////////////
+        ///
+        /// The measure-numbering-value type describes how measure numbers are displayed on
+        /// this part: no numbers, numbers every measure, or numbers every system.
+        ///
+        enum class MeasureNumberingValue
+        {
+            none = 0,
+            measure = 1,
+            system = 2
+        };
+
+        MeasureNumberingValue parseMeasureNumberingValue( const std::string& value );
+        std::string toString( const MeasureNumberingValue value );
+        std::ostream& toStream( std::ostream& os, const MeasureNumberingValue value );
+        std::ostream& operator<<( std::ostream& os, const MeasureNumberingValue value );
+
+        /// MembraneEnum ///////////////////////////////////////////////////////////////////////////
+        ///
+        /// The membrane type represents pictograms for membrane percussion instruments.
+        /// The goblet drum value is in addition to Stone's list.
+        ///
+        enum class MembraneEnum
+        {
+            bassDrum = 0,
+            bassDrumOnSide = 1,
+            bongos = 2,
+            congaDrum = 3,
+            gobletDrum = 4,
+            militaryDrum = 5,
+            snareDrum = 6,
+            snareDrumSnaresOff = 7,
+            tambourine = 8,
+            tenorDrum = 9,
+            timbales = 10,
+            tomtom = 11
+        };
+
+        MembraneEnum parseMembraneEnum( const std::string& value );
+        std::string toString( const MembraneEnum value );
+        std::ostream& toStream( std::ostream& os, const MembraneEnum value );
+        std::ostream& operator<<( std::ostream& os, const MembraneEnum value );
+
+        /// MetalEnum //////////////////////////////////////////////////////////////////////////////
+        ///
+        /// The metal type represents pictograms for metal percussion instruments. The
+        /// hi-hat value refers to a pictogram like Stone's high-hat cymbals but without
+        /// the long vertical line at the bottom.
+        ///
+        enum class MetalEnum
+        {
+            almglocken = 0,
+            bell = 1,
+            bellPlate = 2,
+            brakeDrum = 3,
+            chineseCymbal = 4,
+            cowbell = 5,
+            crashCymbals = 6,
+            crotale = 7,
+            cymbalTongs = 8,
+            domedGong = 9,
+            fingerCymbals = 10,
+            flexatone = 11,
+            gong = 12,
+            hiHat = 13,
+            highHatCymbals = 14,
+            handbell = 15,
+            sistrum = 16,
+            sizzleCymbal = 17,
+            sleighBells = 18,
+            suspendedCymbal = 19,
+            tamTam = 20,
+            triangle = 21,
+            vietnameseHat = 22
+        };
+
+        MetalEnum parseMetalEnum( const std::string& value );
+        std::string toString( const MetalEnum value );
+        std::ostream& toStream( std::ostream& os, const MetalEnum value );
+        std::ostream& operator<<( std::ostream& os, const MetalEnum value );
+
+        /// ModeEnum ///////////////////////////////////////////////////////////////////////////////
+        ///
+        /// The mode type is used to specify major/minor and other mode distinctions. Valid
+        /// mode values include major, minor, dorian, phrygian, lydian, mixolydian,
+        /// aeolian, ionian, locrian, and none.
+        ///
+        enum class ModeEnum
+        {
+            major = 0,
+            minor = 1,
+            dorian = 2,
+            phrygian = 3,
+            lydian = 4,
+            mixolydian = 5,
+            aeolian = 6,
+            ionian = 7,
+            locrian = 8,
+            none = 9,
+            other = 10
+        };
+
+        ModeEnum parseModeEnum( const std::string& value );
+        std::string toString( const ModeEnum value );
+        std::ostream& toStream( std::ostream& os, const ModeEnum value );
+        std::ostream& operator<<( std::ostream& os, const ModeEnum value );
+
+        class ModeValue
+        {
+        public:
+            explicit ModeValue( const ModeEnum value );
+            explicit ModeValue( const std::string& value );
+            ModeValue();
+            ModeEnum getValue() const;
+            std::string getValueString() const;
+            void setValue( const ModeEnum value );
+            void setValue( const std::string& value );
+        private:
+            ModeEnum myEnum;
+            std::string myCustomValue;
+        };
+
+        ModeValue parseModeValue( const std::string& value );
+        std::string toString( const ModeValue& value );
+        std::ostream& toStream( std::ostream& os, const ModeValue& value );
+        std::ostream& operator<<( std::ostream& os, const ModeValue& value );
+
+        /// MuteEnum ///////////////////////////////////////////////////////////////////////////////
+        ///
+        /// The mute type represents muting for different instruments, including brass,
+        /// winds, and strings. The on and off values are used for undifferentiated mutes.
+        /// The remaining values represent specific mutes.
+        ///
+        enum class MuteEnum
+        {
+            on = 0,
+            off = 1,
+            straight = 2,
+            cup = 3,
+            harmonNoStem = 4,
+            harmonStem = 5,
+            bucket = 6,
+            plunger = 7,
+            hat = 8,
+            solotone = 9,
+            practice = 10,
+            stopMute = 11,
+            stopHand = 12,
+            echo = 13,
+            palm = 14
+        };
+
+        MuteEnum parseMuteEnum( const std::string& value );
+        std::string toString( const MuteEnum value );
+        std::ostream& toStream( std::ostream& os, const MuteEnum value );
+        std::ostream& operator<<( std::ostream& os, const MuteEnum value );
+
+        /// NoteSizeType ///////////////////////////////////////////////////////////////////////////
+        ///
+        /// The note-size-type type indicates the type of note being defined by a note-size
+        /// element. The grace type is used for notes of cue size that that include a grace
+        /// element. The cue type is used for all other notes with cue size, whether
+        /// defined explicitly or implicitly via a cue element. The large type is used for
+        /// notes of large size.
+        ///
+        enum class NoteSizeType
+        {
+            cue = 0,
+            grace = 1,
+            large = 2
+        };
+
+        NoteSizeType parseNoteSizeType( const std::string& value );
+        std::string toString( const NoteSizeType value );
+        std::ostream& toStream( std::ostream& os, const NoteSizeType value );
+        std::ostream& operator<<( std::ostream& os, const NoteSizeType value );
+
+        /// NoteTypeValue //////////////////////////////////////////////////////////////////////////
+        ///
+        /// The note-type type is used for the MusicXML type element and represents the
+        /// graphic note type, from 1024th (shortest) to maxima (longest).
+        ///
+        enum class NoteTypeValue
+        {
+            oneThousandTwentyFourth = 0,
+            fiveHundredTwelfth = 1,
+            twoHundredFifthySixth = 2,
+            oneHundredTwentyEighth = 3,
+            sixtyFourth = 4,
+            thirtySecond = 5,
+            sixteenth = 6,
+            eighth = 7,
+            quarter = 8,
+            half = 9,
+            whole = 10,
+            breve = 11,
+            long_ = 12,
+            maxima = 13
+        };
+
+        NoteTypeValue parseNoteTypeValue( const std::string& value );
+        std::string toString( const NoteTypeValue value );
+        std::ostream& toStream( std::ostream& os, const NoteTypeValue value );
+        std::ostream& operator<<( std::ostream& os, const NoteTypeValue value );
+
+        /// NoteheadValue //////////////////////////////////////////////////////////////////////////
+        ///
+        /// The notehead type indicates shapes other than the open and closed ovals
+        /// associated with note durations. The values do, re, mi, fa, fa up, so, la, and
+        /// ti correspond to Aikin's 7-shape system. The fa up shape is typically used with
+        /// upstems; the fa shape is typically used with downstems or no stems.
+        ///
+        ///
+        ///
+        /// The arrow shapes differ from triangle and inverted triangle by being centered
+        /// on the stem. Slashed and back slashed notes include both the normal notehead
+        /// and a slash. The triangle shape has the tip of the triangle pointing up; the
+        /// inverted triangle shape has the tip of the triangle pointing down. The left
+        /// triangle shape is a right triangle with the hypotenuse facing up and to the
+        /// left.
+        ///
+        enum class NoteheadValue
+        {
+            slash = 0,
+            triangle = 1,
+            diamond = 2,
+            square = 3,
+            cross = 4,
+            x = 5,
+            circleX = 6,
+            invertedTriangle = 7,
+            arrowDown = 8,
+            arrowUp = 9,
+            slashed = 10,
+            backSlashed = 11,
+            normal = 12,
+            cluster = 13,
+            circleDot = 14,
+            leftTriangle = 15,
+            rectangle = 16,
+            none = 17,
+            do_ = 18,
+            re = 19,
+            mi = 20,
+            fa = 21,
+            faUp = 22,
+            so = 23,
+            la = 24,
+            ti = 25
+        };
+
+        NoteheadValue parseNoteheadValue( const std::string& value );
+        std::string toString( const NoteheadValue value );
+        std::ostream& toStream( std::ostream& os, const NoteheadValue value );
+        std::ostream& operator<<( std::ostream& os, const NoteheadValue value );
+
+        /// OnOff //////////////////////////////////////////////////////////////////////////////////
+        ///
+        /// The on-off type is used for notation elements such as string mutes.
+        ///
+        enum class OnOff
+        {
+            on = 0,
+            off = 1
+        };
+
+        OnOff parseOnOff( const std::string& value );
+        std::string toString( const OnOff value );
+        std::ostream& toStream( std::ostream& os, const OnOff value );
+        std::ostream& operator<<( std::ostream& os, const OnOff value );
+
+        /// OverUnder //////////////////////////////////////////////////////////////////////////////
+        ///
+        /// The over-under type is used to indicate whether the tips of curved lines such
+        /// as slurs and ties are overhand (tips down) or underhand (tips up).
+        ///
+        enum class OverUnder
+        {
+            over = 0,
+            under = 1
+        };
+
+        OverUnder parseOverUnder( const std::string& value );
+        std::string toString( const OverUnder value );
+        std::ostream& toStream( std::ostream& os, const OverUnder value );
+        std::ostream& operator<<( std::ostream& os, const OverUnder value );
+
+        /// PitchedEnum ////////////////////////////////////////////////////////////////////////////
+        ///
+        /// The pitched type represents pictograms for pitched percussion instruments. The
+        /// chimes and tubular chimes values distinguish the single-line and double-line
+        /// versions of the pictogram. The mallet value is in addition to Stone's list.
+        ///
+        enum class PitchedEnum
+        {
+            chimes = 0,
+            glockenspiel = 1,
+            mallet = 2,
+            marimba = 3,
+            tubularChimes = 4,
+            vibraphone = 5,
+            xylophone = 6
+        };
+
+        PitchedEnum parsePitchedEnum( const std::string& value );
+        std::string toString( const PitchedEnum value );
+        std::ostream& toStream( std::ostream& os, const PitchedEnum value );
+        std::ostream& operator<<( std::ostream& os, const PitchedEnum value );
+
+        /// PrincipalVoiceSymbol ///////////////////////////////////////////////////////////////////
+        ///
+        /// The principal-voice-symbol type represents the type of symbol used to indicate
+        /// the start of a principal or secondary voice. The "plain" value represents a
+        /// plain square bracket. The value of "none" is used for analysis markup when the
+        /// principal-voice element does not have a corresponding appearance in the score.
+        ///
+        enum class PrincipalVoiceSymbol
+        {
+            hauptstimme = 0,
+            nebenstimme = 1,
+            plain = 2,
+            none = 3
+        };
+
+        PrincipalVoiceSymbol parsePrincipalVoiceSymbol( const std::string& value );
+        std::string toString( const PrincipalVoiceSymbol value );
+        std::ostream& toStream( std::ostream& os, const PrincipalVoiceSymbol value );
+        std::ostream& operator<<( std::ostream& os, const PrincipalVoiceSymbol value );
+
+        /// RightLeftMiddle ////////////////////////////////////////////////////////////////////////
+        ///
+        /// The right-left-middle type is used to specify barline location.
+        ///
+        enum class RightLeftMiddle
+        {
+            right = 0,
+            left = 1,
+            middle = 2
+        };
+
+        RightLeftMiddle parseRightLeftMiddle( const std::string& value );
+        std::string toString( const RightLeftMiddle value );
+        std::ostream& toStream( std::ostream& os, const RightLeftMiddle value );
+        std::ostream& operator<<( std::ostream& os, const RightLeftMiddle value );
+
+        /// SemiPitchedEnum ////////////////////////////////////////////////////////////////////////
+        ///
+        /// The semi-pitched type represents categories of indefinite pitch for percussion
+        /// instruments.
+        ///
+        enum class SemiPitchedEnum
+        {
+            high = 0,
+            mediumHigh = 1,
+            medium = 2,
+            mediumLow = 3,
+            low = 4,
+            veryLow = 5
+        };
+
+        SemiPitchedEnum parseSemiPitchedEnum( const std::string& value );
+        std::string toString( const SemiPitchedEnum value );
+        std::ostream& toStream( std::ostream& os, const SemiPitchedEnum value );
+        std::ostream& operator<<( std::ostream& os, const SemiPitchedEnum value );
+
+        /// ShowFrets //////////////////////////////////////////////////////////////////////////////
+        ///
+        /// The show-frets type indicates whether to show tablature frets as numbers (0, 1,
+        /// 2) or letters (a, b, c). The default choice is numbers.
+        ///
+        enum class ShowFrets
+        {
+            numbers = 0,
+            letters = 1
+        };
+
+        ShowFrets parseShowFrets( const std::string& value );
+        std::string toString( const ShowFrets value );
+        std::ostream& toStream( std::ostream& os, const ShowFrets value );
+        std::ostream& operator<<( std::ostream& os, const ShowFrets value );
+
+        /// ShowTuplet /////////////////////////////////////////////////////////////////////////////
+        ///
+        /// The show-tuplet type indicates whether to show a part of a tuplet relating to
+        /// the tuplet-actual element, both the tuplet-actual and tuplet-normal elements,
+        /// or neither.
+        ///
+        enum class ShowTuplet
+        {
+            actual = 0,
+            both = 1,
+            none = 2
+        };
+
+        ShowTuplet parseShowTuplet( const std::string& value );
+        std::string toString( const ShowTuplet value );
+        std::ostream& toStream( std::ostream& os, const ShowTuplet value );
+        std::ostream& operator<<( std::ostream& os, const ShowTuplet value );
+
+        /// StaffTypeEnum //////////////////////////////////////////////////////////////////////////
+        ///
+        /// The staff-type value can be ossia, cue, editorial, regular, or alternate. An
+        /// alternate staff indicates one that shares the same musical data as the prior
+        /// staff, but displayed differently (e.g., treble and bass clef, standard notation
+        /// and tab).
+        ///
+        enum class StaffTypeEnum
+        {
+            ossia = 0,
+            cue = 1,
+            editorial = 2,
+            regular = 3,
+            alternate = 4
+        };
+
+        StaffTypeEnum parseStaffTypeEnum( const std::string& value );
+        std::string toString( const StaffTypeEnum value );
+        std::ostream& toStream( std::ostream& os, const StaffTypeEnum value );
+        std::ostream& operator<<( std::ostream& os, const StaffTypeEnum value );
+
+        /// StartNote //////////////////////////////////////////////////////////////////////////////
+        ///
+        /// The start-note type describes the starting note of trills and mordents for
+        /// playback, relative to the current note.
+        ///
+        enum class StartNote
+        {
+            upper = 0,
+            main = 1,
+            below = 2
+        };
+
+        StartNote parseStartNote( const std::string& value );
+        std::string toString( const StartNote value );
+        std::ostream& toStream( std::ostream& os, const StartNote value );
+        std::ostream& operator<<( std::ostream& os, const StartNote value );
+
+        /// StartStop //////////////////////////////////////////////////////////////////////////////
+        ///
+        /// The start-stop type is used for an attribute of musical elements that can
+        /// either start or stop, such as tuplets.
+        ///
+        ///
+        ///
+        /// The values of start and stop refer to how an element appears in musical score
+        /// order, not in MusicXML document order. An element with a stop attribute may
+        /// precede the corresponding element with a start attribute within a MusicXML
+        /// document. This is particularly common in multi-staff music. For example, the
+        /// stopping point for a tuplet may appear in staff 1 before the starting point for
+        /// the tuplet appears in staff 2 later in the document.
+        ///
+        enum class StartStop
+        {
+            start = 0,
+            stop = 1
+        };
+
+        StartStop parseStartStop( const std::string& value );
+        std::string toString( const StartStop value );
+        std::ostream& toStream( std::ostream& os, const StartStop value );
+        std::ostream& operator<<( std::ostream& os, const StartStop value );
+
+        /// StartStopChangeContinue ////////////////////////////////////////////////////////////////
+        ///
+        /// The start-stop-change-continue type is used to distinguish types of pedal
+        /// directions.
+        ///
+        enum class StartStopChangeContinue
+        {
+            start = 0,
+            stop = 1,
+            change = 2,
+            continue_ = 3
+        };
+
+        StartStopChangeContinue parseStartStopChangeContinue( const std::string& value );
+        std::string toString( const StartStopChangeContinue value );
+        std::ostream& toStream( std::ostream& os, const StartStopChangeContinue value );
+        std::ostream& operator<<( std::ostream& os, const StartStopChangeContinue value );
+
+        /// StartStopContinue //////////////////////////////////////////////////////////////////////
+        ///
+        /// The start-stop-continue type is used for an attribute of musical elements that
+        /// can either start or stop, but also need to refer to an intermediate point in
+        /// the symbol, as for complex slurs or for formatting of symbols across system
+        /// breaks.
+        ///
+        ///
+        ///
+        /// The values of start, stop, and continue refer to how an element appears in
+        /// musical score order, not in MusicXML document order. An element with a stop
+        /// attribute may precede the corresponding element with a start attribute within a
+        /// MusicXML document. This is particularly common in multi-staff music. For
+        /// example, the stopping point for a slur may appear in staff 1 before the
+        /// starting point for the slur appears in staff 2 later in the document.
+        ///
+        enum class StartStopContinue
+        {
+            start = 0,
+            stop = 1,
+            continue_ = 2
+        };
+
+        StartStopContinue parseStartStopContinue( const std::string& value );
+        std::string toString( const StartStopContinue value );
+        std::ostream& toStream( std::ostream& os, const StartStopContinue value );
+        std::ostream& operator<<( std::ostream& os, const StartStopContinue value );
+
+        /// StartStopDiscontinue ///////////////////////////////////////////////////////////////////
+        ///
+        /// The start-stop-discontinue type is used to specify ending types. Typically, the
+        /// start type is associated with the left barline of the first measure in an
+        /// ending. The stop and discontinue types are associated with the right barline of
+        /// the last measure in an ending. Stop is used when the ending mark concludes with
+        /// a downward jog, as is typical for first endings. Discontinue is used when there
+        /// is no downward jog, as is typical for second endings that do not conclude a
+        /// piece.
+        ///
+        enum class StartStopDiscontinue
+        {
+            start = 0,
+            stop = 1,
+            discontinue = 2
+        };
+
+        StartStopDiscontinue parseStartStopDiscontinue( const std::string& value );
+        std::string toString( const StartStopDiscontinue value );
+        std::ostream& toStream( std::ostream& os, const StartStopDiscontinue value );
+        std::ostream& operator<<( std::ostream& os, const StartStopDiscontinue value );
+
+        /// StartStopSingle ////////////////////////////////////////////////////////////////////////
+        ///
+        /// The start-stop-single type is used for an attribute of musical elements that
+        /// can be used for either multi-note or single-note musical elements, as for
+        /// tremolos.
+        ///
+        enum class StartStopSingle
+        {
+            start = 0,
+            stop = 1,
+            single = 2
+        };
+
+        StartStopSingle parseStartStopSingle( const std::string& value );
+        std::string toString( const StartStopSingle value );
+        std::ostream& toStream( std::ostream& os, const StartStopSingle value );
+        std::ostream& operator<<( std::ostream& os, const StartStopSingle value );
+
+        /// StemValue //////////////////////////////////////////////////////////////////////////////
+        ///
+        /// The stem type represents the notated stem direction.
+        ///
+        enum class StemValue
+        {
+            down = 0,
+            up = 1,
+            double_ = 2,
+            none = 3
+        };
+
+        StemValue parseStemValue( const std::string& value );
+        std::string toString( const StemValue value );
+        std::ostream& toStream( std::ostream& os, const StemValue value );
+        std::ostream& operator<<( std::ostream& os, const StemValue value );
+
+        /// StepEnum ///////////////////////////////////////////////////////////////////////////////
+        ///
+        /// The step type represents a step of the diatonic scale, represented using the
+        /// English letters A through G.
+        ///
+        enum class StepEnum
+        {
+            a = 0,
+            b = 1,
+            c = 2,
+            d = 3,
+            e = 4,
+            f = 5,
+            g = 6
+        };
+
+        StepEnum parseStepEnum( const std::string& value );
+        std::string toString( const StepEnum value );
+        std::ostream& toStream( std::ostream& os, const StepEnum value );
+        std::ostream& operator<<( std::ostream& os, const StepEnum value );
+
+        /// StickLocationEnum //////////////////////////////////////////////////////////////////////
+        ///
+        /// The stick-location type represents pictograms for the location of sticks,
+        /// beaters, or mallets on cymbals, gongs, drums, and other instruments.
+        ///
+        enum class StickLocationEnum
+        {
+            center = 0,
+            rim = 1,
+            cymbalBell = 2,
+            cymbalEdge = 3
+        };
+
+        StickLocationEnum parseStickLocationEnum( const std::string& value );
+        std::string toString( const StickLocationEnum value );
+        std::ostream& toStream( std::ostream& os, const StickLocationEnum value );
+        std::ostream& operator<<( std::ostream& os, const StickLocationEnum value );
+
+        /// StickMaterialEnum //////////////////////////////////////////////////////////////////////
+        ///
+        /// The stick-material type represents the material being displayed in a stick
+        /// pictogram.
+        ///
+        enum class StickMaterialEnum
+        {
+            soft = 0,
+            medium = 1,
+            hard = 2,
+            shaded = 3,
+            x = 4
+        };
+
+        StickMaterialEnum parseStickMaterialEnum( const std::string& value );
+        std::string toString( const StickMaterialEnum value );
+        std::ostream& toStream( std::ostream& os, const StickMaterialEnum value );
+        std::ostream& operator<<( std::ostream& os, const StickMaterialEnum value );
+
+        /// StickTypeEnum //////////////////////////////////////////////////////////////////////////
+        ///
+        /// The stick-type type represents the shape of pictograms where the material
+        ///
+        /// in the stick, mallet, or beater is represented in the pictogram.
+        ///
+        enum class StickTypeEnum
+        {
+            bassDrum = 0,
+            doubleBassDrum = 1,
+            timpani = 2,
+            xylophone = 3,
+            yarn = 4
+        };
+
+        StickTypeEnum parseStickTypeEnum( const std::string& value );
+        std::string toString( const StickTypeEnum value );
+        std::ostream& toStream( std::ostream& os, const StickTypeEnum value );
+        std::ostream& operator<<( std::ostream& os, const StickTypeEnum value );
+
+        /// SyllabicEnum ///////////////////////////////////////////////////////////////////////////
+        ///
+        /// Lyric hyphenation is indicated by the syllabic type. The single, begin, end,
+        /// and middle values represent single-syllable words, word-beginning syllables,
+        /// word-ending syllables, and mid-word syllables, respectively.
+        ///
+        enum class SyllabicEnum
+        {
+            single = 0,
+            begin = 1,
+            end = 2,
+            middle = 3
+        };
+
+        SyllabicEnum parseSyllabicEnum( const std::string& value );
+        std::string toString( const SyllabicEnum value );
+        std::ostream& toStream( std::ostream& os, const SyllabicEnum value );
+        std::ostream& operator<<( std::ostream& os, const SyllabicEnum value );
+
+        /// SymbolSize /////////////////////////////////////////////////////////////////////////////
+        ///
+        /// The symbol-size type is used to indicate full vs. cue-sized vs. oversized
+        /// symbols. The large value for oversized symbols was added in version 1.1.
+        ///
+        enum class SymbolSize
+        {
+            full = 0,
+            cue = 1,
+            large = 2
+        };
+
+        SymbolSize parseSymbolSize( const std::string& value );
+        std::string toString( const SymbolSize value );
+        std::ostream& toStream( std::ostream& os, const SymbolSize value );
+        std::ostream& operator<<( std::ostream& os, const SymbolSize value );
+
+        /// TextDirection //////////////////////////////////////////////////////////////////////////
+        ///
+        /// The text-direction type is used to adjust and override the Unicode
+        /// bidirectional text algorithm, similar to the W3C Internationalization Tag Set
+        /// recommendation. Values are ltr (left-to-right embed), rtl (right-to-left
+        /// embed), lro (left-to-right bidi-override), and rlo (right-to-left
+        /// bidi-override). The default value is ltr. This type is typically used by
+        /// applications that store text in left-to-right visual order rather than logical
+        /// order. Such applications can use the lro value to better communicate with other
+        /// applications that more fully support bidirectional text.
+        ///
+        enum class TextDirection
+        {
+            ltr = 0,
+            rtl = 1,
+            lro = 2,
+            rlo = 3
+        };
+
+        TextDirection parseTextDirection( const std::string& value );
+        std::string toString( const TextDirection value );
+        std::ostream& toStream( std::ostream& os, const TextDirection value );
+        std::ostream& operator<<( std::ostream& os, const TextDirection value );
+
+        /// TimeRelationEnum ///////////////////////////////////////////////////////////////////////
+        ///
+        /// The time-relation type indicates the symbol used to represent the
+        /// interchangeable aspect of dual time signatures.
+        ///
+        enum class TimeRelationEnum
+        {
+            parentheses = 0,
+            bracket = 1,
+            equals = 2,
+            slash = 3,
+            space = 4,
+            hyphen = 5
+        };
+
+        TimeRelationEnum parseTimeRelationEnum( const std::string& value );
+        std::string toString( const TimeRelationEnum value );
+        std::ostream& toStream( std::ostream& os, const TimeRelationEnum value );
+        std::ostream& operator<<( std::ostream& os, const TimeRelationEnum value );
+
+        /// TimeSeparator //////////////////////////////////////////////////////////////////////////
+        ///
+        /// The time-separator type indicates how to display the arrangement between the
+        /// beats and beat-type values in a time signature. The default value is none. The
+        /// horizontal, diagonal, and vertical values represent horizontal, diagonal
+        /// lower-left to upper-right, and vertical lines respectively. For these values,
+        /// the beats and beat-type values are arranged on either side of the separator
+        /// line. The none value represents no separator with the beats and beat-type
+        /// arranged vertically. The adjacent value represents no separator with the beats
+        /// and beat-type arranged horizontally.
+        ///
+        enum class TimeSeparator
+        {
+            none = 0,
+            horizontal = 1,
+            diagonal = 2,
+            vertical = 3,
+            adjacent = 4
+        };
+
+        TimeSeparator parseTimeSeparator( const std::string& value );
+        std::string toString( const TimeSeparator value );
+        std::ostream& toStream( std::ostream& os, const TimeSeparator value );
+        std::ostream& operator<<( std::ostream& os, const TimeSeparator value );
+
+        /// TimeSymbol /////////////////////////////////////////////////////////////////////////////
+        ///
+        /// The time-symbol type indicates how to display a time signature. The normal
+        /// value is the usual fractional display, and is the implied symbol type if none
+        /// is specified. Other options are the common and cut time symbols, as well as a
+        /// single number with an implied denominator. The note symbol indicates that the
+        /// beat-type should be represented with the corresponding downstem note rather
+        /// than a number. The dotted-note symbol indicates that the beat-type should be
+        /// represented with a dotted downstem note that corresponds to three times the
+        /// beat-type value, and a numerator that is one third the beats value.
+        ///
+        enum class TimeSymbol
+        {
+            common = 0,
+            cut = 1,
+            singleNumber = 2,
+            note = 3,
+            dottedNote = 4,
+            normal = 5
+        };
+
+        TimeSymbol parseTimeSymbol( const std::string& value );
+        std::string toString( const TimeSymbol value );
+        std::ostream& toStream( std::ostream& os, const TimeSymbol value );
+        std::ostream& operator<<( std::ostream& os, const TimeSymbol value );
+
+        /// TipDirection ///////////////////////////////////////////////////////////////////////////
+        ///
+        /// The tip-direction type represents the direction in which the tip of a stick or
+        /// beater points, using Unicode arrow terminology.
+        ///
+        enum class TipDirection
+        {
+            up = 0,
+            down = 1,
+            left = 2,
+            right = 3,
+            northwest = 4,
+            northeast = 5,
+            southeast = 6,
+            southwest = 7
+        };
+
+        TipDirection parseTipDirection( const std::string& value );
+        std::string toString( const TipDirection value );
+        std::ostream& toStream( std::ostream& os, const TipDirection value );
+        std::ostream& operator<<( std::ostream& os, const TipDirection value );
+
+        /// TopBottom //////////////////////////////////////////////////////////////////////////////
+        ///
+        /// The top-bottom type is used to indicate the top or bottom part of a vertical
+        /// shape like non-arpeggiate.
+        ///
+        enum class TopBottom
+        {
+            top = 0,
+            bottom = 1
+        };
+
+        TopBottom parseTopBottom( const std::string& value );
+        std::string toString( const TopBottom value );
+        std::ostream& toStream( std::ostream& os, const TopBottom value );
+        std::ostream& operator<<( std::ostream& os, const TopBottom value );
+
+        /// TrillStep //////////////////////////////////////////////////////////////////////////////
+        ///
+        /// The trill-step type describes the alternating note of trills and mordents for
+        /// playback, relative to the current note.
+        ///
+        enum class TrillStep
+        {
+            whole = 0,
+            half = 1,
+            unison = 2
+        };
+
+        TrillStep parseTrillStep( const std::string& value );
+        std::string toString( const TrillStep value );
+        std::ostream& toStream( std::ostream& os, const TrillStep value );
+        std::ostream& operator<<( std::ostream& os, const TrillStep value );
+
+        /// TwoNoteTurn ////////////////////////////////////////////////////////////////////////////
+        ///
+        /// The two-note-turn type describes the ending notes of trills and mordents for
+        /// playback, relative to the current note.
+        ///
+        enum class TwoNoteTurn
+        {
+            whole = 0,
+            half = 1,
+            none = 2
+        };
+
+        TwoNoteTurn parseTwoNoteTurn( const std::string& value );
+        std::string toString( const TwoNoteTurn value );
+        std::ostream& toStream( std::ostream& os, const TwoNoteTurn value );
+        std::ostream& operator<<( std::ostream& os, const TwoNoteTurn value );
+
+        /// UpDown /////////////////////////////////////////////////////////////////////////////////
+        ///
+        /// The up-down type is used for the direction of arrows and other pointed symbols
+        /// like vertical accents, indicating which way the tip is pointing.
+        ///
+        enum class UpDown
+        {
+            up = 0,
+            down = 1
+        };
+
+        UpDown parseUpDown( const std::string& value );
+        std::string toString( const UpDown value );
+        std::ostream& toStream( std::ostream& os, const UpDown value );
+        std::ostream& operator<<( std::ostream& os, const UpDown value );
+
+        /// UpDownStopContinue /////////////////////////////////////////////////////////////////////
+        ///
+        /// The up-down-stop-continue type is used for octave-shift elements, indicating
+        /// the direction of the shift from their true pitched values because of printing
+        /// difficulty.
+        ///
+        enum class UpDownStopContinue
+        {
+            up = 0,
+            down = 1,
+            stop = 2,
+            continue_ = 3
+        };
+
+        UpDownStopContinue parseUpDownStopContinue( const std::string& value );
+        std::string toString( const UpDownStopContinue value );
+        std::ostream& toStream( std::ostream& os, const UpDownStopContinue value );
+        std::ostream& operator<<( std::ostream& os, const UpDownStopContinue value );
+
+        /// UprightInverted ////////////////////////////////////////////////////////////////////////
+        ///
+        /// The upright-inverted type describes the appearance of a fermata element. The
+        /// value is upright if not specified.
+        ///
+        enum class UprightInverted
+        {
+            upright = 0,
+            inverted = 1
+        };
+
+        UprightInverted parseUprightInverted( const std::string& value );
+        std::string toString( const UprightInverted value );
+        std::ostream& toStream( std::ostream& os, const UprightInverted value );
+        std::ostream& operator<<( std::ostream& os, const UprightInverted value );
+
+        /// Valign /////////////////////////////////////////////////////////////////////////////////
+        ///
+        /// The valign type is used to indicate vertical alignment to the top, middle,
+        /// bottom, or baseline of the text. Defaults are implementation-dependent.
+        ///
+        enum class Valign
+        {
+            top = 0,
+            middle = 1,
+            bottom = 2,
+            baseline = 3
+        };
+
+        Valign parseValign( const std::string& value );
+        std::string toString( const Valign value );
+        std::ostream& toStream( std::ostream& os, const Valign value );
+        std::ostream& operator<<( std::ostream& os, const Valign value );
+
+        /// ValignImage ////////////////////////////////////////////////////////////////////////////
+        ///
+        /// The valign-image type is used to indicate vertical alignment for images and
+        /// graphics, so it does not include a baseline value. Defaults are
+        /// implementation-dependent.
+        ///
+        enum class ValignImage
+        {
+            top = 0,
+            middle = 1,
+            bottom = 2
+        };
+
+        ValignImage parseValignImage( const std::string& value );
+        std::string toString( const ValignImage value );
+        std::ostream& toStream( std::ostream& os, const ValignImage value );
+        std::ostream& operator<<( std::ostream& os, const ValignImage value );
+
+        /// WedgeType //////////////////////////////////////////////////////////////////////////////
+        ///
+        /// The wedge type is crescendo for the start of a wedge that is closed at the left
+        /// side, diminuendo for the start of a wedge that is closed on the right side, and
+        /// stop for the end of a wedge. The continue type is used for formatting wedges
+        /// over a system break, or for other situations where a single wedge is divided
+        /// into multiple segments.
+        ///
+        enum class WedgeType
+        {
+            crescendo = 0,
+            diminuendo = 1,
+            stop = 2,
+            continue_ = 3
+        };
+
+        WedgeType parseWedgeType( const std::string& value );
+        std::string toString( const WedgeType value );
+        std::ostream& toStream( std::ostream& os, const WedgeType value );
+        std::ostream& operator<<( std::ostream& os, const WedgeType value );
+
+        /// Winged /////////////////////////////////////////////////////////////////////////////////
+        ///
+        /// The winged attribute indicates whether the repeat has winged extensions that
+        /// appear above and below the barline. The straight and curved values represent
+        /// single wings, while the double-straight and double-curved values represent
+        /// double wings. The none value indicates no wings and is the default.
+        ///
+        enum class Winged
+        {
+            none = 0,
+            straight = 1,
+            curved = 2,
+            doubleStraight = 3,
+            doubleCurved = 4
+        };
+
+        Winged parseWinged( const std::string& value );
+        std::string toString( const Winged value );
+        std::ostream& toStream( std::ostream& os, const Winged value );
+        std::ostream& operator<<( std::ostream& os, const Winged value );
+
+        /// WoodEnum ///////////////////////////////////////////////////////////////////////////////
+        ///
+        /// The wood type represents pictograms for wood percussion instruments. The maraca
+        /// and maracas values distinguish the one- and two-maraca versions of the
+        /// pictogram. The vibraslap and castanets values are in addition to Stone's list.
+        ///
+        enum class WoodEnum
+        {
+            boardClapper = 0,
+            cabasa = 1,
+            castanets = 2,
+            claves = 3,
+            guiro = 4,
+            logDrum = 5,
+            maraca = 6,
+            maracas = 7,
+            ratchet = 8,
+            sandpaperBlocks = 9,
+            slitDrum = 10,
+            templeBlock = 11,
+            vibraslap = 12,
+            woodBlock = 13
+        };
+
+        WoodEnum parseWoodEnum( const std::string& value );
+        std::string toString( const WoodEnum value );
+        std::ostream& toStream( std::ostream& os, const WoodEnum value );
+        std::ostream& operator<<( std::ostream& os, const WoodEnum value );
+
+        /// YesNo //////////////////////////////////////////////////////////////////////////////////
+        ///
+        /// The yes-no type is used for boolean-like attributes. We cannot use W3C XML
+        /// Schema booleans due to their restrictions on expression of boolean values.
+        ///
+        enum class YesNo
+        {
+            yes = 0,
+            no = 1
+        };
+
+        YesNo parseYesNo( const std::string& value );
+        std::string toString( const YesNo value );
+        std::ostream& toStream( std::ostream& os, const YesNo value );
+        std::ostream& operator<<( std::ostream& os, const YesNo value );
+    }
 }

--- a/Sourcecode/private/mx/core/EnumsBuiltin.cpp
+++ b/Sourcecode/private/mx/core/EnumsBuiltin.cpp
@@ -1,0 +1,153 @@
+// MusicXML Class Library
+// Copyright (c) by Matthew James Briggs
+// Distributed under the MIT License
+
+#include "mx/core/EnumsBuiltin.h"
+
+namespace mx
+{
+    namespace core
+    {
+        XlinkActuate parseXlinkActuate( const std::string& value )
+        {
+            if ( value == "onLoad" ) { return XlinkActuate::onLoad; }
+            else if ( value == "onRequest" ) { return XlinkActuate::onRequest; }
+            else if ( value == "other" ) { return XlinkActuate::other; }
+            else if ( value == "none" ) { return XlinkActuate::none; }
+            return XlinkActuate::onLoad;
+        }
+
+
+        std::string toString( const XlinkActuate value )
+        {
+            switch ( value )
+            {
+                case XlinkActuate::onLoad: return "onLoad";
+                case XlinkActuate::onRequest: return "onRequest";
+                case XlinkActuate::other: return "other";
+                case XlinkActuate::none: return "none";
+                default: break;
+            }
+            return "none";
+        }
+
+
+        std::ostream& toStream( std::ostream& os, const XlinkActuate value )
+        {
+            return os << toString( value );
+        }
+
+
+        std::ostream& operator<<( std::ostream& os, const XlinkActuate value )
+        {
+            return toStream( os, value );
+        }
+        
+        XlinkShow parseXlinkShow( const std::string& value )
+        {
+            if ( value == "new" ) { return XlinkShow::new_; }
+            else if ( value == "replace" ) { return XlinkShow::replace; }
+            else if ( value == "embed" ) { return XlinkShow::embed; }
+            else if ( value == "other" ) { return XlinkShow::other; }
+            else if ( value == "none" ) { return XlinkShow::none; }
+            return XlinkShow::new_;
+        }
+
+
+        std::string toString( const XlinkShow value )
+        {
+            switch ( value )
+            {
+                case XlinkShow::new_: return "new";
+                case XlinkShow::replace: return "replace";
+                case XlinkShow::embed: return "embed";
+                case XlinkShow::other: return "other";
+                case XlinkShow::none: return "none";
+                default: break;
+            }
+            return "none";
+        }
+
+
+        std::ostream& toStream( std::ostream& os, const XlinkShow value )
+        {
+            return os << toString( value );
+        }
+
+
+        std::ostream& operator<<( std::ostream& os, const XlinkShow value )
+        {
+            return toStream( os, value );
+        }
+        
+        XlinkType parseXlinkType( const std::string& value )
+        {
+            if ( value == "simple" ) { return XlinkType::simple; }
+            else if ( value == "extended" ) { return XlinkType::extended; }
+            else if ( value == "title" ) { return XlinkType::title; }
+            else if ( value == "resource" ) { return XlinkType::resource; }
+            else if ( value == "locator" ) { return XlinkType::locator; }
+            else if ( value == "arc" ) { return XlinkType::arc; }
+            return XlinkType::simple;
+        }
+
+
+        std::string toString( const XlinkType value )
+        {
+            switch ( value )
+            {
+                case XlinkType::simple: return "simple";
+                case XlinkType::extended: return "extended";
+                case XlinkType::title: return "title";
+                case XlinkType::resource: return "resource";
+                case XlinkType::locator: return "locator";
+                case XlinkType::arc: return "arc";
+                default: break;
+            }
+            return "simple";
+        }
+
+
+        std::ostream& toStream( std::ostream& os, const XlinkType value )
+        {
+            return os << toString( value );
+        }
+
+
+        std::ostream& operator<<( std::ostream& os, const XlinkType value )
+        {
+            return toStream( os, value );
+        }
+
+        XmlSpace parseXmlSpace( const std::string& value )
+        {
+            if ( value == "default" ) { return XmlSpace::default_; }
+            else if ( value == "preserve" ) { return XmlSpace::preserve; }
+            return XmlSpace::default_;
+        }
+
+
+        std::string toString( const XmlSpace value )
+        {
+            switch ( value )
+            {
+                case XmlSpace::default_: return "default";
+                case XmlSpace::preserve: return "preserve";
+                default: break;
+            }
+            return "default";
+        }
+
+
+        std::ostream& toStream( std::ostream& os, const XmlSpace value )
+        {
+            return os << toString( value );
+        }
+
+
+        std::ostream& operator<<( std::ostream& os, const XmlSpace value )
+        {
+            return toStream( os, value );
+        }
+    }
+}

--- a/Sourcecode/private/mx/core/EnumsBuiltin.h
+++ b/Sourcecode/private/mx/core/EnumsBuiltin.h
@@ -1,0 +1,65 @@
+// MusicXML Class Library
+// Copyright (c) by Matthew James Briggs
+// Distributed under the MIT License
+
+#pragma once
+
+#include <iostream>
+#include <string>
+
+namespace mx
+{
+    namespace core
+    {
+        enum class XlinkType
+        {
+            simple = 0,
+			extended = 1,
+            title = 2,
+            resource = 3,
+            locator = 4,
+            arc = 5
+        };
+        XlinkType parseXlinkType( const std::string& value );
+		std::string toString( const XlinkType value );
+		std::ostream& toStream( std::ostream& os, const XlinkType value );
+		std::ostream& operator<<( std::ostream& os, const XlinkType value );
+        
+        
+        enum class XmlSpace
+        {
+            default_ = 0,
+			preserve = 1
+        };
+        XmlSpace parseXmlSpace( const std::string& value );
+		std::string toString( const XmlSpace value );
+		std::ostream& toStream( std::ostream& os, const XmlSpace value );
+		std::ostream& operator<<( std::ostream& os, const XmlSpace value );
+
+                
+        enum class XlinkActuate
+        {
+            onLoad = 0,
+            onRequest = 1,
+            other = 2,
+            none = 3
+        };
+        XlinkActuate parseXlinkActuate( const std::string& value );
+        std::string toString( const XlinkActuate value );
+        std::ostream& toStream( std::ostream& os, const XlinkActuate value );
+        std::ostream& operator<<( std::ostream& os, const XlinkActuate value );
+        
+        enum class XlinkShow
+        {
+            new_ = 0,
+            replace = 1,
+            embed = 2,
+            other = 3,
+            none = 4
+        };
+        XlinkShow parseXlinkShow( const std::string& value );
+        std::string toString( const XlinkShow value );
+        std::ostream& toStream( std::ostream& os, const XlinkShow value );
+        std::ostream& operator<<( std::ostream& os, const XlinkShow value );
+    }
+}

--- a/Xcode/Mx.xcodeproj/project.pbxproj
+++ b/Xcode/Mx.xcodeproj/project.pbxproj
@@ -7,6 +7,16 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		293B06EF249F0BB800429597 /* EnumsBuiltin.h in Headers */ = {isa = PBXBuildFile; fileRef = 293B06ED249F0BB800429597 /* EnumsBuiltin.h */; };
+		293B06F0249F0BB800429597 /* EnumsBuiltin.h in Headers */ = {isa = PBXBuildFile; fileRef = 293B06ED249F0BB800429597 /* EnumsBuiltin.h */; };
+		293B06F1249F0BB800429597 /* EnumsBuiltin.h in Headers */ = {isa = PBXBuildFile; fileRef = 293B06ED249F0BB800429597 /* EnumsBuiltin.h */; };
+		293B06F2249F0BB800429597 /* EnumsBuiltin.h in Headers */ = {isa = PBXBuildFile; fileRef = 293B06ED249F0BB800429597 /* EnumsBuiltin.h */; };
+		293B06F3249F0BB800429597 /* EnumsBuiltin.h in Headers */ = {isa = PBXBuildFile; fileRef = 293B06ED249F0BB800429597 /* EnumsBuiltin.h */; };
+		293B06F4249F0BB800429597 /* EnumsBuiltin.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 293B06EE249F0BB800429597 /* EnumsBuiltin.cpp */; };
+		293B06F5249F0BB800429597 /* EnumsBuiltin.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 293B06EE249F0BB800429597 /* EnumsBuiltin.cpp */; };
+		293B06F6249F0BB800429597 /* EnumsBuiltin.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 293B06EE249F0BB800429597 /* EnumsBuiltin.cpp */; };
+		293B06F7249F0BB800429597 /* EnumsBuiltin.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 293B06EE249F0BB800429597 /* EnumsBuiltin.cpp */; };
+		293B06F8249F0BB800429597 /* EnumsBuiltin.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 293B06EE249F0BB800429597 /* EnumsBuiltin.cpp */; };
 		294895A01FC4011400A06219 /* AppearanceData.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 2948959A1FC4011400A06219 /* AppearanceData.cpp */; };
 		294895A11FC4011400A06219 /* AppearanceData.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 2948959A1FC4011400A06219 /* AppearanceData.cpp */; };
 		294895A21FC4011400A06219 /* AppearanceData.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 2948959A1FC4011400A06219 /* AppearanceData.cpp */; };
@@ -3548,6 +3558,8 @@
 /* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
+		293B06ED249F0BB800429597 /* EnumsBuiltin.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = EnumsBuiltin.h; sourceTree = "<group>"; };
+		293B06EE249F0BB800429597 /* EnumsBuiltin.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = EnumsBuiltin.cpp; sourceTree = "<group>"; };
 		293FFED21DD25C74001477E8 /* libmx-macOS.dylib */ = {isa = PBXFileReference; explicitFileType = "compiled.mach-o.dylib"; includeInIndex = 0; path = "libmx-macOS.dylib"; sourceTree = BUILT_PRODUCTS_DIR; };
 		2948959A1FC4011400A06219 /* AppearanceData.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = AppearanceData.cpp; sourceTree = "<group>"; };
 		2975944D1F044C7600DE2F30 /* ChordData.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = ChordData.cpp; sourceTree = "<group>"; };
@@ -5064,6 +5076,8 @@
 		29A8DD881EF0475D00AD2478 /* core */ = {
 			isa = PBXGroup;
 			children = (
+				293B06EE249F0BB800429597 /* EnumsBuiltin.cpp */,
+				293B06ED249F0BB800429597 /* EnumsBuiltin.h */,
 				29A8DD891EF0475D00AD2478 /* AttributesInterface.cpp */,
 				29A8DD8A1EF0475D00AD2478 /* AttributesInterface.h */,
 				29A8DD8B1EF0475D00AD2478 /* Color.cpp */,
@@ -6544,6 +6558,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				29E76341205E2DEE00B754D5 /* LyricType.h in Headers */,
+				293B06F0249F0BB800429597 /* EnumsBuiltin.h in Headers */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -6552,6 +6567,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				29E76340205E2DEE00B754D5 /* LyricType.h in Headers */,
+				293B06EF249F0BB800429597 /* EnumsBuiltin.h in Headers */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -6559,6 +6575,7 @@
 			isa = PBXHeadersBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				293B06F3249F0BB800429597 /* EnumsBuiltin.h in Headers */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -6566,6 +6583,7 @@
 			isa = PBXHeadersBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				293B06F2249F0BB800429597 /* EnumsBuiltin.h in Headers */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -6574,6 +6592,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				29E76342205E2DEE00B754D5 /* LyricType.h in Headers */,
+				293B06F1249F0BB800429597 /* EnumsBuiltin.h in Headers */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -6793,6 +6812,7 @@
 				29A8F3461EF0476800AD2478 /* PartNameDisplayAttributes.cpp in Sources */,
 				29A8E89C1EF0476400AD2478 /* DisplayTextOrAccidentalText.cpp in Sources */,
 				29A8FB7A1EF0476D00AD2478 /* PreciseDecimal.cpp in Sources */,
+				293B06F5249F0BB800429597 /* EnumsBuiltin.cpp in Sources */,
 				29A8EF901EF0476700AD2478 /* MetronomeRelationGroup.cpp in Sources */,
 				29A8F4E51EF0476900AD2478 /* RestAttributes.cpp in Sources */,
 				29A8EF361EF0476700AD2478 /* Membrane.cpp in Sources */,
@@ -7462,6 +7482,7 @@
 				29A8F3451EF0476800AD2478 /* PartNameDisplayAttributes.cpp in Sources */,
 				29A8E89B1EF0476400AD2478 /* DisplayTextOrAccidentalText.cpp in Sources */,
 				29A8FB791EF0476D00AD2478 /* PreciseDecimal.cpp in Sources */,
+				293B06F4249F0BB800429597 /* EnumsBuiltin.cpp in Sources */,
 				29A8EF8F1EF0476700AD2478 /* MetronomeRelationGroup.cpp in Sources */,
 				29A8F4E41EF0476900AD2478 /* RestAttributes.cpp in Sources */,
 				29A8EF351EF0476700AD2478 /* Membrane.cpp in Sources */,
@@ -8131,6 +8152,7 @@
 				29A8FE0D1EF0499200AD2478 /* BeatUnit.cpp in Sources */,
 				29A8FE0E1EF0499200AD2478 /* BeatUnitDot.cpp in Sources */,
 				29A8FE0F1EF0499200AD2478 /* BeatUnitGroup.cpp in Sources */,
+				293B06F8249F0BB800429597 /* EnumsBuiltin.cpp in Sources */,
 				29A8FE101EF0499200AD2478 /* BeatUnitPer.cpp in Sources */,
 				29A8FE111EF0499200AD2478 /* BeatUnitPerOrNoteRelationNoteChoice.cpp in Sources */,
 				29A8FE121EF0499200AD2478 /* Bend.cpp in Sources */,
@@ -8800,6 +8822,7 @@
 				29A8F3481EF0476800AD2478 /* PartNameDisplayAttributes.cpp in Sources */,
 				29A8E89E1EF0476400AD2478 /* DisplayTextOrAccidentalText.cpp in Sources */,
 				29A8FB7C1EF0476D00AD2478 /* PreciseDecimal.cpp in Sources */,
+				293B06F7249F0BB800429597 /* EnumsBuiltin.cpp in Sources */,
 				29A8EF921EF0476700AD2478 /* MetronomeRelationGroup.cpp in Sources */,
 				29A8F4E71EF0476900AD2478 /* RestAttributes.cpp in Sources */,
 				29A8EF381EF0476700AD2478 /* Membrane.cpp in Sources */,
@@ -9469,6 +9492,7 @@
 				29A8F3471EF0476800AD2478 /* PartNameDisplayAttributes.cpp in Sources */,
 				29A8E89D1EF0476400AD2478 /* DisplayTextOrAccidentalText.cpp in Sources */,
 				29A8FB7B1EF0476D00AD2478 /* PreciseDecimal.cpp in Sources */,
+				293B06F6249F0BB800429597 /* EnumsBuiltin.cpp in Sources */,
 				29A8EF911EF0476700AD2478 /* MetronomeRelationGroup.cpp in Sources */,
 				29A8F4E61EF0476900AD2478 /* RestAttributes.cpp in Sources */,
 				29A8EF371EF0476700AD2478 /* Membrane.cpp in Sources */,


### PR DESCRIPTION
Related to #58 

This is the first step in a very large project to regenerate `mx::core` from `musicxml.xsd`. The original code generation was not reproducable, and in order to support versions of MusicXML greater than 3.0 I need to be able to generate `mx::core`, so I am writing a new program to do so.

This is the first product of that program, a regeneration of Enums.h.