### PR TITLE
core: update integers for codegen

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+build/
 cmake-build-*
 CodeGen/target
 Sourcecode/private/mxtest/file/PathRoot.h

--- a/Sourcecode/private/mx/core/Color.cpp
+++ b/Sourcecode/private/mx/core/Color.cpp
@@ -17,28 +17,28 @@ namespace mx
                  const IntType red,
                  const IntType green,
                  const IntType blue )
-            :myAlpha( 0, 255, alpha )
-            ,myRed( 0, 255, red )
-            ,myGreen( 0, 255, green )
-            ,myBlue( 0, 255, blue )
+            :myAlpha( alpha )
+            ,myRed( red )
+            ,myGreen( green )
+            ,myBlue( blue )
             ,myColorType( Color::ColorType::ARGB )
             {}
             
             impl( const IntType red,
                   const IntType green,
                   const IntType blue )
-            :myAlpha( 0, 255, 255 )
-            ,myRed( 0, 255, red )
-            ,myGreen( 0, 255, green )
-            ,myBlue( 0, 255, blue )
+            :myAlpha(255 )
+            ,myRed( red )
+            ,myGreen( green )
+            ,myBlue( blue )
             ,myColorType( Color::ColorType::RGB )
             {}
             
             impl()
-            :myAlpha( 0, 255, 255 )
-            ,myRed( 0, 255, 255 )
-            ,myGreen( 0, 255, 255 )
-            ,myBlue( 0, 255, 255 )
+            :myAlpha( 255 )
+            ,myRed( 255 )
+            ,myGreen( 255 )
+            ,myBlue( 255 )
             ,myColorType( ColorType::RGB )
             {}
             
@@ -134,10 +134,10 @@ namespace mx
             }
             
         private:
-            IntRange myAlpha;
-            IntRange myRed;
-            IntRange myGreen;
-            IntRange myBlue;
+            Byte myAlpha;
+            Byte myRed;
+            Byte myGreen;
+            Byte myBlue;
             Color::ColorType myColorType;
             IntType getInt( const std::string& str, int startpos )
             {

--- a/Sourcecode/private/mx/core/Integers.cpp
+++ b/Sourcecode/private/mx/core/Integers.cpp
@@ -2,38 +2,38 @@
 // Copyright (c) by Matthew James Briggs
 // Distributed under the MIT License
 
+// self
 #include "mx/core/Integers.h"
+
+// std
 #include <sstream>
 
 namespace mx
 {
     namespace core
     {
-        Integer::Integer( IntType value )
-        :myValue( value )
-        {}
-        
-        
         Integer::Integer()
-        :myValue( 0 )
-        {}
-        
-        
-        Integer::~Integer() {}
-        
+        : Integer{ 0 }
+        {
+
+        }
+
+        Integer::Integer( IntType value )
+        : myValue{ value }
+        {
+
+        }
         
         IntType Integer::getValue() const
         {
             return myValue;
         }
-        
-        
+
         void Integer::setValue( IntType value )
         {
             myValue = value;
         }
-        
-        
+
         void Integer::parse( const std::string& value )
         {
             std::stringstream ss( value );
@@ -45,158 +45,13 @@ namespace mx
             ss >> temp;
             setValue( temp );
         }
-        
-        
-        IntRange::IntRange( IntType min, IntType max, IntType value )
-        :Integer( value )
-        ,myMin( min )
-        ,myMax( max )
-        {
-            setValue( value );
-        }
-        
-        
-        IntRange::~IntRange() {}
-        
-        
-        IntRange::IntRange( IntRange&& other )
-        :Integer( std::move( other ) )
-        ,myMin( std::move( other.myMin ) )
-        ,myMax( std::move( other.myMax ) )
-        {}
-        
-        
-        IntRange& IntRange::operator=( const IntRange& other )
-        {
-            this->setValue( other.getValue() );
-            return *this;
-        }
-        
-        
-        IntRange& IntRange::operator=( IntRange&& other )
-        {
-            this->setValue( other.getValue() );
-            return *this;
-        }
-        
-        
-        void IntRange::setValue( IntType value )
-        {
-            if ( value < myMin )
-            {
-                Integer::setValue( myMin );
-            }
-            else if ( value > myMax )
-            {
-                Integer::setValue( myMax );
-            }
-            else
-            {
-                Integer::setValue( value );
-            }
-        }
-        
-        
-        void IntRange::parse( const std::string& value )
-        {
-            std::stringstream ss( value );
-            IntType temp = 0;
-            if ((ss >> temp).fail() || !(ss >> std::ws).eof())
-            {
-                return;
-            }
-            setValue( temp );
-        }
-        
-        
-        PositiveInteger::PositiveInteger( IntType value )
-        :Integer( value )
-        {
-            setValue( value );
-        }
-        
-        
-        PositiveInteger::PositiveInteger()
-        :Integer( 1 ) {}
-        
-        
-        PositiveInteger::~PositiveInteger() {}
-        
-        
-        void PositiveInteger::setValue( IntType value )
-        {
-            if ( value < 1 )
-            {
-                Integer::setValue( 1 );
-            }
-            else
-            {
-                Integer::setValue( value );
-            }
-        }
-        
-        
-        void PositiveInteger::parse( const std::string& value )
-        {
-            std::stringstream ss( value );
-            IntType temp = 1;
-            if ((ss >> temp).fail() || !(ss >> std::ws).eof())
-            {
-                return;
-            }
-            setValue( temp );
-        }
-        
-        
-        NonNegativeInteger::NonNegativeInteger( IntType value )
-        :Integer( value )
-        {
-            setValue( value );
-        }
-        
-        
-        NonNegativeInteger::NonNegativeInteger()
-        :Integer( 1 )
-        {
-            setValue( 1 );
-        }
-        
-        
-        NonNegativeInteger::~NonNegativeInteger() {}
-        
-        
-        void NonNegativeInteger::setValue( IntType value )
-        {
-            if ( value < 0 )
-            {
-                Integer::setValue( 0 );
-            }
-            else
-            {
-                Integer::setValue( value );
-            }
-        }
-        
-        
-        void NonNegativeInteger::parse( const std::string& value )
-        {
-            std::stringstream ss( value );
-            IntType temp = 0;
-            if ((ss >> temp).fail() || !(ss >> std::ws).eof())
-            {
-                return;
-            }
-            this->setValue( temp );
-        }
-        
-        
+
         std::string toString( const Integer& value )
         {
             std::stringstream ss;
             toStream( ss, value );
             return ss.str();
         }
-
 
         std::ostream& toStream( std::ostream& os, const Integer& value )
         {
@@ -208,72 +63,226 @@ namespace mx
         {
             return toStream( os, value );
         }
-        
-        
-        AccordionMiddleValue::AccordionMiddleValue( IntType value )
-        :IntRange( 0, 3, value ) {}
+
+        inline IntType clamp( IntType min, IntType max, IntType value )
+        {
+            if( value < min )
+            {
+                return min;
+            }
+            else if( value > max )
+            {
+                return max;
+            }
+            else
+            {
+                return value;
+            }
+        }
+
+        IntRange::IntRange( IntType min, IntType max, IntType value )
+        : Integer{ clamp( min, max, value ) }
+        , myMin{ min }
+        , myMax{ max }
+        {
+            
+        }
+
+        void IntRange::setValue( IntType value )
+        {
+            Integer::setValue( clamp( myMin, myMax, value ) );
+        }
+
         AccordionMiddleValue::AccordionMiddleValue()
-        :IntRange( 0, 3, 0 ) {}
-        
-        
-        BeamLevel::BeamLevel( IntType value )
-        :IntRange( 1, 8, value ) {}
+        :AccordionMiddleValue{ 0 }
+        {
+
+        }
+
+        AccordionMiddleValue::AccordionMiddleValue( IntType value )
+        :IntRange( 0, 3, value )
+        {
+
+        }
+
         BeamLevel::BeamLevel()
-        :IntRange( 1, 8, 1 ) {}
-        
-        
-        FifthsValue::FifthsValue( IntType value )
-        :Integer( value ) {}
+        :BeamLevel{ 0 }
+        {
+
+        }
+
+        BeamLevel::BeamLevel( IntType value )
+        :IntRange( 1, 8, value )
+        {
+
+        }
+
+        Byte::Byte()
+        :Byte{ 0 }
+        {
+
+        }
+
+        Byte::Byte( IntType value )
+        :IntRange( 0, 255, value )
+        {
+
+        }
+
         FifthsValue::FifthsValue()
-        :Integer( 0 ) {}
-        
-        
-        Midi16::Midi16( IntType value )
-        :IntRange( 1, 16, value ) {}
-        Midi16::Midi16()
-        :IntRange( 1, 16, 1 ) {}
-        
-        
-        Midi128::Midi128( IntType value )
-        :IntRange( 1, 128, value ) {}
+        :FifthsValue{ 0 }
+        {
+
+        }
+
+        FifthsValue::FifthsValue( IntType value )
+        :IntRange( IntMin, IntMax, value )
+        {
+
+        }
+
         Midi128::Midi128()
-        :IntRange( 1, 128, 1 ) {}
-        
-        
-        Midi16384::Midi16384( IntType value )
-        :IntRange( 1, 16384, value ) {}
+        :Midi128{ 0 }
+        {
+
+        }
+
+        Midi128::Midi128( IntType value )
+        :IntRange( 1, 128, value )
+        {
+
+        }
+
+        Midi16::Midi16()
+        :Midi16{ 0 }
+        {
+
+        }
+
+        Midi16::Midi16( IntType value )
+        :IntRange( 1, 16, value )
+        {
+
+        }
+
         Midi16384::Midi16384()
-        :IntRange( 1, 16384, 1 ) {}
-        
-        
-        NumberLevel::NumberLevel( IntType value )
-        :IntRange( 1, 6, value ) {}
+        :Midi16384{ 0 }
+        {
+
+        }
+
+        Midi16384::Midi16384( IntType value )
+        :IntRange( 1, 16384, value )
+        {
+
+        }
+
+        NonNegativeInteger::NonNegativeInteger()
+        :NonNegativeInteger{ 0 }
+        {
+
+        }
+
+        NonNegativeInteger::NonNegativeInteger( IntType value )
+        :IntRange( 0, IntMax, value )
+        {
+
+        }
+
         NumberLevel::NumberLevel()
-        :IntRange( 1, 6, 1 ) {}
-        
-        
-        NumberOfLines::NumberOfLines( IntType value )
-        :IntRange( 0, 3, value ) {}
+        :NumberLevel{ 0 }
+        {
+
+        }
+
+        NumberLevel::NumberLevel( IntType value )
+        :IntRange( 1, 6, value )
+        {
+
+        }
+
         NumberOfLines::NumberOfLines()
-        :IntRange( 0, 3, 0 ) {}
-        
-        
-        OctaveValue::OctaveValue( IntType value )
-        :IntRange( 0, 9, value ) {}
+        :NumberOfLines{ 0 }
+        {
+
+        }
+
+        NumberOfLines::NumberOfLines( IntType value )
+        :IntRange( 0, 3, value )
+        {
+
+        }
+
         OctaveValue::OctaveValue()
-        :IntRange( 0, 9, 0 ) {}
-        
-        
-        StaffLine::StaffLine( IntType value )
-        :Integer( value ) {}
+        :OctaveValue{ 0 }
+        {
+
+        }
+
+        OctaveValue::OctaveValue( IntType value )
+        :IntRange( 0, 9, value )
+        {
+
+        }
+
+        PositiveInteger::PositiveInteger()
+        :PositiveInteger{ 0 }
+        {
+
+        }
+
+        PositiveInteger::PositiveInteger( IntType value )
+        :IntRange( 1, IntMax, value )
+        {
+
+        }
+
         StaffLine::StaffLine()
-        :Integer( 0 ) {}
-        
-        
-        TremoloMarks::TremoloMarks( IntType value )
-        :IntRange( 0, 8, value ) {}
+        :StaffLine{ 0 }
+        {
+
+        }
+
+        StaffLine::StaffLine( IntType value )
+        :IntRange( IntMin, IntMax, value )
+        {
+
+        }
+
+        StaffNumber::StaffNumber()
+        :StaffNumber{ 0 }
+        {
+
+        }
+
+        StaffNumber::StaffNumber( IntType value )
+        :IntRange( 1, IntMax, value )
+        {
+
+        }
+
+        StringNumber::StringNumber()
+        :StringNumber{ 0 }
+        {
+
+        }
+
+        StringNumber::StringNumber( IntType value )
+        :IntRange( 1, IntMax, value )
+        {
+
+        }
+
         TremoloMarks::TremoloMarks()
-        :IntRange( 0, 8, 0 ) {}
-        
+        :TremoloMarks{ 0 }
+        {
+
+        }
+
+        TremoloMarks::TremoloMarks( IntType value )
+        :IntRange( 0, 8, value )
+        {
+
+        }
     }
 }

--- a/Sourcecode/private/mx/core/Integers.h
+++ b/Sourcecode/private/mx/core/Integers.h
@@ -5,187 +5,238 @@
 #pragma once
 
 #include <iostream>
+#include <limits>
 #include <string>
 
 namespace mx
 {
     namespace core
     {
-        /* alias for the int size used by this library */
+        /// Alias for the int type used by this library.
         using IntType = int;
-        
+        constexpr const IntType IntMax = std::numeric_limits<IntType>::max();
+        constexpr const IntType IntMin = std::numeric_limits<IntType>::min();
+
+        /// A base class for all integer types.
         class Integer
         {
         public:
-            explicit Integer( IntType value );
             Integer();
-            virtual ~Integer();
-            IntType getValue() const;
+            explicit Integer( IntType value );
+            virtual ~Integer() = default;
+            Integer( const Integer& ) = default;
+            Integer( Integer&& ) = default;
+            Integer& operator=( const Integer& ) = default;
+            Integer& operator=( Integer&& ) = default;
+            [[nodiscard]] IntType getValue() const;
             virtual void setValue( IntType value );
-            virtual void parse( const std::string& value );
+            virtual void parse( const std::string& value ) final;
         private:
             IntType myValue;
         };
-        
-        
+
+
         std::string toString( const Integer& value );
         std::ostream& toStream( std::ostream& os, const Integer& value );
         std::ostream& operator<<( std::ostream& os, const Integer& value );
-        
-        
+
+        /// A 'clamped', or 'ranged' Integer where the value can never be set
+        /// less than min or greater than max.
         class IntRange : public Integer
         {
         public:
             explicit IntRange( IntType min, IntType max, IntType value );
-            virtual ~IntRange();
-            IntRange( const IntRange& ) = default;
-            IntRange( IntRange&& );
-            IntRange& operator=( const IntRange& );
-            IntRange& operator=( IntRange&& );
-            
-            virtual void setValue( IntType value );
-            virtual void parse( const std::string& value );
+            void setValue( IntType value ) override;
         private:
-            const IntType myMin;
-            const IntType myMax;
+            IntType myMin;
+            IntType myMax;
         };
-        
-        
-        class PositiveInteger: public Integer
-        {
-        public:
-            explicit PositiveInteger( IntType value );
-            PositiveInteger();
-            virtual ~PositiveInteger();
-            virtual void setValue( IntType value );
-            virtual void parse( const std::string& value );
-        };
-        
-        
-        class NonNegativeInteger: public Integer
-        {
-        public:
-            explicit NonNegativeInteger( IntType value );
-            NonNegativeInteger();
-            virtual ~NonNegativeInteger();
-            virtual void setValue( IntType value );
-            virtual void parse( const std::string& value );
-        };
-        
-        
-		std::string toString( const Integer& value );
-		std::ostream& toStream( std::ostream& os, const Integer& value );
-		std::ostream& operator<<( std::ostream& os, const Integer& value );
-        
-        
-        // The specification restrics the values from 1 to 3
-        // This seems incorrect when searching accordion symbols
-        // online so this library will support 0 to 3 instead.
-        /* MIN = 0, MAX = 3, DEFAULT = 0 */
+
+        /// The accordion-middle type may have values of 1, 2, or 3, corresponding to
+        /// having 1 to 3 dots in the middle section of the accordion registration symbol.
+        ///
+        /// Note: MusicXML specifies the minimum allowable value as 1, however test
+        /// documents exist that have a value of 0. This library supports a minimum value
+        /// of 0. Per https://github.com/w3c/musicxml/issues/134, the correct
+        /// representation for 0 dots is to omit the element, so it is possible to create
+        /// invalid MusicXML by setting the value to 0 here.
+        ///
+        /// Range: min=0, max=3
         class AccordionMiddleValue : public IntRange
         {
         public:
             explicit AccordionMiddleValue( IntType value );
             AccordionMiddleValue();
         };
-        
-        
-        /* MIN = 1, MAX = 8, DEFAULT = 1 */
+
+        /// The MusicXML format supports six levels of beaming, up to 1024th notes. Unlike
+        /// the number-level type, the beam-level type identifies concurrent beams in a
+        /// beam group. It does not distinguish overlapping beams such as grace notes
+        /// within regular notes, or beams used in different voices.
+        ///
+        /// Range: min=1, max=8
         class BeamLevel : public IntRange
         {
         public:
             explicit BeamLevel( IntType value );
             BeamLevel();
         };
-        
-        
-        /* MIN = N/A, MAX = N/A, DEFAULT = 0 */
-        class FifthsValue : public Integer
+
+        /// This is not part of MusicXML. It represents a clamped byte.
+        ///
+        /// Range: min=0, max=255
+        class Byte : public IntRange
+        {
+        public:
+            explicit Byte( IntType value );
+            Byte();
+        };
+
+        /// The fifths type represents the number of flats or sharps in a traditional key
+        /// signature. Negative numbers are used for flats and positive numbers for sharps,
+        /// reflecting the key's placement within the circle of fifths (hence the type
+        /// name).
+        ///
+        /// Range: min=None, max=None
+        class FifthsValue : public IntRange
         {
         public:
             explicit FifthsValue( IntType value );
             FifthsValue();
         };
-        
-        
-        /* MIN = 1, MAX = 16, DEFAULT = 1 */
-        class Midi16 : public IntRange
-        {
-        public:
-            explicit Midi16( IntType value );
-            Midi16();
-        };
-        
-        
-        /* MIN = 1, MAX = 128, DEFAULT = 1 */
+
+        /// The midi-16 type is used to express MIDI 1.0 values that range from 1 to 128.
+        ///
+        /// Range: min=1, max=128
         class Midi128 : public IntRange
         {
         public:
             explicit Midi128( IntType value );
             Midi128();
         };
-        
-        
-        /* MIN = 1, MAX = 16384, DEFAULT = 1 */
+
+        /// The midi-16 type is used to express MIDI 1.0 values that range from 1 to 16.
+        ///
+        /// Range: min=1, max=16
+        class Midi16 : public IntRange
+        {
+        public:
+            explicit Midi16( IntType value );
+            Midi16();
+        };
+
+        /// The midi-16 type is used to express MIDI 1.0 values that range from 1 to
+        /// 16,384.
+        ///
+        /// Range: min=1, max=16384
         class Midi16384 : public IntRange
         {
         public:
             explicit Midi16384( IntType value );
             Midi16384();
         };
-        
-        
-        /* MIN = 1, MAX = 6, DEFAULT = 1 */
+
+        /// The built-in primitive xs:nonNegativeInteger
+        ///
+        /// Range: min=0, max=None
+        class NonNegativeInteger : public IntRange
+        {
+        public:
+            explicit NonNegativeInteger( IntType value );
+            NonNegativeInteger();
+        };
+
+        /// Slurs, tuplets, and many other features can be concurrent and overlapping
+        /// within a single musical part. The number-level type distinguishes up to six
+        /// concurrent objects of the same type. A reading program should be prepared to
+        /// handle cases where the number-levels stop in an arbitrary order. Different
+        /// numbers are needed when the features overlap in MusicXML document order. When a
+        /// number-level value is implied, the value is 1 by default.
+        ///
+        /// Range: min=1, max=6
         class NumberLevel : public IntRange
         {
         public:
             explicit NumberLevel( IntType value );
             NumberLevel();
         };
-        
-        
-        /* MIN = 0, MAX = 3, DEFAULT = 0 */
+
+        /// The number-of-lines type is used to specify the number of lines in text
+        /// decoration attributes.
+        ///
+        /// Range: min=0, max=3
         class NumberOfLines : public IntRange
         {
         public:
             explicit NumberOfLines( IntType value );
             NumberOfLines();
         };
-        
-        
-        /* MIN = 0, MAX = 9, DEFAULT = 0 */
+
+        /// Octaves are represented by the numbers 0 to 9, where 4 indicates the octave
+        /// started by middle C.
+        ///
+        /// Range: min=0, max=9
         class OctaveValue : public IntRange
         {
         public:
             explicit OctaveValue( IntType value );
             OctaveValue();
         };
-        
-        
-        /* MIN = N/A, MAX = N/A, DEFAULT = 0 */
-        class StaffLine : public Integer
+
+        /// The built-in primitive xs:positiveInteger
+        ///
+        /// Range: min=1, max=None
+        class PositiveInteger : public IntRange
+        {
+        public:
+            explicit PositiveInteger( IntType value );
+            PositiveInteger();
+        };
+
+        /// The staff-line type indicates the line on a given staff. Staff lines are
+        /// numbered from bottom to top, with 1 being the bottom line on a staff. Staff
+        /// line values can be used to specify positions outside the staff, such as a C
+        /// clef positioned in the middle of a grand staff.
+        ///
+        /// Range: min=None, max=None
+        class StaffLine : public IntRange
         {
         public:
             explicit StaffLine( IntType value );
             StaffLine();
         };
-        
-        
-        /* MIN = 1, MAX = N/A, DEFAULT = 1 */
-        using StaffNumber = PositiveInteger;
-        
-        
-        /* MIN = 1, MAX = N/A, DEFAULT = 1 */
-        using StringNumber = PositiveInteger;
-        
-        
-        /* MIN = 0, MAX = 8, DEFAULT = 0 */
+
+        /// The staff-number type indicates staff numbers within a multi-staff part. Staves
+        /// are numbered from top to bottom, with 1 being the top staff on a part.
+        ///
+        /// Range: min=1, max=None
+        class StaffNumber : public IntRange
+        {
+        public:
+            explicit StaffNumber( IntType value );
+            StaffNumber();
+        };
+
+        /// The string-number type indicates a string number. Strings are numbered from
+        /// high to low, with 1 being the highest pitched string.
+        ///
+        /// Range: min=1, max=None
+        class StringNumber : public IntRange
+        {
+        public:
+            explicit StringNumber( IntType value );
+            StringNumber();
+        };
+
+        /// The number of tremolo marks is represented by a number from 0 to 8: the same as
+        /// beam-level with 0 added.
+        ///
+        /// Range: min=0, max=8
         class TremoloMarks : public IntRange
         {
         public:
             explicit TremoloMarks( IntType value );
             TremoloMarks();
         };
-        
     }
 }

--- a/Sourcecode/private/mx/impl/DirectionWriter.cpp
+++ b/Sourcecode/private/mx/impl/DirectionWriter.cpp
@@ -95,7 +95,7 @@ namespace mx
             if( myDirectionData.isStaffValueSpecified || myCursor.staffIndex != 0 )
             {
                 directionPtr->setHasStaff( true );
-                directionPtr->getStaff()->setValue( core::StaffNumber{ myCursor.staffIndex + 1 } );
+                directionPtr->getStaff()->setValue( core::PositiveInteger{ myCursor.staffIndex + 1 } );
             }
 
             int offset = 0;

--- a/Sourcecode/private/mx/impl/NoteReader.cpp
+++ b/Sourcecode/private/mx/impl/NoteReader.cpp
@@ -323,6 +323,7 @@ namespace mx
             {
                 myTimeModificationActualNotes = 1;
                 myTimeModificationNormalNotes = 1;
+                return;
             }
             
             const auto& mxTimeMod = *myNote.getTimeModification();

--- a/Sourcecode/private/mx/impl/NoteWriter.cpp
+++ b/Sourcecode/private/mx/impl/NoteWriter.cpp
@@ -386,7 +386,7 @@ namespace mx
             if( myCursor.getNumStaves() > 1 && myCursor.staffIndex >= 0 )
             {
                 myOutNote->setHasStaff( true );
-                myOutNote->getStaff()->setValue( core::StaffNumber{ myCursor.staffIndex + 1 } );
+                myOutNote->getStaff()->setValue( core::PositiveInteger{ myCursor.staffIndex + 1 } );
             }
             
             if( myCursor.voiceIndex >= 0 )

--- a/Sourcecode/private/mxtest/core/ActualNotesTest.cpp
+++ b/Sourcecode/private/mxtest/core/ActualNotesTest.cpp
@@ -22,7 +22,7 @@ TEST( Test01, ActualNotes )
 	object1.toStream( default_constructed, 0 );
 	std::stringstream object2_stream;
 	object2.toStream( object2_stream, 2 );
-	std::string expected = R"(<actual-notes>1</actual-notes>)";
+	std::string expected = R"(<actual-notes>0</actual-notes>)";
 	std::string actual = default_constructed.str();
 	CHECK_EQUAL( expected, actual )
 	expected = indentString+indentString+R"(<actual-notes>3</actual-notes>)";

--- a/Sourcecode/private/mxtest/core/CapoTest.cpp
+++ b/Sourcecode/private/mxtest/core/CapoTest.cpp
@@ -22,7 +22,7 @@ TEST( Test01, Capo )
 	object1.toStream( default_constructed, 0 );
 	std::stringstream object2_stream;
 	object2.toStream( object2_stream, 2 );
-	std::string expected = R"(<capo>1</capo>)";
+	std::string expected = R"(<capo>0</capo>)";
 	std::string actual = default_constructed.str();
 	CHECK_EQUAL( expected, actual )
 	expected = indentString+indentString+R"(<capo>3</capo>)";

--- a/Sourcecode/private/mxtest/core/FrameNoteTest.cpp
+++ b/Sourcecode/private/mxtest/core/FrameNoteTest.cpp
@@ -19,7 +19,7 @@ TEST( Test01, FrameNote )
 	stringstream expected;
 	streamLine( expected, 1, R"(<frame-note>)" );
 	streamLine( expected, 2, R"(<string>1</string>)" );
-	streamLine( expected, 2, R"(<fret>1</fret>)" );
+	streamLine( expected, 2, R"(<fret>0</fret>)" );
 	streamLine( expected, 1, R"(</frame-note>)", false );
 	stringstream actual;
 	// object.toStream( std::cout, 1 );

--- a/Sourcecode/private/mxtest/core/FrameTest.cpp
+++ b/Sourcecode/private/mxtest/core/FrameTest.cpp
@@ -22,7 +22,7 @@ TEST( Test01, Frame )
 	streamLine( expected, 2, R"(<frame-frets>1</frame-frets>)" );
 	streamLine( expected, 2, R"(<frame-note>)" );
 	streamLine( expected, 3, R"(<string>1</string>)" );
-	streamLine( expected, 3, R"(<fret>1</fret>)" );
+	streamLine( expected, 3, R"(<fret>0</fret>)" );
 	streamLine( expected, 2, R"(</frame-note>)" );
     streamLine( expected, 1, R"(</frame>)", false );
 	stringstream actual;
@@ -53,7 +53,7 @@ TEST( Test02, Frame )
 	streamLine( expected, 2, R"(<first-fret>1</first-fret>)" );
 	streamLine( expected, 2, R"(<frame-note>)" );
     streamLine( expected, 3, R"(<string>2</string>)" );
-    streamLine( expected, 3, R"(<fret>1</fret>)" );
+    streamLine( expected, 3, R"(<fret>0</fret>)" );
     streamLine( expected, 2, R"(</frame-note>)" );
     streamLine( expected, 2, R"(<frame-note>)" );
     streamLine( expected, 3, R"(<string>8</string>)" );

--- a/Sourcecode/private/mxtest/core/FretTest.cpp
+++ b/Sourcecode/private/mxtest/core/FretTest.cpp
@@ -28,7 +28,7 @@ TEST( Test01, Fret )
 	object1.toStream( default_constructed, 0 );
 	std::stringstream object2_stream;
 	object2.toStream( object2_stream, 2 );
-	std::string expected = R"(<fret>1</fret>)";
+	std::string expected = R"(<fret>0</fret>)";
 	std::string actual = default_constructed.str();
 	CHECK_EQUAL( expected, actual )
 	expected = indentString+indentString+R"(<fret font-weight="bold">2</fret>)";

--- a/Sourcecode/private/mxtest/core/HarmonyTest.cpp
+++ b/Sourcecode/private/mxtest/core/HarmonyTest.cpp
@@ -124,7 +124,7 @@ namespace mxtest
                 streamLine( os, i+2, R"(<frame-frets>1</frame-frets>)" );
                 streamLine( os, i+2, R"(<frame-note>)" );
                 streamLine( os, i+3, R"(<string>1</string>)" );
-                streamLine( os, i+3, R"(<fret>1</fret>)" );
+                streamLine( os, i+3, R"(<fret>0</fret>)" );
                 streamLine( os, i+2, R"(</frame-note>)" );
                 streamLine( os, i+1, R"(</frame>)" );
                 streamLine( os, i+1, R"(<staff>2</staff>)" );

--- a/Sourcecode/private/mxtest/core/InstrumentsTest.cpp
+++ b/Sourcecode/private/mxtest/core/InstrumentsTest.cpp
@@ -22,7 +22,7 @@ TEST( Test01, Instruments )
 	object1.toStream( default_constructed, 0 );
 	std::stringstream object2_stream;
 	object2.toStream( object2_stream, 2 );
-	std::string expected = R"(<instruments>1</instruments>)";
+	std::string expected = R"(<instruments>0</instruments>)";
 	std::string actual = default_constructed.str();
 	CHECK_EQUAL( expected, actual )
 	expected = indentString+indentString+R"(<instruments>3</instruments>)";

--- a/Sourcecode/private/mxtest/core/InversionTest.cpp
+++ b/Sourcecode/private/mxtest/core/InversionTest.cpp
@@ -28,7 +28,7 @@ TEST( Test01, Inversion )
 	object1.toStream( default_constructed, 0 );
 	std::stringstream object2_stream;
 	object2.toStream( object2_stream, 2 );
-	std::string expected = R"(<inversion>1</inversion>)";
+	std::string expected = R"(<inversion>0</inversion>)";
 	std::string actual = default_constructed.str();
 	CHECK_EQUAL( expected, actual )
 	expected = indentString+indentString+R"(<inversion font-style="italic">3</inversion>)";

--- a/Sourcecode/private/mxtest/core/MetronomeTupletTest.cpp
+++ b/Sourcecode/private/mxtest/core/MetronomeTupletTest.cpp
@@ -18,8 +18,8 @@ TEST( Test01, MetronomeTuplet )
 	MetronomeTuplet object;
 	stringstream expected;
 	streamLine( expected, 1, R"(<metronome-tuplet type="start">)" );
-	streamLine( expected, 2, R"(<actual-notes>1</actual-notes>)" );
-	streamLine( expected, 2, R"(<normal-notes>1</normal-notes>)" );
+	streamLine( expected, 2, R"(<actual-notes>0</actual-notes>)" );
+	streamLine( expected, 2, R"(<normal-notes>0</normal-notes>)" );
 	streamLine( expected, 1, R"(</metronome-tuplet>)", false );
 	stringstream actual;
 	// object.toStream( std::cout, 1 );

--- a/Sourcecode/private/mxtest/core/NormalNotesTest.cpp
+++ b/Sourcecode/private/mxtest/core/NormalNotesTest.cpp
@@ -22,7 +22,7 @@ TEST( Test01, NormalNotes )
 	object1.toStream( default_constructed, 0 );
 	std::stringstream object2_stream;
 	object2.toStream( object2_stream, 2 );
-	std::string expected = R"(<normal-notes>1</normal-notes>)";
+	std::string expected = R"(<normal-notes>0</normal-notes>)";
 	std::string actual = default_constructed.str();
 	CHECK_EQUAL( expected, actual )
 	expected = indentString+indentString+R"(<normal-notes>3</normal-notes>)";

--- a/Sourcecode/private/mxtest/core/StaffLinesTest.cpp
+++ b/Sourcecode/private/mxtest/core/StaffLinesTest.cpp
@@ -22,7 +22,7 @@ TEST( Test01, StaffLines )
 	object1.toStream( default_constructed, 0 );
 	std::stringstream object2_stream;
 	object2.toStream( object2_stream, 2 );
-	std::string expected = R"(<staff-lines>1</staff-lines>)";
+	std::string expected = R"(<staff-lines>0</staff-lines>)";
 	std::string actual = default_constructed.str();
 	CHECK_EQUAL( expected, actual )
 	expected = indentString+indentString+R"(<staff-lines>3</staff-lines>)";

--- a/Sourcecode/private/mxtest/core/StavesTest.cpp
+++ b/Sourcecode/private/mxtest/core/StavesTest.cpp
@@ -22,7 +22,7 @@ TEST( Test01, Staves )
 	object1.toStream( default_constructed, 0 );
 	std::stringstream object2_stream;
 	object2.toStream( object2_stream, 2 );
-	std::string expected = R"(<staves>1</staves>)";
+	std::string expected = R"(<staves>0</staves>)";
 	std::string actual = default_constructed.str();
 	CHECK_EQUAL( expected, actual )
 	expected = indentString+indentString+R"(<staves>3</staves>)";

--- a/Sourcecode/private/mxtest/core/TimeModificationTest.cpp
+++ b/Sourcecode/private/mxtest/core/TimeModificationTest.cpp
@@ -124,8 +124,8 @@ namespace mxtest
             case variant::one:
             {
                 streamLine( os, i, R"(<time-modification>)" );
-                streamLine( os, i+1, R"(<actual-notes>1</actual-notes>)" );
-                streamLine( os, i+1, R"(<normal-notes>1</normal-notes>)" );
+                streamLine( os, i+1, R"(<actual-notes>0</actual-notes>)" );
+                streamLine( os, i+1, R"(<normal-notes>0</normal-notes>)" );
                 streamLine( os, i, R"(</time-modification>)", false );
             }
                 break;

--- a/build.sh
+++ b/build.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+set -eo pipefail
+mx="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
+bld="${mx}/build"
+
+echo "mx=${mx}"
+echo "bld=${bld}"
+procs=$1
+
+mkdir -p "${bld}"
+cd "${bld}"
+cmake "${mx}" \
+  -DMX_BUILD_TESTS=on \
+  -DMX_BUILD_CORE_TESTS=on \
+  -DMX_BUILD_EXAMPLES=on
+make -C "${bld}" -j"${procs:=48}"
+echo "Running MxRead"
+"${bld}/MxRead"
+echo "Running MxWrite"
+"${bld}/MxWrite"
+echo "Running MxTest"
+"${bld}/MxTest"


### PR DESCRIPTION
In support of #58

Re-generate `Integers.h` and `Integers.cpp` from `musicxml.xsd`.

Note that `NonNegativeInteger` previously default constructed to `1`, which is weird. Changed it to default to `0`, and changed the tests that had locked-in that behavior. This revealed a bug in the NoteReader around tuplets, which I fixed.