### PR TITLE
api: support transposing instruments in part data

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ On 2020-05-31, two tags were deleted from origin, `v1.0.0` and `v1.0.1` and repl
 If you cloned/forked the repository before 2020-05-31, you should delete `v1.0.0` and `v1.0.1` and pull tags.
 
 ## [Unreleased]
+### API Changes
+- Add support for setting an instrument's transposition at the start of the score. [#116]
+
+### Internal Changes
 - Change the default-constructed value of `DynamicsEnum` to `mf` instead of `otherDynamics`. [#106]/[8a5cd6b]
 - Change the spelling of `KindValue` enums from, e.g. `dominant11Th` to `dominant11th`. [#105]
 - Break up `Strings.h` into multiple `.h` files, one for each type [#107]. (Related to codegen, [#58]).
@@ -19,6 +23,7 @@ If you cloned/forked the repository before 2020-05-31, you should delete `v1.0.0
 [#111]: https://github.com/webern/mx/pull/111
 [#112]: https://github.com/webern/mx/pull/112
 [#113]: https://github.com/webern/mx/pull/113
+[#116]: https://github.com/webern/mx/pull/116
 [#58]: https://github.com/webern/mx/issues/58
 [8a5cd6b]: https://github.com/webern/mx/commit/8a5cd6b
 

--- a/Resources/custom/transposition.musicxml
+++ b/Resources/custom/transposition.musicxml
@@ -1,0 +1,2646 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE score-partwise PUBLIC "-//Recordare//DTD MusicXML 3.1 Partwise//EN" "http://www.musicxml.org/dtds/partwise.dtd">
+<score-partwise version="3.0">
+  <work>
+    <work-title>Transposition Test</work-title>
+    </work>
+  <identification>
+    <creator type="composer">Matthew James Briggs</creator>
+    <rights type="copyright">No Copyright</rights>
+    <encoding>
+      <software>MuseScore 3.4.2</software>
+      <supports element="accidental" type="yes"/>
+      <supports element="beam" type="yes"/>
+      <supports element="print" attribute="new-page" type="yes" value="yes"/>
+      <supports element="print" attribute="new-system" type="yes" value="yes"/>
+      <supports element="stem" type="yes"/>
+      </encoding>
+    </identification>
+  <defaults>
+    <scaling>
+      <millimeters>3.08</millimeters>
+      <tenths>40</tenths>
+      </scaling>
+    <page-layout>
+      <page-height>3628.57</page-height>
+      <page-width>2803.9</page-width>
+      <page-margins type="both">
+        <left-margin>129.87</left-margin>
+        <right-margin>129.87</right-margin>
+        <top-margin>129.87</top-margin>
+        <bottom-margin>259.74</bottom-margin>
+       </page-margins>
+     </page-layout>
+    </defaults>
+  <credit page="1">
+    <credit-words default-x="1401.95" default-y="3498.7" valign="top" font-size="24">Transposition Test</credit-words>
+    </credit>
+  <credit page="1">
+    <credit-words default-x="1401.95" default-y="3368.83" valign="top" font-size="14">Created with MuseScore to test mx:api Transposition</credit-words>
+    </credit>
+  <credit page="1">
+    <credit-words default-x="2674.03" default-y="3398.7" valign="bottom" font-size="12">Matthew James Briggs</credit-words>
+    </credit>
+  <credit page="1">
+    <credit-words default-x="1401.95" default-y="259.74" valign="bottom" font-size="8">No Copyright</credit-words>
+    </credit>
+  <part-list>
+    <part-group type="start" number="1">
+      <group-symbol>bracket</group-symbol>
+      <group-barline>yes</group-barline>
+      </part-group>
+    <score-part id="P1">
+      <part-name print-object="no">Piccolo</part-name>
+      <part-abbreviation print-object="no">Picc.</part-abbreviation>
+      <score-instrument id="P1-I1">
+        <instrument-name>Piccolo</instrument-name>
+        </score-instrument>
+      <midi-instrument id="P1-I1">
+        <midi-channel>1</midi-channel>
+        <midi-program>73</midi-program>
+        <volume>78.7402</volume>
+        <pan>0</pan>
+        </midi-instrument>
+      </score-part>
+    <part-group type="start" number="2">
+      <group-symbol>square</group-symbol>
+      <group-barline>yes</group-barline>
+      </part-group>
+    <score-part id="P2">
+      <part-name print-object="no">Flute 1</part-name>
+      <part-abbreviation print-object="no">Fl. 1</part-abbreviation>
+      <score-instrument id="P2-I1">
+        <instrument-name>Flute</instrument-name>
+        </score-instrument>
+      <midi-instrument id="P2-I1">
+        <midi-channel>2</midi-channel>
+        <midi-program>74</midi-program>
+        <volume>78.7402</volume>
+        <pan>0</pan>
+        </midi-instrument>
+      </score-part>
+    <score-part id="P3">
+      <part-name print-object="no">Flute 2</part-name>
+      <part-abbreviation print-object="no">Fl. 2</part-abbreviation>
+      <score-instrument id="P3-I1">
+        <instrument-name>Flute</instrument-name>
+        </score-instrument>
+      <midi-instrument id="P3-I1">
+        <midi-channel>3</midi-channel>
+        <midi-program>74</midi-program>
+        <volume>78.7402</volume>
+        <pan>0</pan>
+        </midi-instrument>
+      </score-part>
+    <part-group type="stop" number="2"/>
+    <part-group type="start" number="2">
+      <group-symbol>square</group-symbol>
+      <group-barline>yes</group-barline>
+      </part-group>
+    <score-part id="P4">
+      <part-name print-object="no">Oboe 1</part-name>
+      <part-abbreviation print-object="no">Ob. 1</part-abbreviation>
+      <score-instrument id="P4-I1">
+        <instrument-name>Oboe</instrument-name>
+        </score-instrument>
+      <midi-instrument id="P4-I1">
+        <midi-channel>4</midi-channel>
+        <midi-program>69</midi-program>
+        <volume>78.7402</volume>
+        <pan>0</pan>
+        </midi-instrument>
+      </score-part>
+    <score-part id="P5">
+      <part-name print-object="no">Oboe 2</part-name>
+      <part-abbreviation print-object="no">Ob. 2</part-abbreviation>
+      <score-instrument id="P5-I1">
+        <instrument-name>Oboe</instrument-name>
+        </score-instrument>
+      <midi-instrument id="P5-I1">
+        <midi-channel>5</midi-channel>
+        <midi-program>69</midi-program>
+        <volume>78.7402</volume>
+        <pan>0</pan>
+        </midi-instrument>
+      </score-part>
+    <part-group type="stop" number="2"/>
+    <part-group type="start" number="2">
+      <group-symbol>square</group-symbol>
+      <group-barline>yes</group-barline>
+      </part-group>
+    <score-part id="P6">
+      <part-name print-object="no">Bassoon 1</part-name>
+      <part-abbreviation print-object="no">Bsn. 1</part-abbreviation>
+      <score-instrument id="P6-I1">
+        <instrument-name>Bassoon</instrument-name>
+        </score-instrument>
+      <midi-instrument id="P6-I1">
+        <midi-channel>6</midi-channel>
+        <midi-program>71</midi-program>
+        <volume>78.7402</volume>
+        <pan>0</pan>
+        </midi-instrument>
+      </score-part>
+    <score-part id="P7">
+      <part-name print-object="no">Bassoon 2</part-name>
+      <part-abbreviation print-object="no">Bsn. 2</part-abbreviation>
+      <score-instrument id="P7-I1">
+        <instrument-name>Bassoon</instrument-name>
+        </score-instrument>
+      <midi-instrument id="P7-I1">
+        <midi-channel>7</midi-channel>
+        <midi-program>71</midi-program>
+        <volume>78.7402</volume>
+        <pan>0</pan>
+        </midi-instrument>
+      </score-part>
+    <part-group type="stop" number="2"/>
+    <part-group type="stop" number="1"/>
+    <part-group type="start" number="1">
+      <group-symbol>bracket</group-symbol>
+      <group-barline>yes</group-barline>
+      </part-group>
+    <score-part id="P8">
+      <part-name print-object="no">E♭ Clarinet</part-name>
+      <part-abbreviation print-object="no">E♭ Cl.</part-abbreviation>
+      <score-instrument id="P8-I1">
+        <instrument-name>E♭ Clarinet</instrument-name>
+        </score-instrument>
+      <midi-instrument id="P8-I1">
+        <midi-channel>8</midi-channel>
+        <midi-program>72</midi-program>
+        <volume>78.7402</volume>
+        <pan>0</pan>
+        </midi-instrument>
+      </score-part>
+    <part-group type="start" number="2">
+      <group-symbol>square</group-symbol>
+      <group-barline>yes</group-barline>
+      </part-group>
+    <score-part id="P9">
+      <part-name print-object="no">B♭ Clarinet 1</part-name>
+      <part-abbreviation print-object="no">B♭ Cl. 1</part-abbreviation>
+      <score-instrument id="P9-I1">
+        <instrument-name>B♭ Clarinet</instrument-name>
+        </score-instrument>
+      <midi-instrument id="P9-I1">
+        <midi-channel>9</midi-channel>
+        <midi-program>72</midi-program>
+        <volume>78.7402</volume>
+        <pan>0</pan>
+        </midi-instrument>
+      </score-part>
+    <score-part id="P10">
+      <part-name print-object="no">B♭ Clarinet 2</part-name>
+      <part-abbreviation print-object="no">B♭ Cl. 2</part-abbreviation>
+      <score-instrument id="P10-I1">
+        <instrument-name>B♭ Clarinet</instrument-name>
+        </score-instrument>
+      <midi-instrument id="P10-I1">
+        <midi-channel>11</midi-channel>
+        <midi-program>72</midi-program>
+        <volume>78.7402</volume>
+        <pan>0</pan>
+        </midi-instrument>
+      </score-part>
+    <score-part id="P11">
+      <part-name print-object="no">B♭ Clarinet 3</part-name>
+      <part-abbreviation print-object="no">B♭ Cl. 3</part-abbreviation>
+      <score-instrument id="P11-I1">
+        <instrument-name>B♭ Clarinet</instrument-name>
+        </score-instrument>
+      <midi-instrument id="P11-I1">
+        <midi-channel>12</midi-channel>
+        <midi-program>72</midi-program>
+        <volume>78.7402</volume>
+        <pan>0</pan>
+        </midi-instrument>
+      </score-part>
+    <part-group type="stop" number="2"/>
+    <score-part id="P12">
+      <part-name print-object="no">Bass Clarinet</part-name>
+      <part-abbreviation print-object="no">B. Cl.</part-abbreviation>
+      <score-instrument id="P12-I1">
+        <instrument-name>Bass Clarinet</instrument-name>
+        </score-instrument>
+      <midi-instrument id="P12-I1">
+        <midi-channel>13</midi-channel>
+        <midi-program>72</midi-program>
+        <volume>78.7402</volume>
+        <pan>0</pan>
+        </midi-instrument>
+      </score-part>
+    <part-group type="stop" number="1"/>
+    <part-group type="start" number="1">
+      <group-symbol>bracket</group-symbol>
+      <group-barline>yes</group-barline>
+      </part-group>
+    <part-group type="start" number="2">
+      <group-symbol>square</group-symbol>
+      <group-barline>yes</group-barline>
+      </part-group>
+    <score-part id="P13">
+      <part-name print-object="no">Alto Saxophone 1</part-name>
+      <part-abbreviation print-object="no">A. Sax. 1</part-abbreviation>
+      <score-instrument id="P13-I1">
+        <instrument-name>Alto Saxophone</instrument-name>
+        </score-instrument>
+      <midi-instrument id="P13-I1">
+        <midi-channel>14</midi-channel>
+        <midi-program>66</midi-program>
+        <volume>78.7402</volume>
+        <pan>0</pan>
+        </midi-instrument>
+      </score-part>
+    <score-part id="P14">
+      <part-name print-object="no">Alto Saxophone 2</part-name>
+      <part-abbreviation print-object="no">A. Sax. 2</part-abbreviation>
+      <score-instrument id="P14-I1">
+        <instrument-name>Alto Saxophone</instrument-name>
+        </score-instrument>
+      <midi-instrument id="P14-I1">
+        <midi-channel>15</midi-channel>
+        <midi-program>66</midi-program>
+        <volume>78.7402</volume>
+        <pan>0</pan>
+        </midi-instrument>
+      </score-part>
+    <part-group type="stop" number="2"/>
+    <score-part id="P15">
+      <part-name print-object="no">Tenor Saxophone</part-name>
+      <part-abbreviation print-object="no">T. Sax.</part-abbreviation>
+      <score-instrument id="P15-I1">
+        <instrument-name>Tenor Saxophone</instrument-name>
+        </score-instrument>
+      <midi-instrument id="P15-I1">
+        <midi-channel>16</midi-channel>
+        <midi-program>67</midi-program>
+        <volume>78.7402</volume>
+        <pan>0</pan>
+        </midi-instrument>
+      </score-part>
+    <score-part id="P16">
+      <part-name print-object="no">Baritone Saxophone</part-name>
+      <part-abbreviation print-object="no">Bar. Sax.</part-abbreviation>
+      <score-instrument id="P16-I1">
+        <instrument-name>Baritone Saxophone</instrument-name>
+        </score-instrument>
+      <midi-instrument id="P16-I1">
+        <midi-channel>1</midi-channel>
+        <midi-program>68</midi-program>
+        <volume>78.7402</volume>
+        <pan>0</pan>
+        </midi-instrument>
+      </score-part>
+    <part-group type="stop" number="1"/>
+    <part-group type="start" number="1">
+      <group-symbol>bracket</group-symbol>
+      <group-barline>yes</group-barline>
+      </part-group>
+    <part-group type="start" number="2">
+      <group-symbol>square</group-symbol>
+      <group-barline>yes</group-barline>
+      </part-group>
+    <score-part id="P17">
+      <part-name print-object="no">B♭ Trumpet 1</part-name>
+      <part-abbreviation print-object="no">B♭ Tpt. 1</part-abbreviation>
+      <score-instrument id="P17-I1">
+        <instrument-name>B♭ Trumpet</instrument-name>
+        </score-instrument>
+      <midi-instrument id="P17-I1">
+        <midi-channel>2</midi-channel>
+        <midi-program>57</midi-program>
+        <volume>78.7402</volume>
+        <pan>0</pan>
+        </midi-instrument>
+      </score-part>
+    <score-part id="P18">
+      <part-name print-object="no">B♭ Trumpet 2</part-name>
+      <part-abbreviation print-object="no">B♭ Tpt. 2</part-abbreviation>
+      <score-instrument id="P18-I1">
+        <instrument-name>B♭ Trumpet</instrument-name>
+        </score-instrument>
+      <midi-instrument id="P18-I1">
+        <midi-channel>4</midi-channel>
+        <midi-program>57</midi-program>
+        <volume>78.7402</volume>
+        <pan>0</pan>
+        </midi-instrument>
+      </score-part>
+    <score-part id="P19">
+      <part-name print-object="no">B♭ Trumpet 3</part-name>
+      <part-abbreviation print-object="no">B♭ Tpt. 3</part-abbreviation>
+      <score-instrument id="P19-I1">
+        <instrument-name>B♭ Trumpet</instrument-name>
+        </score-instrument>
+      <midi-instrument id="P19-I1">
+        <midi-channel>6</midi-channel>
+        <midi-program>57</midi-program>
+        <volume>78.7402</volume>
+        <pan>0</pan>
+        </midi-instrument>
+      </score-part>
+    <part-group type="stop" number="2"/>
+    <part-group type="start" number="2">
+      <group-symbol>square</group-symbol>
+      <group-barline>yes</group-barline>
+      </part-group>
+    <score-part id="P20">
+      <part-name print-object="no">F Horn 1 &amp;amp; 2</part-name>
+      <part-abbreviation print-object="no">F Hn. 1 2</part-abbreviation>
+      <score-instrument id="P20-I1">
+        <instrument-name>Horn in F</instrument-name>
+        </score-instrument>
+      <midi-instrument id="P20-I1">
+        <midi-channel>8</midi-channel>
+        <midi-program>61</midi-program>
+        <volume>78.7402</volume>
+        <pan>0</pan>
+        </midi-instrument>
+      </score-part>
+    <score-part id="P21">
+      <part-name print-object="no">F Horn 3 &amp;amp; 4</part-name>
+      <part-abbreviation print-object="no">F Hn. 3 4</part-abbreviation>
+      <score-instrument id="P21-I1">
+        <instrument-name>Horn in F</instrument-name>
+        </score-instrument>
+      <midi-instrument id="P21-I1">
+        <midi-channel>9</midi-channel>
+        <midi-program>61</midi-program>
+        <volume>78.7402</volume>
+        <pan>0</pan>
+        </midi-instrument>
+      </score-part>
+    <part-group type="stop" number="2"/>
+    <part-group type="start" number="2">
+      <group-symbol>square</group-symbol>
+      <group-barline>yes</group-barline>
+      </part-group>
+    <score-part id="P22">
+      <part-name print-object="no">Trombone 1</part-name>
+      <part-abbreviation print-object="no">Tbn. 1</part-abbreviation>
+      <score-instrument id="P22-I1">
+        <instrument-name>Trombone</instrument-name>
+        </score-instrument>
+      <midi-instrument id="P22-I1">
+        <midi-channel>11</midi-channel>
+        <midi-program>58</midi-program>
+        <volume>78.7402</volume>
+        <pan>0</pan>
+        </midi-instrument>
+      </score-part>
+    <score-part id="P23">
+      <part-name print-object="no">Trombone 2</part-name>
+      <part-abbreviation print-object="no">Tbn. 2</part-abbreviation>
+      <score-instrument id="P23-I1">
+        <instrument-name>Trombone</instrument-name>
+        </score-instrument>
+      <midi-instrument id="P23-I1">
+        <midi-channel>12</midi-channel>
+        <midi-program>58</midi-program>
+        <volume>78.7402</volume>
+        <pan>0</pan>
+        </midi-instrument>
+      </score-part>
+    <score-part id="P24">
+      <part-name print-object="no">Trombone 3 &amp;amp;
+Bass Trombone</part-name>
+      <part-abbreviation print-object="no">Tbn. 3
+B. Tbn.</part-abbreviation>
+      <score-instrument id="P24-I1">
+        <instrument-name>Trombone</instrument-name>
+        </score-instrument>
+      <midi-instrument id="P24-I1">
+        <midi-channel>13</midi-channel>
+        <midi-program>58</midi-program>
+        <volume>78.7402</volume>
+        <pan>0</pan>
+        </midi-instrument>
+      </score-part>
+    <part-group type="stop" number="2"/>
+    <score-part id="P25">
+      <part-name print-object="no">Euphonium</part-name>
+      <part-abbreviation print-object="no">Euph.</part-abbreviation>
+      <score-instrument id="P25-I1">
+        <instrument-name>Euphonium</instrument-name>
+        </score-instrument>
+      <midi-instrument id="P25-I1">
+        <midi-channel>14</midi-channel>
+        <midi-program>59</midi-program>
+        <volume>78.7402</volume>
+        <pan>0</pan>
+        </midi-instrument>
+      </score-part>
+    <score-part id="P26">
+      <part-name print-object="no">Tuba</part-name>
+      <part-abbreviation print-object="no">Tba.</part-abbreviation>
+      <score-instrument id="P26-I1">
+        <instrument-name>Tuba</instrument-name>
+        </score-instrument>
+      <midi-instrument id="P26-I1">
+        <midi-channel>15</midi-channel>
+        <midi-program>59</midi-program>
+        <volume>78.7402</volume>
+        <pan>0</pan>
+        </midi-instrument>
+      </score-part>
+    <part-group type="stop" number="1"/>
+    <part-group type="start" number="1">
+      <group-symbol>bracket</group-symbol>
+      <group-barline>yes</group-barline>
+      </part-group>
+    <score-part id="P27">
+      <part-name print-object="no">Double Bass</part-name>
+      <part-abbreviation print-object="no">Db.</part-abbreviation>
+      <score-instrument id="P27-I1">
+        <instrument-name>Double Bass</instrument-name>
+        </score-instrument>
+      <midi-instrument id="P27-I1">
+        <midi-channel>16</midi-channel>
+        <midi-program>44</midi-program>
+        <volume>78.7402</volume>
+        <pan>0</pan>
+        </midi-instrument>
+      </score-part>
+    <part-group type="stop" number="1"/>
+    <part-group type="start" number="1">
+      <group-symbol>bracket</group-symbol>
+      <group-barline>yes</group-barline>
+      </part-group>
+    <score-part id="P28">
+      <part-name print-object="no">Timpani</part-name>
+      <part-abbreviation print-object="no">Timp.</part-abbreviation>
+      <score-instrument id="P28-I1">
+        <instrument-name>Timpani</instrument-name>
+        </score-instrument>
+      <midi-instrument id="P28-I1">
+        <midi-channel>3</midi-channel>
+        <midi-program>48</midi-program>
+        <volume>78.7402</volume>
+        <pan>0</pan>
+        </midi-instrument>
+      </score-part>
+    <score-part id="P29">
+      <part-name print-object="no">Glockenspiel</part-name>
+      <part-abbreviation print-object="no">Glk.</part-abbreviation>
+      <score-instrument id="P29-I1">
+        <instrument-name>Glockenspiel</instrument-name>
+        </score-instrument>
+      <midi-instrument id="P29-I1">
+        <midi-channel>4</midi-channel>
+        <midi-program>10</midi-program>
+        <volume>78.7402</volume>
+        <pan>0</pan>
+        </midi-instrument>
+      </score-part>
+    <score-part id="P30">
+      <part-name print-object="no">Percussion 1</part-name>
+      <part-abbreviation print-object="no">Perc. 1</part-abbreviation>
+      <score-instrument id="P30-I28">
+        <instrument-name>Closed Hi-Hat</instrument-name>
+        </score-instrument>
+      <midi-instrument id="P30-I28">
+        <midi-channel>10</midi-channel>
+        <midi-program>49</midi-program>
+        <volume>78.7402</volume>
+        <pan>0</pan>
+        </midi-instrument>
+      </score-part>
+    <score-part id="P31">
+      <part-name print-object="no">Percussion 2</part-name>
+      <part-abbreviation print-object="no">Perc. 2</part-abbreviation>
+      <score-instrument id="P31-I28">
+        <instrument-name>Closed Hi-Hat</instrument-name>
+        </score-instrument>
+      <midi-instrument id="P31-I28">
+        <midi-channel>10</midi-channel>
+        <midi-program>49</midi-program>
+        <volume>78.7402</volume>
+        <pan>0</pan>
+        </midi-instrument>
+      </score-part>
+    <part-group type="stop" number="1"/>
+    </part-list>
+  <part id="P1">
+    <measure number="1" width="529.52">
+      <attributes>
+        <divisions>1</divisions>
+        <key>
+          <fifths>-7</fifths>
+          </key>
+        <time>
+          <beats>4</beats>
+          <beat-type>4</beat-type>
+          </time>
+        <clef>
+          <sign>G</sign>
+          <line>2</line>
+          </clef>
+        <transpose>
+          <diatonic>0</diatonic>
+          <chromatic>0</chromatic>
+          <octave-change>1</octave-change>
+          </transpose>
+        </attributes>
+      <note default-x="161.57" default-y="-15.00">
+        <pitch>
+          <step>C</step>
+          <alter>-1</alter>
+          <octave>5</octave>
+          </pitch>
+        <duration>4</duration>
+        <voice>1</voice>
+        <type>whole</type>
+        </note>
+      </measure>
+    <measure number="2" width="332.07">
+      <note default-x="13.80" default-y="-25.00">
+        <pitch>
+          <step>A</step>
+          <alter>-1</alter>
+          <octave>4</octave>
+          </pitch>
+        <duration>4</duration>
+        <voice>1</voice>
+        <type>whole</type>
+        </note>
+      <barline location="right">
+        <bar-style>light-heavy</bar-style>
+        </barline>
+      </measure>
+    </part>
+  <part id="P2">
+    <measure number="1" width="529.52">
+      <attributes>
+        <divisions>1</divisions>
+        <key>
+          <fifths>-7</fifths>
+          </key>
+        <time>
+          <beats>4</beats>
+          <beat-type>4</beat-type>
+          </time>
+        <clef>
+          <sign>G</sign>
+          <line>2</line>
+          </clef>
+        </attributes>
+      <note default-x="164.89" default-y="-125.00">
+        <pitch>
+          <step>B</step>
+          <alter>-1</alter>
+          <octave>4</octave>
+          </pitch>
+        <duration>1</duration>
+        <voice>1</voice>
+        <type>quarter</type>
+        <stem>down</stem>
+        </note>
+      <note default-x="255.65" default-y="-100.00">
+        <pitch>
+          <step>G</step>
+          <alter>-1</alter>
+          <octave>5</octave>
+          </pitch>
+        <duration>1</duration>
+        <voice>1</voice>
+        <type>quarter</type>
+        <stem>down</stem>
+        </note>
+      <note default-x="346.40" default-y="-115.00">
+        <pitch>
+          <step>D</step>
+          <alter>-1</alter>
+          <octave>5</octave>
+          </pitch>
+        <duration>1</duration>
+        <voice>1</voice>
+        <type>quarter</type>
+        <stem>down</stem>
+        </note>
+      <note default-x="437.16" default-y="-155.00">
+        <pitch>
+          <step>C</step>
+          <alter>-1</alter>
+          <octave>4</octave>
+          </pitch>
+        <duration>1</duration>
+        <voice>1</voice>
+        <type>quarter</type>
+        <stem>up</stem>
+        </note>
+      </measure>
+    <measure number="2" width="332.07">
+      <note default-x="13.80" default-y="-130.00">
+        <pitch>
+          <step>A</step>
+          <alter>-1</alter>
+          <octave>4</octave>
+          </pitch>
+        <duration>4</duration>
+        <voice>1</voice>
+        <type>whole</type>
+        </note>
+      <barline location="right">
+        <bar-style>light-heavy</bar-style>
+        </barline>
+      </measure>
+    </part>
+  <part id="P3">
+    <measure number="1" width="529.52">
+      <attributes>
+        <divisions>1</divisions>
+        <key>
+          <fifths>-7</fifths>
+          </key>
+        <time>
+          <beats>4</beats>
+          <beat-type>4</beat-type>
+          </time>
+        <clef>
+          <sign>G</sign>
+          <line>2</line>
+          </clef>
+        </attributes>
+      <note default-x="164.89" default-y="-230.00">
+        <pitch>
+          <step>B</step>
+          <alter>-1</alter>
+          <octave>4</octave>
+          </pitch>
+        <duration>1</duration>
+        <voice>1</voice>
+        <type>quarter</type>
+        <stem>down</stem>
+        </note>
+      <note>
+        <rest/>
+        <duration>1</duration>
+        <voice>1</voice>
+        <type>quarter</type>
+        </note>
+      <note default-x="346.40" default-y="-260.00">
+        <pitch>
+          <step>C</step>
+          <alter>-1</alter>
+          <octave>4</octave>
+          </pitch>
+        <duration>1</duration>
+        <voice>1</voice>
+        <type>quarter</type>
+        <stem>up</stem>
+        </note>
+      <note>
+        <rest/>
+        <duration>1</duration>
+        <voice>1</voice>
+        <type>quarter</type>
+        </note>
+      </measure>
+    <measure number="2" width="332.07">
+      <note default-x="13.80" default-y="-210.00">
+        <pitch>
+          <step>F</step>
+          <alter>-1</alter>
+          <octave>5</octave>
+          </pitch>
+        <duration>4</duration>
+        <voice>1</voice>
+        <type>whole</type>
+        </note>
+      <barline location="right">
+        <bar-style>light-heavy</bar-style>
+        </barline>
+      </measure>
+    </part>
+  <part id="P4">
+    <measure number="1" width="529.52">
+      <attributes>
+        <divisions>1</divisions>
+        <key>
+          <fifths>-7</fifths>
+          </key>
+        <time>
+          <beats>4</beats>
+          <beat-type>4</beat-type>
+          </time>
+        <clef>
+          <sign>G</sign>
+          <line>2</line>
+          </clef>
+        </attributes>
+      <note default-x="164.89" default-y="-355.00">
+        <pitch>
+          <step>E</step>
+          <alter>-1</alter>
+          <octave>4</octave>
+          </pitch>
+        <duration>1</duration>
+        <voice>1</voice>
+        <type>quarter</type>
+        <stem>up</stem>
+        </note>
+      <note>
+        <rest/>
+        <duration>1</duration>
+        <voice>1</voice>
+        <type>quarter</type>
+        </note>
+      <note default-x="346.40" default-y="-340.00">
+        <pitch>
+          <step>A</step>
+          <alter>-1</alter>
+          <octave>4</octave>
+          </pitch>
+        <duration>1</duration>
+        <voice>1</voice>
+        <type>quarter</type>
+        <stem>up</stem>
+        </note>
+      <note>
+        <rest/>
+        <duration>1</duration>
+        <voice>1</voice>
+        <type>quarter</type>
+        </note>
+      </measure>
+    <measure number="2" width="332.07">
+      <note default-x="13.80" default-y="-320.00">
+        <pitch>
+          <step>E</step>
+          <alter>-1</alter>
+          <octave>5</octave>
+          </pitch>
+        <duration>4</duration>
+        <voice>1</voice>
+        <type>whole</type>
+        </note>
+      <barline location="right">
+        <bar-style>light-heavy</bar-style>
+        </barline>
+      </measure>
+    </part>
+  <part id="P5">
+    <measure number="1" width="529.52">
+      <attributes>
+        <divisions>1</divisions>
+        <key>
+          <fifths>-7</fifths>
+          </key>
+        <time>
+          <beats>4</beats>
+          <beat-type>4</beat-type>
+          </time>
+        <clef>
+          <sign>G</sign>
+          <line>2</line>
+          </clef>
+        </attributes>
+      <note default-x="164.89" default-y="-440.00">
+        <pitch>
+          <step>B</step>
+          <alter>-1</alter>
+          <octave>4</octave>
+          </pitch>
+        <duration>1</duration>
+        <voice>1</voice>
+        <type>quarter</type>
+        <stem>down</stem>
+        </note>
+      <note>
+        <rest/>
+        <duration>1</duration>
+        <voice>1</voice>
+        <type>quarter</type>
+        </note>
+      <note default-x="346.40" default-y="-480.00">
+        <pitch>
+          <step>A</step>
+          <alter>-1</alter>
+          <octave>3</octave>
+          </pitch>
+        <duration>1</duration>
+        <voice>1</voice>
+        <type>quarter</type>
+        <stem>up</stem>
+        </note>
+      <note>
+        <rest/>
+        <duration>1</duration>
+        <voice>1</voice>
+        <type>quarter</type>
+        </note>
+      </measure>
+    <measure number="2" width="332.07">
+      <note default-x="13.80" default-y="-425.00">
+        <pitch>
+          <step>E</step>
+          <alter>-1</alter>
+          <octave>5</octave>
+          </pitch>
+        <duration>4</duration>
+        <voice>1</voice>
+        <type>whole</type>
+        </note>
+      <barline location="right">
+        <bar-style>light-heavy</bar-style>
+        </barline>
+      </measure>
+    </part>
+  <part id="P6">
+    <measure number="1" width="529.52">
+      <attributes>
+        <divisions>1</divisions>
+        <key>
+          <fifths>-7</fifths>
+          </key>
+        <time>
+          <beats>4</beats>
+          <beat-type>4</beat-type>
+          </time>
+        <clef>
+          <sign>F</sign>
+          <line>4</line>
+          </clef>
+        </attributes>
+      <note default-x="164.89" default-y="-535.00">
+        <pitch>
+          <step>F</step>
+          <alter>-1</alter>
+          <octave>3</octave>
+          </pitch>
+        <duration>1</duration>
+        <voice>1</voice>
+        <type>quarter</type>
+        <stem>down</stem>
+        </note>
+      <note>
+        <rest/>
+        <duration>1</duration>
+        <voice>1</voice>
+        <type>quarter</type>
+        </note>
+      <note default-x="346.40" default-y="-545.00">
+        <pitch>
+          <step>D</step>
+          <alter>-1</alter>
+          <octave>3</octave>
+          </pitch>
+        <duration>1</duration>
+        <voice>1</voice>
+        <type>quarter</type>
+        <stem>down</stem>
+        </note>
+      <note>
+        <rest/>
+        <duration>1</duration>
+        <voice>1</voice>
+        <type>quarter</type>
+        </note>
+      </measure>
+    <measure number="2" width="332.07">
+      <note default-x="13.80" default-y="-540.00">
+        <pitch>
+          <step>E</step>
+          <alter>-1</alter>
+          <octave>3</octave>
+          </pitch>
+        <duration>4</duration>
+        <voice>1</voice>
+        <type>whole</type>
+        </note>
+      <barline location="right">
+        <bar-style>light-heavy</bar-style>
+        </barline>
+      </measure>
+    </part>
+  <part id="P7">
+    <measure number="1" width="529.52">
+      <attributes>
+        <divisions>1</divisions>
+        <key>
+          <fifths>-7</fifths>
+          </key>
+        <time>
+          <beats>4</beats>
+          <beat-type>4</beat-type>
+          </time>
+        <clef>
+          <sign>F</sign>
+          <line>4</line>
+          </clef>
+        </attributes>
+      <note default-x="164.89" default-y="-655.00">
+        <pitch>
+          <step>C</step>
+          <alter>-1</alter>
+          <octave>3</octave>
+          </pitch>
+        <duration>1</duration>
+        <voice>1</voice>
+        <type>quarter</type>
+        <stem>up</stem>
+        </note>
+      <note>
+        <rest/>
+        <duration>1</duration>
+        <voice>1</voice>
+        <type>quarter</type>
+        </note>
+      <note default-x="346.40" default-y="-685.00">
+        <pitch>
+          <step>D</step>
+          <alter>-1</alter>
+          <octave>2</octave>
+          </pitch>
+        <duration>1</duration>
+        <voice>1</voice>
+        <type>quarter</type>
+        <stem>up</stem>
+        </note>
+      <note>
+        <rest/>
+        <duration>1</duration>
+        <voice>1</voice>
+        <type>quarter</type>
+        </note>
+      </measure>
+    <measure number="2" width="332.07">
+      <note default-x="13.80" default-y="-650.00">
+        <pitch>
+          <step>D</step>
+          <alter>-1</alter>
+          <octave>3</octave>
+          </pitch>
+        <duration>4</duration>
+        <voice>1</voice>
+        <type>whole</type>
+        </note>
+      <barline location="right">
+        <bar-style>light-heavy</bar-style>
+        </barline>
+      </measure>
+    </part>
+  <part id="P8">
+    <measure number="1" width="529.52">
+      <attributes>
+        <divisions>1</divisions>
+        <key>
+          <fifths>-4</fifths>
+          </key>
+        <time>
+          <beats>4</beats>
+          <beat-type>4</beat-type>
+          </time>
+        <clef>
+          <sign>G</sign>
+          <line>2</line>
+          </clef>
+        <transpose>
+          <diatonic>2</diatonic>
+          <chromatic>3</chromatic>
+          </transpose>
+        </attributes>
+      <note default-x="164.89" default-y="-755.00">
+        <pitch>
+          <step>B</step>
+          <alter>-1</alter>
+          <octave>4</octave>
+          </pitch>
+        <duration>1</duration>
+        <voice>1</voice>
+        <type>quarter</type>
+        <stem>down</stem>
+        </note>
+      <note default-x="255.65" default-y="-765.00">
+        <pitch>
+          <step>G</step>
+          <octave>4</octave>
+          </pitch>
+        <duration>1</duration>
+        <voice>1</voice>
+        <type>quarter</type>
+        <stem>up</stem>
+        </note>
+      <note default-x="346.40" default-y="-770.00">
+        <pitch>
+          <step>F</step>
+          <octave>4</octave>
+          </pitch>
+        <duration>1</duration>
+        <voice>1</voice>
+        <type>quarter</type>
+        <stem>up</stem>
+        </note>
+      <note default-x="437.16" default-y="-785.00">
+        <pitch>
+          <step>C</step>
+          <octave>4</octave>
+          </pitch>
+        <duration>1</duration>
+        <voice>1</voice>
+        <type>quarter</type>
+        <stem>up</stem>
+        </note>
+      </measure>
+    <measure number="2" width="332.07">
+      <note default-x="13.80" default-y="-750.00">
+        <pitch>
+          <step>C</step>
+          <octave>5</octave>
+          </pitch>
+        <duration>4</duration>
+        <voice>1</voice>
+        <type>whole</type>
+        </note>
+      <barline location="right">
+        <bar-style>light-heavy</bar-style>
+        </barline>
+      </measure>
+    </part>
+  <part id="P9">
+    <measure number="1" width="529.52">
+      <attributes>
+        <divisions>1</divisions>
+        <key>
+          <fifths>-5</fifths>
+          </key>
+        <time>
+          <beats>4</beats>
+          <beat-type>4</beat-type>
+          </time>
+        <clef>
+          <sign>G</sign>
+          <line>2</line>
+          </clef>
+        <transpose>
+          <diatonic>-1</diatonic>
+          <chromatic>-2</chromatic>
+          </transpose>
+        </attributes>
+      <note default-x="164.89" default-y="-865.00">
+        <pitch>
+          <step>A</step>
+          <alter>-1</alter>
+          <octave>4</octave>
+          </pitch>
+        <duration>1</duration>
+        <voice>1</voice>
+        <type>quarter</type>
+        <stem>up</stem>
+        </note>
+      <note default-x="255.65" default-y="-840.00">
+        <pitch>
+          <step>F</step>
+          <octave>5</octave>
+          </pitch>
+        <duration>1</duration>
+        <voice>1</voice>
+        <type>quarter</type>
+        <stem>down</stem>
+        </note>
+      <note default-x="346.40" default-y="-825.00">
+        <pitch>
+          <step>B</step>
+          <alter>-1</alter>
+          <octave>5</octave>
+          </pitch>
+        <duration>1</duration>
+        <voice>1</voice>
+        <type>quarter</type>
+        <stem>down</stem>
+        </note>
+      <note default-x="437.16" default-y="-815.00">
+        <pitch>
+          <step>D</step>
+          <alter>-1</alter>
+          <octave>6</octave>
+          </pitch>
+        <duration>1</duration>
+        <voice>1</voice>
+        <type>quarter</type>
+        <stem>down</stem>
+        </note>
+      </measure>
+    <measure number="2" width="332.07">
+      <note default-x="13.80" default-y="-860.00">
+        <pitch>
+          <step>B</step>
+          <alter>-1</alter>
+          <octave>4</octave>
+          </pitch>
+        <duration>4</duration>
+        <voice>1</voice>
+        <type>whole</type>
+        </note>
+      <barline location="right">
+        <bar-style>light-heavy</bar-style>
+        </barline>
+      </measure>
+    </part>
+  <part id="P10">
+    <measure number="1" width="529.52">
+      <attributes>
+        <divisions>1</divisions>
+        <key>
+          <fifths>-5</fifths>
+          </key>
+        <time>
+          <beats>4</beats>
+          <beat-type>4</beat-type>
+          </time>
+        <clef>
+          <sign>G</sign>
+          <line>2</line>
+          </clef>
+        <transpose>
+          <diatonic>-1</diatonic>
+          <chromatic>-2</chromatic>
+          </transpose>
+        </attributes>
+      <note default-x="164.89" default-y="-985.00">
+        <pitch>
+          <step>E</step>
+          <alter>-1</alter>
+          <octave>4</octave>
+          </pitch>
+        <duration>1</duration>
+        <voice>1</voice>
+        <type>quarter</type>
+        <stem>up</stem>
+        </note>
+      <note default-x="255.65" default-y="-970.00">
+        <pitch>
+          <step>A</step>
+          <alter>-1</alter>
+          <octave>4</octave>
+          </pitch>
+        <duration>1</duration>
+        <voice>1</voice>
+        <type>quarter</type>
+        <stem>up</stem>
+        </note>
+      <note default-x="346.40" default-y="-955.00">
+        <pitch>
+          <step>D</step>
+          <alter>-1</alter>
+          <octave>5</octave>
+          </pitch>
+        <duration>1</duration>
+        <voice>1</voice>
+        <type>quarter</type>
+        <stem>down</stem>
+        </note>
+      <note default-x="437.16" default-y="-930.00">
+        <pitch>
+          <step>B</step>
+          <alter>-1</alter>
+          <octave>5</octave>
+          </pitch>
+        <duration>1</duration>
+        <voice>1</voice>
+        <type>quarter</type>
+        <stem>down</stem>
+        </note>
+      </measure>
+    <measure number="2" width="332.07">
+      <note default-x="13.80" default-y="-975.00">
+        <pitch>
+          <step>G</step>
+          <alter>-1</alter>
+          <octave>4</octave>
+          </pitch>
+        <duration>4</duration>
+        <voice>1</voice>
+        <type>whole</type>
+        </note>
+      <barline location="right">
+        <bar-style>light-heavy</bar-style>
+        </barline>
+      </measure>
+    </part>
+  <part id="P11">
+    <measure number="1" width="529.52">
+      <attributes>
+        <divisions>1</divisions>
+        <key>
+          <fifths>-5</fifths>
+          </key>
+        <time>
+          <beats>4</beats>
+          <beat-type>4</beat-type>
+          </time>
+        <clef>
+          <sign>G</sign>
+          <line>2</line>
+          </clef>
+        <transpose>
+          <diatonic>-1</diatonic>
+          <chromatic>-2</chromatic>
+          </transpose>
+        </attributes>
+      <note default-x="164.89" default-y="-1090.00">
+        <pitch>
+          <step>E</step>
+          <alter>-1</alter>
+          <octave>4</octave>
+          </pitch>
+        <duration>1</duration>
+        <voice>1</voice>
+        <type>quarter</type>
+        <stem>up</stem>
+        </note>
+      <note>
+        <rest/>
+        <duration>1</duration>
+        <voice>1</voice>
+        <type>quarter</type>
+        </note>
+      <note default-x="346.40" default-y="-1075.00">
+        <pitch>
+          <step>A</step>
+          <alter>-1</alter>
+          <octave>4</octave>
+          </pitch>
+        <duration>1</duration>
+        <voice>1</voice>
+        <type>quarter</type>
+        <stem>up</stem>
+        </note>
+      <note>
+        <rest/>
+        <duration>1</duration>
+        <voice>1</voice>
+        <type>quarter</type>
+        </note>
+      </measure>
+    <measure number="2" width="332.07">
+      <note default-x="13.80" default-y="-1020.00">
+        <pitch>
+          <step>E</step>
+          <alter>-1</alter>
+          <octave>6</octave>
+          </pitch>
+        <duration>4</duration>
+        <voice>1</voice>
+        <type>whole</type>
+        </note>
+      <barline location="right">
+        <bar-style>light-heavy</bar-style>
+        </barline>
+      </measure>
+    </part>
+  <part id="P12">
+    <measure number="1" width="529.52">
+      <attributes>
+        <divisions>1</divisions>
+        <key>
+          <fifths>-5</fifths>
+          </key>
+        <time>
+          <beats>4</beats>
+          <beat-type>4</beat-type>
+          </time>
+        <clef>
+          <sign>G</sign>
+          <line>2</line>
+          </clef>
+        <transpose>
+          <diatonic>-1</diatonic>
+          <chromatic>-2</chromatic>
+          <octave-change>-1</octave-change>
+          </transpose>
+        </attributes>
+      <note default-x="164.89" default-y="-1180.00">
+        <pitch>
+          <step>A</step>
+          <alter>-1</alter>
+          <octave>4</octave>
+          </pitch>
+        <duration>1</duration>
+        <voice>1</voice>
+        <type>quarter</type>
+        <stem>up</stem>
+        </note>
+      <note>
+        <rest/>
+        <duration>1</duration>
+        <voice>1</voice>
+        <type>quarter</type>
+        </note>
+      <note default-x="346.40" default-y="-1185.00">
+        <pitch>
+          <step>G</step>
+          <alter>-1</alter>
+          <octave>4</octave>
+          </pitch>
+        <duration>1</duration>
+        <voice>1</voice>
+        <type>quarter</type>
+        <stem>up</stem>
+        </note>
+      <note>
+        <rest/>
+        <duration>1</duration>
+        <voice>1</voice>
+        <type>quarter</type>
+        </note>
+      </measure>
+    <measure number="2" width="332.07">
+      <note default-x="13.80" default-y="-1190.00">
+        <pitch>
+          <step>F</step>
+          <octave>4</octave>
+          </pitch>
+        <duration>4</duration>
+        <voice>1</voice>
+        <type>whole</type>
+        </note>
+      <barline location="right">
+        <bar-style>light-heavy</bar-style>
+        </barline>
+      </measure>
+    </part>
+  <part id="P13">
+    <measure number="1" width="529.52">
+      <attributes>
+        <divisions>1</divisions>
+        <key>
+          <fifths>-4</fifths>
+          </key>
+        <time>
+          <beats>4</beats>
+          <beat-type>4</beat-type>
+          </time>
+        <clef>
+          <sign>G</sign>
+          <line>2</line>
+          </clef>
+        <transpose>
+          <diatonic>-5</diatonic>
+          <chromatic>-9</chromatic>
+          </transpose>
+        </attributes>
+      <note default-x="164.89" default-y="-1270.00">
+        <pitch>
+          <step>D</step>
+          <alter>-1</alter>
+          <octave>5</octave>
+          </pitch>
+        <duration>1</duration>
+        <voice>1</voice>
+        <type>quarter</type>
+        <stem>down</stem>
+        </note>
+      <note default-x="255.65" default-y="-1280.00">
+        <pitch>
+          <step>B</step>
+          <alter>-1</alter>
+          <octave>4</octave>
+          </pitch>
+        <duration>1</duration>
+        <voice>1</voice>
+        <type>quarter</type>
+        <stem>down</stem>
+        </note>
+      <note default-x="346.40" default-y="-1305.00">
+        <pitch>
+          <step>D</step>
+          <alter>-1</alter>
+          <octave>4</octave>
+          </pitch>
+        <duration>1</duration>
+        <voice>1</voice>
+        <type>quarter</type>
+        <stem>up</stem>
+        </note>
+      <note default-x="437.16" default-y="-1315.00">
+        <pitch>
+          <step>B</step>
+          <alter>-1</alter>
+          <octave>3</octave>
+          </pitch>
+        <duration>1</duration>
+        <voice>1</voice>
+        <type>quarter</type>
+        <stem>up</stem>
+        </note>
+      </measure>
+    <measure number="2" width="332.07">
+      <note default-x="13.80" default-y="-1290.00">
+        <pitch>
+          <step>G</step>
+          <octave>4</octave>
+          </pitch>
+        <duration>4</duration>
+        <voice>1</voice>
+        <type>whole</type>
+        </note>
+      <barline location="right">
+        <bar-style>light-heavy</bar-style>
+        </barline>
+      </measure>
+    </part>
+  <part id="P14">
+    <measure number="1" width="529.52">
+      <attributes>
+        <divisions>1</divisions>
+        <key>
+          <fifths>-4</fifths>
+          </key>
+        <time>
+          <beats>4</beats>
+          <beat-type>4</beat-type>
+          </time>
+        <clef>
+          <sign>G</sign>
+          <line>2</line>
+          </clef>
+        <transpose>
+          <diatonic>-5</diatonic>
+          <chromatic>-9</chromatic>
+          </transpose>
+        </attributes>
+      <note default-x="164.89" default-y="-1390.00">
+        <pitch>
+          <step>A</step>
+          <alter>-1</alter>
+          <octave>4</octave>
+          </pitch>
+        <duration>1</duration>
+        <voice>1</voice>
+        <type>quarter</type>
+        <stem>up</stem>
+        </note>
+      <note default-x="255.65" default-y="-1370.00">
+        <pitch>
+          <step>E</step>
+          <alter>-1</alter>
+          <octave>5</octave>
+          </pitch>
+        <duration>1</duration>
+        <voice>1</voice>
+        <type>quarter</type>
+        <stem>down</stem>
+        </note>
+      <note default-x="346.40" default-y="-1380.00">
+        <pitch>
+          <step>C</step>
+          <octave>5</octave>
+          </pitch>
+        <duration>1</duration>
+        <voice>1</voice>
+        <type>quarter</type>
+        <stem>down</stem>
+        </note>
+      <note default-x="437.16" default-y="-1405.00">
+        <pitch>
+          <step>E</step>
+          <alter>-1</alter>
+          <octave>4</octave>
+          </pitch>
+        <duration>1</duration>
+        <voice>1</voice>
+        <type>quarter</type>
+        <stem>up</stem>
+        </note>
+      </measure>
+    <measure number="2" width="332.07">
+      <note default-x="13.80" default-y="-1395.00">
+        <pitch>
+          <step>G</step>
+          <octave>4</octave>
+          </pitch>
+        <duration>4</duration>
+        <voice>1</voice>
+        <type>whole</type>
+        </note>
+      <barline location="right">
+        <bar-style>light-heavy</bar-style>
+        </barline>
+      </measure>
+    </part>
+  <part id="P15">
+    <measure number="1" width="529.52">
+      <attributes>
+        <divisions>1</divisions>
+        <key>
+          <fifths>-5</fifths>
+          </key>
+        <time>
+          <beats>4</beats>
+          <beat-type>4</beat-type>
+          </time>
+        <clef>
+          <sign>G</sign>
+          <line>2</line>
+          </clef>
+        <transpose>
+          <diatonic>-1</diatonic>
+          <chromatic>-2</chromatic>
+          <octave-change>-1</octave-change>
+          </transpose>
+        </attributes>
+      <note default-x="164.89" default-y="-1495.00">
+        <pitch>
+          <step>A</step>
+          <alter>-1</alter>
+          <octave>4</octave>
+          </pitch>
+        <duration>1</duration>
+        <voice>1</voice>
+        <type>quarter</type>
+        <stem>up</stem>
+        </note>
+      <note default-x="255.65" default-y="-1505.00">
+        <pitch>
+          <step>F</step>
+          <octave>4</octave>
+          </pitch>
+        <duration>1</duration>
+        <voice>1</voice>
+        <type>quarter</type>
+        <stem>up</stem>
+        </note>
+      <note default-x="346.40" default-y="-1510.00">
+        <pitch>
+          <step>E</step>
+          <alter>-1</alter>
+          <octave>4</octave>
+          </pitch>
+        <duration>1</duration>
+        <voice>1</voice>
+        <type>quarter</type>
+        <stem>up</stem>
+        </note>
+      <note default-x="437.16" default-y="-1520.00">
+        <pitch>
+          <step>C</step>
+          <octave>4</octave>
+          </pitch>
+        <duration>1</duration>
+        <voice>1</voice>
+        <type>quarter</type>
+        <stem>up</stem>
+        </note>
+      </measure>
+    <measure number="2" width="332.07">
+      <note default-x="13.80" default-y="-1510.00">
+        <pitch>
+          <step>E</step>
+          <alter>-1</alter>
+          <octave>4</octave>
+          </pitch>
+        <duration>4</duration>
+        <voice>1</voice>
+        <type>whole</type>
+        </note>
+      <barline location="right">
+        <bar-style>light-heavy</bar-style>
+        </barline>
+      </measure>
+    </part>
+  <part id="P16">
+    <measure number="1" width="529.52">
+      <attributes>
+        <divisions>1</divisions>
+        <key>
+          <fifths>-4</fifths>
+          </key>
+        <time>
+          <beats>4</beats>
+          <beat-type>4</beat-type>
+          </time>
+        <clef>
+          <sign>G</sign>
+          <line>2</line>
+          </clef>
+        <transpose>
+          <diatonic>-5</diatonic>
+          <chromatic>-9</chromatic>
+          <octave-change>-1</octave-change>
+          </transpose>
+        </attributes>
+      <note default-x="164.89" default-y="-1595.00">
+        <pitch>
+          <step>B</step>
+          <alter>-1</alter>
+          <octave>4</octave>
+          </pitch>
+        <duration>1</duration>
+        <voice>1</voice>
+        <type>quarter</type>
+        <stem>down</stem>
+        </note>
+      <note default-x="255.65" default-y="-1575.00">
+        <pitch>
+          <step>F</step>
+          <octave>5</octave>
+          </pitch>
+        <duration>1</duration>
+        <voice>1</voice>
+        <type>quarter</type>
+        <stem>down</stem>
+        </note>
+      <note default-x="346.40" default-y="-1600.00">
+        <pitch>
+          <step>A</step>
+          <alter>-1</alter>
+          <octave>4</octave>
+          </pitch>
+        <duration>1</duration>
+        <voice>1</voice>
+        <type>quarter</type>
+        <stem>up</stem>
+        </note>
+      <note default-x="437.16" default-y="-1620.00">
+        <pitch>
+          <step>D</step>
+          <alter>-1</alter>
+          <octave>4</octave>
+          </pitch>
+        <duration>1</duration>
+        <voice>1</voice>
+        <type>quarter</type>
+        <stem>up</stem>
+        </note>
+      </measure>
+    <measure number="2" width="332.07">
+      <note default-x="13.80" default-y="-1595.00">
+        <pitch>
+          <step>B</step>
+          <alter>-1</alter>
+          <octave>4</octave>
+          </pitch>
+        <duration>4</duration>
+        <voice>1</voice>
+        <type>whole</type>
+        </note>
+      <barline location="right">
+        <bar-style>light-heavy</bar-style>
+        </barline>
+      </measure>
+    </part>
+  <part id="P17">
+    <measure number="1" width="529.52">
+      <attributes>
+        <divisions>1</divisions>
+        <key>
+          <fifths>-5</fifths>
+          </key>
+        <time>
+          <beats>4</beats>
+          <beat-type>4</beat-type>
+          </time>
+        <clef>
+          <sign>G</sign>
+          <line>2</line>
+          </clef>
+        <transpose>
+          <diatonic>-1</diatonic>
+          <chromatic>-2</chromatic>
+          </transpose>
+        </attributes>
+      <note default-x="164.89" default-y="-1710.00">
+        <pitch>
+          <step>G</step>
+          <alter>-1</alter>
+          <octave>4</octave>
+          </pitch>
+        <duration>1</duration>
+        <voice>1</voice>
+        <type>quarter</type>
+        <stem>up</stem>
+        </note>
+      <note>
+        <rest/>
+        <duration>1</duration>
+        <voice>1</voice>
+        <type>quarter</type>
+        </note>
+      <note default-x="346.40" default-y="-1710.00">
+        <pitch>
+          <step>G</step>
+          <alter>-1</alter>
+          <octave>4</octave>
+          </pitch>
+        <duration>1</duration>
+        <voice>1</voice>
+        <type>quarter</type>
+        <stem>up</stem>
+        </note>
+      <note>
+        <rest/>
+        <duration>1</duration>
+        <voice>1</voice>
+        <type>quarter</type>
+        </note>
+      </measure>
+    <measure number="2" width="332.07">
+      <note default-x="13.80" default-y="-1725.00">
+        <pitch>
+          <step>D</step>
+          <alter>-1</alter>
+          <octave>4</octave>
+          </pitch>
+        <duration>4</duration>
+        <voice>1</voice>
+        <type>whole</type>
+        </note>
+      <barline location="right">
+        <bar-style>light-heavy</bar-style>
+        </barline>
+      </measure>
+    </part>
+  <part id="P18">
+    <measure number="1" width="529.52">
+      <attributes>
+        <divisions>1</divisions>
+        <key>
+          <fifths>-5</fifths>
+          </key>
+        <time>
+          <beats>4</beats>
+          <beat-type>4</beat-type>
+          </time>
+        <clef>
+          <sign>G</sign>
+          <line>2</line>
+          </clef>
+        <transpose>
+          <diatonic>-1</diatonic>
+          <chromatic>-2</chromatic>
+          </transpose>
+        </attributes>
+      <note default-x="164.89" default-y="-1825.00">
+        <pitch>
+          <step>E</step>
+          <alter>-1</alter>
+          <octave>4</octave>
+          </pitch>
+        <duration>1</duration>
+        <voice>1</voice>
+        <type>quarter</type>
+        <stem>up</stem>
+        </note>
+      <note>
+        <rest/>
+        <duration>1</duration>
+        <voice>1</voice>
+        <type>quarter</type>
+        </note>
+      <note default-x="346.40" default-y="-1825.00">
+        <pitch>
+          <step>E</step>
+          <alter>-1</alter>
+          <octave>4</octave>
+          </pitch>
+        <duration>1</duration>
+        <voice>1</voice>
+        <type>quarter</type>
+        <stem>up</stem>
+        </note>
+      <note>
+        <rest/>
+        <duration>1</duration>
+        <voice>1</voice>
+        <type>quarter</type>
+        </note>
+      </measure>
+    <measure number="2" width="332.07">
+      <note default-x="13.80" default-y="-1815.00">
+        <pitch>
+          <step>G</step>
+          <alter>-1</alter>
+          <octave>4</octave>
+          </pitch>
+        <duration>4</duration>
+        <voice>1</voice>
+        <type>whole</type>
+        </note>
+      <barline location="right">
+        <bar-style>light-heavy</bar-style>
+        </barline>
+      </measure>
+    </part>
+  <part id="P19">
+    <measure number="1" width="529.52">
+      <attributes>
+        <divisions>1</divisions>
+        <key>
+          <fifths>-5</fifths>
+          </key>
+        <time>
+          <beats>4</beats>
+          <beat-type>4</beat-type>
+          </time>
+        <clef>
+          <sign>G</sign>
+          <line>2</line>
+          </clef>
+        <transpose>
+          <diatonic>-1</diatonic>
+          <chromatic>-2</chromatic>
+          </transpose>
+        </attributes>
+      <note default-x="164.89" default-y="-1895.00">
+        <pitch>
+          <step>E</step>
+          <alter>-1</alter>
+          <octave>5</octave>
+          </pitch>
+        <duration>1</duration>
+        <voice>1</voice>
+        <type>quarter</type>
+        <stem>down</stem>
+        </note>
+      <note>
+        <rest/>
+        <duration>1</duration>
+        <voice>1</voice>
+        <type>quarter</type>
+        </note>
+      <note default-x="346.40" default-y="-1900.00">
+        <pitch>
+          <step>D</step>
+          <alter>-1</alter>
+          <octave>5</octave>
+          </pitch>
+        <duration>1</duration>
+        <voice>1</voice>
+        <type>quarter</type>
+        <stem>down</stem>
+        </note>
+      <note>
+        <rest/>
+        <duration>1</duration>
+        <voice>1</voice>
+        <type>quarter</type>
+        </note>
+      </measure>
+    <measure number="2" width="332.07">
+      <note default-x="13.80" default-y="-1910.00">
+        <pitch>
+          <step>B</step>
+          <alter>-1</alter>
+          <octave>4</octave>
+          </pitch>
+        <duration>4</duration>
+        <voice>1</voice>
+        <type>whole</type>
+        </note>
+      <barline location="right">
+        <bar-style>light-heavy</bar-style>
+        </barline>
+      </measure>
+    </part>
+  <part id="P20">
+    <measure number="1" width="529.52">
+      <attributes>
+        <divisions>1</divisions>
+        <key>
+          <fifths>-6</fifths>
+          </key>
+        <time>
+          <beats>4</beats>
+          <beat-type>4</beat-type>
+          </time>
+        <clef>
+          <sign>G</sign>
+          <line>2</line>
+          </clef>
+        <transpose>
+          <diatonic>-4</diatonic>
+          <chromatic>-7</chromatic>
+          </transpose>
+        </attributes>
+      <note default-x="164.89" default-y="-2000.00">
+        <pitch>
+          <step>E</step>
+          <alter>-1</alter>
+          <octave>5</octave>
+          </pitch>
+        <duration>1</duration>
+        <voice>1</voice>
+        <type>quarter</type>
+        <stem>down</stem>
+        </note>
+      <note>
+        <rest/>
+        <duration>1</duration>
+        <voice>1</voice>
+        <type>quarter</type>
+        </note>
+      <note default-x="346.40" default-y="-2025.00">
+        <pitch>
+          <step>G</step>
+          <alter>-1</alter>
+          <octave>4</octave>
+          </pitch>
+        <duration>1</duration>
+        <voice>1</voice>
+        <type>quarter</type>
+        <stem>up</stem>
+        </note>
+      <note>
+        <rest/>
+        <duration>1</duration>
+        <voice>1</voice>
+        <type>quarter</type>
+        </note>
+      </measure>
+    <measure number="2" width="332.07">
+      <note default-x="13.80" default-y="-2010.00">
+        <pitch>
+          <step>C</step>
+          <alter>-1</alter>
+          <octave>5</octave>
+          </pitch>
+        <duration>4</duration>
+        <voice>1</voice>
+        <type>whole</type>
+        </note>
+      <barline location="right">
+        <bar-style>light-heavy</bar-style>
+        </barline>
+      </measure>
+    </part>
+  <part id="P21">
+    <measure number="1" width="529.52">
+      <attributes>
+        <divisions>1</divisions>
+        <key>
+          <fifths>-6</fifths>
+          </key>
+        <time>
+          <beats>4</beats>
+          <beat-type>4</beat-type>
+          </time>
+        <clef>
+          <sign>G</sign>
+          <line>2</line>
+          </clef>
+        <transpose>
+          <diatonic>-4</diatonic>
+          <chromatic>-7</chromatic>
+          </transpose>
+        </attributes>
+      <note default-x="164.89" default-y="-2145.00">
+        <pitch>
+          <step>D</step>
+          <alter>-1</alter>
+          <octave>4</octave>
+          </pitch>
+        <duration>1</duration>
+        <voice>1</voice>
+        <type>quarter</type>
+        <stem>up</stem>
+        </note>
+      <note>
+        <rest/>
+        <duration>1</duration>
+        <voice>1</voice>
+        <type>quarter</type>
+        </note>
+      <note default-x="346.40" default-y="-2130.00">
+        <pitch>
+          <step>G</step>
+          <alter>-1</alter>
+          <octave>4</octave>
+          </pitch>
+        <duration>1</duration>
+        <voice>1</voice>
+        <type>quarter</type>
+        <stem>up</stem>
+        </note>
+      <note>
+        <rest/>
+        <duration>1</duration>
+        <voice>1</voice>
+        <type>quarter</type>
+        </note>
+      </measure>
+    <measure number="2" width="332.07">
+      <note default-x="13.80" default-y="-2135.00">
+        <pitch>
+          <step>F</step>
+          <octave>4</octave>
+          </pitch>
+        <duration>4</duration>
+        <voice>1</voice>
+        <type>whole</type>
+        </note>
+      <barline location="right">
+        <bar-style>light-heavy</bar-style>
+        </barline>
+      </measure>
+    </part>
+  <part id="P22">
+    <measure number="1" width="529.52">
+      <attributes>
+        <divisions>1</divisions>
+        <key>
+          <fifths>-7</fifths>
+          </key>
+        <time>
+          <beats>4</beats>
+          <beat-type>4</beat-type>
+          </time>
+        <clef>
+          <sign>F</sign>
+          <line>4</line>
+          </clef>
+        </attributes>
+      <note default-x="164.89" default-y="-2235.00">
+        <pitch>
+          <step>B</step>
+          <alter>-1</alter>
+          <octave>2</octave>
+          </pitch>
+        <duration>1</duration>
+        <voice>1</voice>
+        <type>quarter</type>
+        <stem>up</stem>
+        </note>
+      <note default-x="255.65" default-y="-2200.00">
+        <pitch>
+          <step>B</step>
+          <alter>-1</alter>
+          <octave>3</octave>
+          </pitch>
+        <duration>1</duration>
+        <voice>1</voice>
+        <type>quarter</type>
+        <stem>down</stem>
+        </note>
+      <note default-x="346.40" default-y="-2200.00">
+        <pitch>
+          <step>B</step>
+          <alter>-1</alter>
+          <octave>3</octave>
+          </pitch>
+        <duration>1</duration>
+        <voice>1</voice>
+        <type>quarter</type>
+        <stem>down</stem>
+        </note>
+      <note default-x="437.16" default-y="-2220.00">
+        <pitch>
+          <step>E</step>
+          <alter>-1</alter>
+          <octave>3</octave>
+          </pitch>
+        <duration>1</duration>
+        <voice>1</voice>
+        <type>quarter</type>
+        <stem>down</stem>
+        </note>
+      </measure>
+    <measure number="2" width="332.07">
+      <note default-x="13.80" default-y="-2245.00">
+        <pitch>
+          <step>G</step>
+          <alter>-1</alter>
+          <octave>2</octave>
+          </pitch>
+        <duration>4</duration>
+        <voice>1</voice>
+        <type>whole</type>
+        </note>
+      <barline location="right">
+        <bar-style>light-heavy</bar-style>
+        </barline>
+      </measure>
+    </part>
+  <part id="P23">
+    <measure number="1" width="529.52">
+      <attributes>
+        <divisions>1</divisions>
+        <key>
+          <fifths>-7</fifths>
+          </key>
+        <time>
+          <beats>4</beats>
+          <beat-type>4</beat-type>
+          </time>
+        <clef>
+          <sign>F</sign>
+          <line>4</line>
+          </clef>
+        </attributes>
+      <note default-x="164.89" default-y="-2330.00">
+        <pitch>
+          <step>D</step>
+          <alter>-1</alter>
+          <octave>3</octave>
+          </pitch>
+        <duration>1</duration>
+        <voice>1</voice>
+        <type>quarter</type>
+        <stem>down</stem>
+        </note>
+      <note>
+        <rest/>
+        <duration>1</duration>
+        <voice>1</voice>
+        <type>quarter</type>
+        </note>
+      <note default-x="346.40" default-y="-2340.00">
+        <pitch>
+          <step>B</step>
+          <alter>-1</alter>
+          <octave>2</octave>
+          </pitch>
+        <duration>1</duration>
+        <voice>1</voice>
+        <type>quarter</type>
+        <stem>up</stem>
+        </note>
+      <note>
+        <rest/>
+        <duration>1</duration>
+        <voice>1</voice>
+        <type>quarter</type>
+        </note>
+      </measure>
+    <measure number="2" width="332.07">
+      <note default-x="13.80" default-y="-2340.00">
+        <pitch>
+          <step>B</step>
+          <alter>-1</alter>
+          <octave>2</octave>
+          </pitch>
+        <duration>4</duration>
+        <voice>1</voice>
+        <type>whole</type>
+        </note>
+      <barline location="right">
+        <bar-style>light-heavy</bar-style>
+        </barline>
+      </measure>
+    </part>
+  <part id="P24">
+    <measure number="1" width="529.52">
+      <attributes>
+        <divisions>1</divisions>
+        <key>
+          <fifths>-7</fifths>
+          </key>
+        <time>
+          <beats>4</beats>
+          <beat-type>4</beat-type>
+          </time>
+        <clef>
+          <sign>F</sign>
+          <line>4</line>
+          </clef>
+        </attributes>
+      <note default-x="164.89" default-y="-2430.00">
+        <pitch>
+          <step>E</step>
+          <alter>-1</alter>
+          <octave>3</octave>
+          </pitch>
+        <duration>1</duration>
+        <voice>1</voice>
+        <type>quarter</type>
+        <stem>down</stem>
+        </note>
+      <note default-x="255.65" default-y="-2465.00">
+        <pitch>
+          <step>E</step>
+          <alter>-1</alter>
+          <octave>2</octave>
+          </pitch>
+        <duration>1</duration>
+        <voice>1</voice>
+        <type>quarter</type>
+        <stem>up</stem>
+        </note>
+      <note>
+        <rest/>
+        <duration>2</duration>
+        <voice>1</voice>
+        <type>half</type>
+        </note>
+      </measure>
+    <measure number="2" width="332.07">
+      <note default-x="13.80" default-y="-2430.00">
+        <pitch>
+          <step>E</step>
+          <alter>-1</alter>
+          <octave>3</octave>
+          </pitch>
+        <duration>4</duration>
+        <voice>1</voice>
+        <type>whole</type>
+        </note>
+      <barline location="right">
+        <bar-style>light-heavy</bar-style>
+        </barline>
+      </measure>
+    </part>
+  <part id="P25">
+    <measure number="1" width="529.52">
+      <attributes>
+        <divisions>1</divisions>
+        <key>
+          <fifths>-7</fifths>
+          </key>
+        <time>
+          <beats>4</beats>
+          <beat-type>4</beat-type>
+          </time>
+        <clef>
+          <sign>F</sign>
+          <line>4</line>
+          </clef>
+        </attributes>
+      <note default-x="164.89" default-y="-2525.00">
+        <pitch>
+          <step>G</step>
+          <alter>-1</alter>
+          <octave>3</octave>
+          </pitch>
+        <duration>1</duration>
+        <voice>1</voice>
+        <type>quarter</type>
+        <stem>down</stem>
+        </note>
+      <note>
+        <rest/>
+        <duration>1</duration>
+        <voice>1</voice>
+        <type>quarter</type>
+        </note>
+      <note default-x="346.40" default-y="-2540.00">
+        <pitch>
+          <step>D</step>
+          <alter>-1</alter>
+          <octave>3</octave>
+          </pitch>
+        <duration>1</duration>
+        <voice>1</voice>
+        <type>quarter</type>
+        <stem>down</stem>
+        </note>
+      <note default-x="437.16" default-y="-2530.00">
+        <pitch>
+          <step>F</step>
+          <alter>-1</alter>
+          <octave>3</octave>
+          </pitch>
+        <duration>1</duration>
+        <voice>1</voice>
+        <type>quarter</type>
+        <stem>down</stem>
+        </note>
+      </measure>
+    <measure number="2" width="332.07">
+      <note default-x="13.80" default-y="-2540.00">
+        <pitch>
+          <step>D</step>
+          <alter>-1</alter>
+          <octave>3</octave>
+          </pitch>
+        <duration>4</duration>
+        <voice>1</voice>
+        <type>whole</type>
+        </note>
+      <barline location="right">
+        <bar-style>light-heavy</bar-style>
+        </barline>
+      </measure>
+    </part>
+  <part id="P26">
+    <measure number="1" width="529.52">
+      <attributes>
+        <divisions>1</divisions>
+        <key>
+          <fifths>-7</fifths>
+          </key>
+        <time>
+          <beats>4</beats>
+          <beat-type>4</beat-type>
+          </time>
+        <clef>
+          <sign>F</sign>
+          <line>4</line>
+          </clef>
+        </attributes>
+      <note default-x="164.89" default-y="-2625.00">
+        <pitch>
+          <step>A</step>
+          <alter>-1</alter>
+          <octave>3</octave>
+          </pitch>
+        <duration>1</duration>
+        <voice>1</voice>
+        <type>quarter</type>
+        <stem>down</stem>
+        </note>
+      <note>
+        <rest/>
+        <duration>1</duration>
+        <voice>1</voice>
+        <type>quarter</type>
+        </note>
+      <note default-x="346.40" default-y="-2640.00">
+        <pitch>
+          <step>E</step>
+          <alter>-1</alter>
+          <octave>3</octave>
+          </pitch>
+        <duration>1</duration>
+        <voice>1</voice>
+        <type>quarter</type>
+        <stem>down</stem>
+        </note>
+      <note default-x="437.16" default-y="-2645.00">
+        <pitch>
+          <step>D</step>
+          <alter>-1</alter>
+          <octave>3</octave>
+          </pitch>
+        <duration>1</duration>
+        <voice>1</voice>
+        <type>quarter</type>
+        <stem>down</stem>
+        </note>
+      </measure>
+    <measure number="2" width="332.07">
+      <note default-x="13.80" default-y="-2655.00">
+        <pitch>
+          <step>B</step>
+          <alter>-1</alter>
+          <octave>2</octave>
+          </pitch>
+        <duration>4</duration>
+        <voice>1</voice>
+        <type>whole</type>
+        </note>
+      <barline location="right">
+        <bar-style>light-heavy</bar-style>
+        </barline>
+      </measure>
+    </part>
+  <part id="P27">
+    <measure number="1" width="529.52">
+      <attributes>
+        <divisions>1</divisions>
+        <key>
+          <fifths>-7</fifths>
+          </key>
+        <time>
+          <beats>4</beats>
+          <beat-type>4</beat-type>
+          </time>
+        <clef>
+          <sign>F</sign>
+          <line>4</line>
+          </clef>
+        <transpose>
+          <diatonic>0</diatonic>
+          <chromatic>0</chromatic>
+          <octave-change>-1</octave-change>
+          </transpose>
+        </attributes>
+      <note default-x="164.89" default-y="-2730.00">
+        <pitch>
+          <step>A</step>
+          <alter>-1</alter>
+          <octave>3</octave>
+          </pitch>
+        <duration>1</duration>
+        <voice>1</voice>
+        <type>quarter</type>
+        <stem>down</stem>
+        </note>
+      <note default-x="255.65" default-y="-2730.00">
+        <pitch>
+          <step>A</step>
+          <alter>-1</alter>
+          <octave>3</octave>
+          </pitch>
+        <duration>1</duration>
+        <voice>1</voice>
+        <type>quarter</type>
+        <stem>down</stem>
+        </note>
+      <note default-x="346.40" default-y="-2740.00">
+        <pitch>
+          <step>F</step>
+          <alter>-1</alter>
+          <octave>3</octave>
+          </pitch>
+        <duration>1</duration>
+        <voice>1</voice>
+        <type>quarter</type>
+        <stem>down</stem>
+        </note>
+      <note default-x="437.16" default-y="-2745.00">
+        <pitch>
+          <step>E</step>
+          <alter>-1</alter>
+          <octave>3</octave>
+          </pitch>
+        <duration>1</duration>
+        <voice>1</voice>
+        <type>quarter</type>
+        <stem>down</stem>
+        </note>
+      </measure>
+    <measure number="2" width="332.07">
+      <note default-x="13.80" default-y="-2745.00">
+        <pitch>
+          <step>E</step>
+          <alter>-1</alter>
+          <octave>3</octave>
+          </pitch>
+        <duration>4</duration>
+        <voice>1</voice>
+        <type>whole</type>
+        </note>
+      <barline location="right">
+        <bar-style>light-heavy</bar-style>
+        </barline>
+      </measure>
+    </part>
+  <part id="P28">
+    <measure number="1" width="529.52">
+      <attributes>
+        <divisions>1</divisions>
+        <key>
+          <fifths>-7</fifths>
+          </key>
+        <time>
+          <beats>4</beats>
+          <beat-type>4</beat-type>
+          </time>
+        <clef>
+          <sign>F</sign>
+          <line>4</line>
+          </clef>
+        </attributes>
+      <note default-x="164.89" default-y="-2870.00">
+        <pitch>
+          <step>A</step>
+          <alter>-1</alter>
+          <octave>2</octave>
+          </pitch>
+        <duration>1</duration>
+        <voice>1</voice>
+        <type>quarter</type>
+        <stem>up</stem>
+        </note>
+      <note>
+        <rest/>
+        <duration>1</duration>
+        <voice>1</voice>
+        <type>quarter</type>
+        </note>
+      <note default-x="346.40" default-y="-2835.00">
+        <pitch>
+          <step>A</step>
+          <alter>-1</alter>
+          <octave>3</octave>
+          </pitch>
+        <duration>1</duration>
+        <voice>1</voice>
+        <type>quarter</type>
+        <stem>down</stem>
+        </note>
+      <note>
+        <rest/>
+        <duration>1</duration>
+        <voice>1</voice>
+        <type>quarter</type>
+        </note>
+      </measure>
+    <measure number="2" width="332.07">
+      <note default-x="13.80" default-y="-2850.00">
+        <pitch>
+          <step>E</step>
+          <alter>-1</alter>
+          <octave>3</octave>
+          </pitch>
+        <duration>4</duration>
+        <voice>1</voice>
+        <type>whole</type>
+        </note>
+      <barline location="right">
+        <bar-style>light-heavy</bar-style>
+        </barline>
+      </measure>
+    </part>
+  <part id="P29">
+    <measure number="1" width="529.52">
+      <attributes>
+        <divisions>1</divisions>
+        <key>
+          <fifths>-7</fifths>
+          </key>
+        <time>
+          <beats>4</beats>
+          <beat-type>4</beat-type>
+          </time>
+        <clef>
+          <sign>G</sign>
+          <line>2</line>
+          </clef>
+        <transpose>
+          <diatonic>0</diatonic>
+          <chromatic>0</chromatic>
+          <octave-change>2</octave-change>
+          </transpose>
+        </attributes>
+      <note>
+        <rest/>
+        <duration>4</duration>
+        <voice>1</voice>
+        <type>whole</type>
+        </note>
+      </measure>
+    <measure number="2" width="332.07">
+      <note>
+        <rest/>
+        <duration>4</duration>
+        <voice>1</voice>
+        <type>whole</type>
+        </note>
+      <barline location="right">
+        <bar-style>light-heavy</bar-style>
+        </barline>
+      </measure>
+    </part>
+  <part id="P30">
+    <measure number="1" width="529.52">
+      <attributes>
+        <divisions>1</divisions>
+        <key>
+          <fifths>0</fifths>
+          </key>
+        <time>
+          <beats>4</beats>
+          <beat-type>4</beat-type>
+          </time>
+        <clef>
+          <sign>percussion</sign>
+          <line>2</line>
+          </clef>
+        </attributes>
+      <note>
+        <rest/>
+        <duration>4</duration>
+        <voice>1</voice>
+        <type>whole</type>
+        </note>
+      </measure>
+    <measure number="2" width="332.07">
+      <note>
+        <rest/>
+        <duration>4</duration>
+        <voice>1</voice>
+        <type>whole</type>
+        </note>
+      <barline location="right">
+        <bar-style>light-heavy</bar-style>
+        </barline>
+      </measure>
+    </part>
+  <part id="P31">
+    <measure number="1" width="529.52">
+      <attributes>
+        <divisions>1</divisions>
+        <key>
+          <fifths>0</fifths>
+          </key>
+        <time>
+          <beats>4</beats>
+          <beat-type>4</beat-type>
+          </time>
+        <clef>
+          <sign>percussion</sign>
+          <line>2</line>
+          </clef>
+        </attributes>
+      <note>
+        <rest/>
+        <duration>4</duration>
+        <voice>1</voice>
+        <type>whole</type>
+        </note>
+      </measure>
+    <measure number="2" width="332.07">
+      <note>
+        <rest/>
+        <duration>4</duration>
+        <voice>1</voice>
+        <type>whole</type>
+        </note>
+      <barline location="right">
+        <bar-style>light-heavy</bar-style>
+        </barline>
+      </measure>
+    </part>
+  </score-partwise>

--- a/Sourcecode/include/mx/api/PartData.h
+++ b/Sourcecode/include/mx/api/PartData.h
@@ -6,7 +6,9 @@
 
 #include "mx/api/MeasureData.h"
 #include "mx/api/SoundID.h"
+#include "mx/api/TransposeData.h"
 
+#include <optional>
 #include <string>
 #include <vector>
 
@@ -124,6 +126,14 @@ namespace mx
             PositionData displayAbbreviationPositionData;
             
             InstrumentData instrumentData;
+
+            /// The initial transposition for the part. If the music entered into the part is not in
+            /// concert pitch, then this field is used to specify the transposition that is in-
+            /// effect. Note, MusicXML encodes transposition in the measure data, not in the part
+            /// data. Here we offer a convient way to set the transposition in the first measure of
+            /// the part. Subsequent transposition changes are not currently supported by mx::api.
+            std::optional<TransposeData> transposition;
+
             std::vector<MeasureData> measures;
             
             inline int getNumStaves() const
@@ -205,6 +215,7 @@ namespace mx
         MXAPI_EQUALS_MEMBER( displayAbbreviationPrintData )
         MXAPI_EQUALS_MEMBER( displayAbbreviationPositionData )
         MXAPI_EQUALS_MEMBER( instrumentData )
+        MXAPI_EQUALS_MEMBER( transposition )
         MXAPI_EQUALS_MEMBER( measures )
         MXAPI_EQUALS_END;
         MXAPI_NOT_EQUALS_AND_VECTORS( PartData );

--- a/Sourcecode/include/mx/api/TransposeData.h
+++ b/Sourcecode/include/mx/api/TransposeData.h
@@ -1,0 +1,82 @@
+// MusicXML Class Library
+// Copyright (c) by Matthew James Briggs
+// Distributed under the MIT License
+
+#pragma once
+
+#include "mx/api/ApiCommon.h"
+
+namespace mx
+{
+    namespace api
+    {
+        /// TransposeData is used to instruments for whom the music has been transposed. The
+        /// transposition is specified by naming the directional diatonic interval between the
+        /// written pitch and the sounding pitch. For example when C4 is written for Bb Clarinet,
+        /// the sounding pitch is Bb3 which is a major second lower. The transposition for Bb
+        /// Clarinet is thus 'down a major second'. There may be cases where such a transposition
+        /// would produce a painful key signature, and engravers may choose to notate the Bb
+        /// Clarinet in A# instead. In that case the interval is 'down a diminished third'.
+        ///
+        /// In order to distinguish between intervals that are enharmonically equivalent (having
+        /// the same number of semitones), two values are needed. TransposeData encodes the
+        /// diatonic interval by providing the number of chromatic steps and the number of diatonic
+        /// steps where the number of 'diatonic' steps is the number of steps via letter names (or
+        /// piano white notes).
+        ///
+        /// Some examples may help. Clarinet in Bb transposes down a major second, which is two
+        /// semitones, so `chromatic = -2`. In order to distinguish this from, say A#, or Cbb, we
+        /// need additional information, so we specify `diatonic = -1`. That is, we want the letter
+        /// to be B, and B is one letter lower than C.
+        ///
+        /// Here is a table of some common transpositions and their TransposeData equivalents.
+        /// |---------------------|--------------------|----------|---------|
+        /// | Name                | Interval           | Chromatic| Diatonic|
+        /// |---------------------|--------------------|----------|---------|
+        /// | Glockenspiel        | Up two Octaves     | 24       | 14      |
+        /// | Piccolo             | Up an Octave       | 12       | 7       |
+        /// | Clarient in Bb      | Down a Major Second| -2       | -1      |
+        /// | French Horn in F    | Down a Fifth       | -7       | -4      |
+        /// | Alto Saxophone in Eb| Down a Major Sixth | -9       | -5      |
+        /// | Bass Clarinet in Bb | Down a Major Ninth | -14      | -8      |
+        /// |---------------------|--------------------|----------|---------|
+        ///
+        /// Note that MusicXML encodes this slightly differently. In MusicXML required (but not
+        /// enforced) that chromatic should be >= -11 and <= 11, and that diatonic should be
+        /// <= -6 and >= 6. An additional `<octave-offset>` element is used for intervals beyond
+        /// that range. Additionally, the `<diatonic>` element is optional in MusicXML, but is
+        /// required in TransposeData.
+        class TransposeData
+        {
+        public:
+            TransposeData()
+            : TransposeData{ 0, 0 }
+            {
+
+            }
+
+            TransposeData( int inChromatic, int inHarmonic )
+            : chromatic{ inChromatic }
+            , diatonic{ inHarmonic }
+            {
+
+            }
+
+            /// The number of semitones in the interval.
+            int chromatic;
+
+            /// The number of diatonic steps in the interval
+            int diatonic;
+
+            /// If both chromatic and diatonic are zero, then TransposeData is unused (i.e. it need
+            /// not be encoded in the MusicXML output).
+            inline bool isUsed() const { return chromatic != 0 || diatonic != 0; }
+        };
+
+        MXAPI_EQUALS_BEGIN( TransposeData )
+            MXAPI_EQUALS_MEMBER( chromatic )
+            MXAPI_EQUALS_MEMBER( diatonic )
+        MXAPI_EQUALS_END;
+        MXAPI_NOT_EQUALS_AND_VECTORS( TransposeData );
+    }
+}

--- a/Sourcecode/private/cpul/catchDefines.h
+++ b/Sourcecode/private/cpul/catchDefines.h
@@ -16,9 +16,9 @@
 
 #define CHECK_WITH_MESSAGE( trueStatement, msg ) \
 { \
-    if(!(#trueStatement)) \
+    if(!(trueStatement)) \
     { \
-        FAIL( (#msg) ); \
+        FAIL( (msg) ); \
     } \
 }
 

--- a/Sourcecode/private/mx/impl/Converter.h
+++ b/Sourcecode/private/mx/impl/Converter.h
@@ -12,11 +12,12 @@
 #include "mx/api/ScoreData.h"
 #include "mx/api/SoundID.h"
 #include "mx/core/Decimals.h"
+#include "mx/core/Enums.h"
+#include "mx/core/PlaybackSound.h"
 #include "mx/core/elements/ArticulationsChoice.h"
 #include "mx/core/elements/OrnamentsChoice.h"
 #include "mx/core/elements/TechnicalChoice.h"
-#include "mx/core/Enums.h"
-#include "mx/core/PlaybackSound.h"
+#include "mx/core/elements/Transpose.h"
 
 #include <map>
 
@@ -121,6 +122,9 @@ namespace mx
 
             static mx::core::DecimalType convertToAlter( int semitones, double cents );
             static std::pair<int, double> convertToSemitonesAndCents( mx::core::DecimalType alter );
+
+            static mx::core::TransposePtr convertToTranspose( const mx::api::TransposeData& inTransposeData );
+            static mx::api::TransposeData convertToTransposeData( const mx::core::Transpose& inTranspose );
 
             const static std::map<core::StepEnum, api::Step> stepMap;
             const static std::map<core::NoteTypeValue, api::DurationName> durationMap;

--- a/Sourcecode/private/mx/impl/LayoutFunctions.h
+++ b/Sourcecode/private/mx/impl/LayoutFunctions.h
@@ -25,8 +25,8 @@ namespace mx
         void addScaling( const api::DefaultsData& inDefaults, core::ScoreHeaderGroup& outScoreHeaderGroup );
         void addPageLayout( const api::PageLayoutData& inPageLayout, core::ScoreHeaderGroup& outScoreHeaderGroup );
         void addPageMargins( const api::PageMarginsData& inPageMargins, core::PageLayout& outPageLayout );
-        void addSystemMargins(const api::DefaultsData& inDefaults, core::ScoreHeaderGroup& outScoreHeaderGroup );
-        void addAppearance(const api::DefaultsData& inDefaults, core::ScoreHeaderGroup& outScoreHeaderGroup );
+        void addSystemMargins( const api::DefaultsData& inDefaults, core::ScoreHeaderGroup& outScoreHeaderGroup );
+        void addAppearance( const api::DefaultsData& inDefaults, core::ScoreHeaderGroup& outScoreHeaderGroup );
 
         ////////////////////////////////////////////////////////////////////////////////////////////////////////////////
         // core::ScoreHeaderGroup -> api::DefaultsData

--- a/Sourcecode/private/mx/impl/MarkDataFunctions.h
+++ b/Sourcecode/private/mx/impl/MarkDataFunctions.h
@@ -13,7 +13,7 @@ namespace mx
     namespace impl
     {
         template<typename ATTRIBUTES_TYPE>
-        void parseMarkDataAttributes(const ATTRIBUTES_TYPE& attr, api::MarkData& outMarkData )
+        void parseMarkDataAttributes( const ATTRIBUTES_TYPE& attr, api::MarkData& outMarkData )
         {
             outMarkData.positionData = getPositionData<ATTRIBUTES_TYPE>( attr );
             outMarkData.printData = getPrintData<ATTRIBUTES_TYPE>( attr );

--- a/Sourcecode/private/mx/impl/MeasureWriter.h
+++ b/Sourcecode/private/mx/impl/MeasureWriter.h
@@ -223,6 +223,7 @@ namespace mx
             using dIter = dirs::const_iterator;
             void writeDirections( dIter& directionIter, const dIter& directionEnd, const NoteIter& inNoteIter, const NoteIter& inNotesBegin, const NoteIter& inNoteEnd );
             void writeDirection( const api::DirectionData& inDirectionData );
+            inline const MeasureCursor& cursor() const { return myHistory.getCursor(); }
 
             template<typename T>
             std::vector<T> findItemsAtTimePosition( const std::vector<T>& inItems, int inTickTimePosition )

--- a/Sourcecode/private/mx/impl/NoteWriter.cpp
+++ b/Sourcecode/private/mx/impl/NoteWriter.cpp
@@ -414,8 +414,11 @@ namespace mx
         
         void NoteWriter::setNotehead() const
         {
-            myOutNote->setHasNotehead( true );
-            myOutNote->getNotehead()->setValue( myConverter.convert( myNoteData.notehead ) );
+            if( myNoteData.notehead != mx::api::Notehead::normal )
+            {
+                myOutNote->setHasNotehead( true );
+                myOutNote->getNotehead()->setValue( myConverter.convert( myNoteData.notehead ) );
+            }
         }
         
         void NoteWriter::setStemDirection() const

--- a/Sourcecode/private/mx/impl/PartReader.cpp
+++ b/Sourcecode/private/mx/impl/PartReader.cpp
@@ -97,7 +97,17 @@ namespace mx
             {
                 const auto& mxMeasure = *mxMeasurePtr;
                 MeasureReader reader{ mxMeasure, myCurrentCursor, myPreviousCursor };
-                auto measureData = reader.getMeasureData();
+                // the reader returns the measure data and any data that needs to be written at
+                // the part-level (e.g. transposition). currently this is done as a pair.
+                auto measureDataPair = reader.getMeasureData();
+                auto measureData = measureDataPair.first;
+                auto& transpositionData = measureDataPair.second;
+                // if it's the first measure, and if we received transposition data, then we
+                // should write it to the part.
+                if( myCurrentCursor.isFirstMeasureInPart && transpositionData.has_value() )
+                {
+                    myOutPartData.transposition = transpositionData;
+                }
                 myCurrentCursor.timeSignature = measureData.timeSignature;
                 myCurrentCursor.ticksPerQuarter = reader.getCursor().ticksPerQuarter;
                 myOutPartData.measures.emplace_back( std::move( measureData ) );

--- a/Sourcecode/private/mx/impl/PartWriter.h
+++ b/Sourcecode/private/mx/impl/PartWriter.h
@@ -5,32 +5,33 @@
 #pragma once
 
 #include "mx/api/PartData.h"
-#include <mutex>
+
 #include <memory>
+#include <mutex>
 
 namespace mx
 {
-	namespace core
-	{
-		class PartwisePart;
+    namespace core
+    {
+        class PartwisePart;
         using PartwisePartPtr = std::shared_ptr<PartwisePart>;
         class ScorePart;
         using ScorePartPtr = std::shared_ptr<ScorePart>;
-	}
+    }
 
     namespace impl
     {
         class ScoreWriter;
         
-    	class PartWriter
-    	{
-    	public:
+        class PartWriter
+        {
+        public:
             PartWriter( const api::PartData& inPartData, int inPartIndex, int inTicksPerQuarter, const ScoreWriter& inScoreWriter );
-    		core::ScorePartPtr getScorePart() const;
+            core::ScorePartPtr getScorePart() const;
             core::PartwisePartPtr getPartwisePart() const;
 
-    	private:
-    		const api::PartData& myPartData;
+        private:
+            const api::PartData& myPartData;
             const int myPartIndex;
             const int myTicksPerQuarter;
             mutable std::mutex myMutex;
@@ -39,7 +40,14 @@ namespace mx
             const ScoreWriter& myScoreWriter;
             
         private:
+            /// Writes all the measures from myPartData to myOutScorePart
             void writeMeasures() const;
-    	};
+
+            /// Writes all the measures from inPartData to myOutScorePart. We added this function,
+            /// in which the part data is passed in, to handle a case when there are zero measures
+            /// in myPartData, but we need to force a single measure to exist in the MusicXML to
+            /// preserve something about the part.
+            void writeMeasures( const mx::api::PartData& inPartData ) const;
+        };
     }
 }

--- a/Sourcecode/private/mx/impl/PropertiesWriter.cpp
+++ b/Sourcecode/private/mx/impl/PropertiesWriter.cpp
@@ -116,13 +116,6 @@ namespace mx
             MX_ASSERT( myPartwiseMeasure != nullptr );
         }
 
-        
-        void PropertiesWriter::clearBuffer()
-        {
-            allocate();
-        }
-        
-        
         void PropertiesWriter::flushBuffer()
         {
             if( !isPropertiesEmpty() )
@@ -131,8 +124,8 @@ namespace mx
                 mdc->setChoice( core::MusicDataChoice::Choice::properties );
                 mdc->setProperties( myProperties );
                 myPartwiseMeasure->getMusicDataGroup()->addMusicDataChoice( mdc );
-                allocate();
             }
+            allocate();
         }
         
         
@@ -289,7 +282,12 @@ namespace mx
             }
             myProperties->addClef( mxClef );
         }
-        
+
+        void PropertiesWriter::writeTranspose( const api::TransposeData& inTransposeData )
+        {
+            auto transposePtr = Converter::convertToTranspose( inTransposeData );
+            myProperties->addTranspose( transposePtr );
+        }
         
         void PropertiesWriter::allocate()
         {

--- a/Sourcecode/private/mx/impl/PropertiesWriter.h
+++ b/Sourcecode/private/mx/impl/PropertiesWriter.h
@@ -7,22 +7,31 @@
 #include "mx/api/TimeSignatureData.h"
 #include "mx/api/KeyData.h"
 #include "mx/api/ClefData.h"
+#include "mx/api/TransposeData.h"
 #include <memory>
 
 namespace mx
 {
-	namespace core
-	{
+    namespace core
+    {
         class PartwiseMeasure;
         using PartwiseMeasurePtr = std::shared_ptr<PartwiseMeasure>;
         class Properties;
         using PropertiesPtr = std::shared_ptr<Properties>;
         class Key;
         using KeyPtr = std::shared_ptr<Key>;
-	}
+    }
 
     namespace impl
     {
+        /// Provides a way to ensure that properties (i.e. things in the `<attributes>` element) are
+        /// added to a single <attributes> element instead of creating a new <attributes> element
+        /// for each property.
+        ///
+        /// The design is weird. It holds the current meausre that we are writing, and acts like a
+        /// buffer of properties. You can write things like clefs and time signatures to the
+        /// PropertiesWriter, and then when you call `flushBuffer()` everything gets written to the
+        /// measure.
         class PropertiesWriter
         {
         public:
@@ -50,6 +59,7 @@ namespace mx
             void writeTime( const api::TimeSignatureData& value );
             void writeNumStaves( int value );
             void writeClef( int staffIndex, const api::ClefData& inClefData );
+            void writeTranspose( const api::TransposeData& inTransposeData );
 
         private:
             void allocate();

--- a/Sourcecode/private/mx/impl/ScoreWriter.cpp
+++ b/Sourcecode/private/mx/impl/ScoreWriter.cpp
@@ -145,7 +145,11 @@ namespace mx
 
             return myOutScorePartwise;
         }
-        
+
+        const api::PartData& ScoreWriter::getPart( int inPartIndex ) const
+        {
+            return getScoreData().parts.at( inPartIndex );
+        }
         
         void ScoreWriter::addScorePart( int partIndex, const core::ScorePartPtr& scorePart ) const
         {
@@ -339,14 +343,14 @@ namespace mx
         }
         
         
-        bool ScoreWriter::isStartOfSystem( int measureIndex ) const
+        bool ScoreWriter::isSystemInfo( int measureIndex ) const
         {
             const auto iter = myScoreData.layout.find( measureIndex );
             if( iter == std::cend( myScoreData.layout ) )
             {
                 return false;
             }
-            return iter->second.system.newSystem == api::Bool::yes;
+            return iter->second.system.isUsed();
         }
 
 

--- a/Sourcecode/private/mx/impl/ScoreWriter.h
+++ b/Sourcecode/private/mx/impl/ScoreWriter.h
@@ -12,9 +12,9 @@
 
 namespace mx
 {
-	namespace core
-	{
-		class ScorePartwise;
+    namespace core
+    {
+        class ScorePartwise;
         using ScorePartwisePtr = std::shared_ptr<ScorePartwise>;
         class PartGroup;
         using PartGroupPtr = std::shared_ptr<PartGroup>;
@@ -24,23 +24,27 @@ namespace mx
         using ScorePartPtr = std::shared_ptr<ScorePart>;
         class PartwisePart;
         using PartwisePartPtr = std::shared_ptr<PartwisePart>;
-	}
+    }
 
     namespace impl
     {
-    	class ScoreWriter
-    	{
-    	public:
+        class ScoreWriter
+        {
+        public:
             ScoreWriter( const api::ScoreData& inScoreData );
 
-    		core::ScorePartwisePtr getScorePartwise() const;
+            core::ScorePartwisePtr getScorePartwise() const;
+            inline const api::ScoreData& getScoreData() const { return myScoreData; }
 
-            bool isStartOfSystem( int measureIndex ) const;
+            /// Finds the part in ScoreData and returns it. Throws if out-of-range.
+            const api::PartData& getPart( int inPartIndex ) const;
+
+            bool isSystemInfo(int measureIndex ) const;
             std::optional<api::PageData> findPageLayoutData( api::MeasureIndex measureIndex ) const;
             api::SystemData getSystemData( int measureIndex ) const;
             
-    	private:
-    		api::ScoreData myScoreData;
+        private:
+            api::ScoreData myScoreData;
             mutable std::mutex myMutex;
             mutable core::ScorePartwisePtr myOutScorePartwise;
             
@@ -55,7 +59,7 @@ namespace mx
             core::PartGroupPtr makePartGroupStop( const api::PartGroupData& apiGrp ) const;
             core::PartGroupOrScorePartPtr makePartGroupOrScorePart( const core::PartGroupPtr& grp ) const;
             core::PartGroupOrScorePartPtr makePartGroupOrScorePart( const core::ScorePartPtr& spr ) const;
-    	};
+        };
     }
 }
 
@@ -63,7 +67,7 @@ namespace mx
 
 /*
  // TODO
- if( myScoreWriter.isStartOfSystem( myCursor.measureIndex ) )
+ if( myScoreWriter.isSystemInfo( myCursor.measureIndex ) )
  {
  auto systemData = myScoreWriter.getSystemData( myCursor.measureIndex );
  // TODO - add it to the measure

--- a/Sourcecode/private/mxtest/api/FreezingRoundTrip.cpp
+++ b/Sourcecode/private/mxtest/api/FreezingRoundTrip.cpp
@@ -223,6 +223,10 @@ TEST( roundTripViolaDynamicWrongTime, Freezing )
     const auto savedMdcEnd = savedMdcSet.cend();
 
     CHECK( savedMdcIter != savedMdcEnd );
+    CHECK( MusicDataChoice::Choice::print == (*savedMdcIter)->getChoice() );
+
+    ++savedMdcIter;
+    CHECK( savedMdcIter != savedMdcEnd );
     CHECK( MusicDataChoice::Choice::note == (*savedMdcIter)->getChoice() );
     auto savedCurrentNote = (*savedMdcIter)->getNote();
     CHECK_DOUBLES_EQUAL( 30.0 * tickTimeScaleFactor, savedCurrentNote->getNoteChoice()->getNormalNoteGroup()->getDuration()->getValue().getValue(), 0.0001 );

--- a/Sourcecode/private/mxtest/api/TranspositionTest.cpp
+++ b/Sourcecode/private/mxtest/api/TranspositionTest.cpp
@@ -1,0 +1,864 @@
+// MusicXML Class Library
+// Copyright (c) by Matthew James Briggs
+// Distributed under the MIT License
+
+#include "mxtest/control/CompileControl.h"
+#ifdef MX_COMPILE_API_TESTS
+#include "cpul/cpulTestHarness.h"
+#include "mx/api/DocumentManager.h"
+#include "mx/core/Document.h"
+#include "mx/core/elements/Chromatic.h"
+#include "mx/core/elements/Diatonic.h"
+#include "mx/core/elements/MusicDataChoice.h"
+#include "mx/core/elements/Properties.h"
+#include "mx/core/elements/Transpose.h"
+#include "mx/impl/Converter.h"
+#include "mxtest/file/MxFileRepository.h"
+
+#include <sstream>
+
+namespace mxtest
+{
+    // There seems to be an existing notion of an API 'round trip' test which requires specifying the
+    // music data by hand. In this version of an API round trip test, we will load the file into API,
+    // save the file back to disk, load it back up into the API and assert equality.
+    inline mx::api::ScoreData roundtrip( const mx::api::ScoreData& inOriginal )
+    {
+        auto& docMgr = mx::api::DocumentManager::getInstance();
+        const auto id = docMgr.createFromScore( inOriginal );
+        std::ostringstream oss;
+        docMgr.writeToStream( id, oss );
+        std::istringstream iss{ oss.str() };
+        const auto id2 = docMgr.createFromStream( iss );
+        auto result = docMgr.getData( id2 );
+        docMgr.destroyDocument( id );
+        docMgr.destroyDocument( id2 );
+        return result;
+    }
+
+    // create a score with one part an any number of measures
+    inline mx::api::ScoreData makeScore( int measures )
+    {
+        auto score = mx::api::ScoreData{};
+        score.parts.emplace_back( mx::api::PartData{} );
+        auto& part = score.parts.back();
+        for( int i = 0; i < measures; ++ i )
+        {
+            part.measures.emplace_back( mx::api::MeasureData{} );
+        }
+        return score;
+    }
+
+    inline void checkCoreTransposeElement(
+            const mx::api::ScoreData& inScore,
+            int inExpectedChromatic,
+            std::optional<int> inExpectedDiatonic,
+            std::optional<int> inExpectedOctave )
+    {
+        auto& docMgr = mx::api::DocumentManager::getInstance();
+        const auto id = docMgr.createFromScore( inScore );
+        const auto core = docMgr.getDocument( id );
+        docMgr.destroyDocument( id );
+        CHECK( core->getChoice() == mx::core::DocumentChoice::partwise );
+        const auto& score = core->getScorePartwise();
+        REQUIRE( !score->getPartwisePartSet().empty() );
+        const auto& part = score->getPartwisePartSet().front();
+        REQUIRE( !part->getPartwiseMeasureSet().empty() );
+        const auto& measure = part->getPartwiseMeasureSet().front();
+        const auto& choices = measure->getMusicDataGroup()->getMusicDataChoiceSet();
+        REQUIRE( !choices.empty() );
+        mx::core::PropertiesPtr properties;
+        for( const auto& choice : choices )
+        {
+            if( choice->getChoice() == mx::core::MusicDataChoice::Choice::properties )
+            {
+                // there should be only 1 properties element
+                CHECK( properties == nullptr );
+                properties = choice->getProperties();
+                // continue looping to make sure we don't hit another properties element
+            }
+        }
+        // we should have found exactly one properties element
+        CHECK( properties != nullptr );
+        // assert that the transpose element matches
+        REQUIRE( properties->getTransposeSet().size() == 1 );
+        const auto& transpose = properties->getTransposeSet().front();
+        CHECK_EQUAL( inExpectedChromatic, static_cast<int>( transpose->getChromatic()->getValue().getValue() ) );
+        if( inExpectedDiatonic.has_value() )
+        {
+            CHECK( transpose->getHasDiatonic() );
+            CHECK_EQUAL( inExpectedDiatonic.value(), static_cast<int>( transpose->getDiatonic()->getValue().getValue() ) );
+        }
+        if( inExpectedOctave.has_value() )
+        {
+            CHECK( transpose->getHasOctaveChange() );
+            CHECK_EQUAL( inExpectedOctave.value(), static_cast<int>( transpose->getOctaveChange()->getValue().getValue() ) );
+        }
+    }
+
+    inline mx::core::TransposePtr makeTranspose( int inChromatic, std::optional<int> inDiatonic, std::optional<int> inOctave )
+    {
+        auto transpose = mx::core::makeTranspose();
+        transpose->getChromatic()->setValue( mx::core::Semitones{ static_cast<mx::core::DecimalType>( inChromatic ) } );
+        if( inDiatonic.has_value() )
+        {
+            transpose->setHasDiatonic( true );
+            transpose->getDiatonic()->setValue( mx::core::Integer{ inDiatonic.value() } );
+        }
+        if( inOctave.has_value() )
+        {
+            transpose->setHasOctaveChange( true );
+            transpose->getOctaveChange()->setValue( mx::core::Integer{ inOctave.value() } );
+        }
+        return transpose;
+    }
+}
+
+TEST( convertToTransposeData01, Transposition )
+{
+    // in Db (up) with no diatonic
+    const int expectedChromatic = 1;
+    const int expectedDiatonic = 1;
+    const auto transpose = mxtest::makeTranspose( 1, std::nullopt, std::nullopt );
+    const auto actual = mx::impl::Converter::convertToTransposeData( *transpose );
+    CHECK_EQUAL( expectedChromatic, actual.chromatic );
+    CHECK_EQUAL( expectedDiatonic, actual.diatonic );
+}
+
+TEST( convertToTransposeData02, Transposition )
+{
+    // in B (down) with no diatonic
+    const int expectedChromatic = -1;
+    const int expectedDiatonic = -1;
+    const auto transpose = mxtest::makeTranspose( expectedChromatic, std::nullopt, std::nullopt );
+    const auto actual = mx::impl::Converter::convertToTransposeData( *transpose );
+    CHECK_EQUAL( expectedChromatic, actual.chromatic );
+    CHECK_EQUAL( expectedDiatonic, actual.diatonic );
+}
+
+TEST( convertToTransposeData03, Transposition )
+{
+    // in D with no diatonic
+    const int expectedChromatic = 2;
+    const int expectedDiatonic = 1;
+    const auto transpose = mxtest::makeTranspose( expectedChromatic, std::nullopt, std::nullopt );
+    const auto actual = mx::impl::Converter::convertToTransposeData( *transpose );
+    CHECK_EQUAL( expectedChromatic, actual.chromatic );
+    CHECK_EQUAL( expectedDiatonic, actual.diatonic );
+}
+
+TEST( convertToTransposeData04, Transposition )
+{
+    // in Bb with no diatonic
+    const int expectedChromatic = -2;
+    const int expectedDiatonic = -1;
+    const auto transpose = mxtest::makeTranspose( expectedChromatic, std::nullopt, std::nullopt );
+    const auto actual = mx::impl::Converter::convertToTransposeData( *transpose );
+    CHECK_EQUAL( expectedChromatic, actual.chromatic );
+    CHECK_EQUAL( expectedDiatonic, actual.diatonic );
+}
+
+TEST( convertToTransposeData05, Transposition )
+{
+    // in Eb (up) with no diatonic
+    const int expectedChromatic = 3;
+    const int expectedDiatonic = 2;
+    const auto transpose = mxtest::makeTranspose( expectedChromatic, std::nullopt, std::nullopt );
+    const auto actual = mx::impl::Converter::convertToTransposeData( *transpose );
+    CHECK_EQUAL( expectedChromatic, actual.chromatic );
+    CHECK_EQUAL( expectedDiatonic, actual.diatonic );
+}
+
+TEST( convertToTransposeData06, Transposition )
+{
+    // in A with no diatonic
+    const int expectedChromatic = -3;
+    const int expectedDiatonic = -2;
+    const auto transpose = mxtest::makeTranspose( expectedChromatic, std::nullopt, std::nullopt );
+    const auto actual = mx::impl::Converter::convertToTransposeData( *transpose );
+    CHECK_EQUAL( expectedChromatic, actual.chromatic );
+    CHECK_EQUAL( expectedDiatonic, actual.diatonic );
+}
+
+TEST( convertToTransposeData07, Transposition )
+{
+    // in E with no diatonic
+    const int expectedChromatic = 4;
+    const int expectedDiatonic = 2;
+    const auto transpose = mxtest::makeTranspose( expectedChromatic, std::nullopt, std::nullopt );
+    const auto actual = mx::impl::Converter::convertToTransposeData( *transpose );
+    CHECK_EQUAL( expectedChromatic, actual.chromatic );
+    CHECK_EQUAL( expectedDiatonic, actual.diatonic );
+}
+
+TEST( convertToTransposeData08, Transposition )
+{
+    // in Ab with no diatonic
+    const int expectedChromatic = -4;
+    const int expectedDiatonic = -2;
+    const auto transpose = mxtest::makeTranspose( expectedChromatic, std::nullopt, std::nullopt );
+    const auto actual = mx::impl::Converter::convertToTransposeData( *transpose );
+    CHECK_EQUAL( expectedChromatic, actual.chromatic );
+    CHECK_EQUAL( expectedDiatonic, actual.diatonic );
+}
+
+TEST( convertToTransposeData09, Transposition )
+{
+    // in F with no diatonic
+    const int expectedChromatic = 5;
+    const int expectedDiatonic = 3;
+    const auto transpose = mxtest::makeTranspose( expectedChromatic, std::nullopt, std::nullopt );
+    const auto actual = mx::impl::Converter::convertToTransposeData( *transpose );
+    CHECK_EQUAL( expectedChromatic, actual.chromatic );
+    CHECK_EQUAL( expectedDiatonic, actual.diatonic );
+}
+
+TEST( convertToTransposeData10, Transposition )
+{
+    // in G with no diatonic
+    const int expectedChromatic = -5;
+    const int expectedDiatonic = -3;
+    const auto transpose = mxtest::makeTranspose( expectedChromatic, std::nullopt, std::nullopt );
+    const auto actual = mx::impl::Converter::convertToTransposeData( *transpose );
+    CHECK_EQUAL( expectedChromatic, actual.chromatic );
+    CHECK_EQUAL( expectedDiatonic, actual.diatonic );
+}
+
+TEST( convertToTransposeData11, Transposition )
+{
+    // in F# with no diatonic
+    const int expectedChromatic = 6;
+    const int expectedDiatonic = 3;
+    const auto transpose = mxtest::makeTranspose( expectedChromatic, std::nullopt, std::nullopt );
+    const auto actual = mx::impl::Converter::convertToTransposeData( *transpose );
+    CHECK_EQUAL( expectedChromatic, actual.chromatic );
+    CHECK_EQUAL( expectedDiatonic, actual.diatonic );
+}
+
+TEST( convertToTransposeData12, Transposition )
+{
+    // in Gb with no diatonic
+    const int expectedChromatic = -6;
+    const int expectedDiatonic = -3;
+    const auto transpose = mxtest::makeTranspose( expectedChromatic, std::nullopt, std::nullopt );
+    const auto actual = mx::impl::Converter::convertToTransposeData( *transpose );
+    CHECK_EQUAL( expectedChromatic, actual.chromatic );
+    CHECK_EQUAL( expectedDiatonic, actual.diatonic );
+}
+
+TEST( convertToTransposeData13, Transposition )
+{
+    // in G (up) with no diatonic
+    const int expectedChromatic = 7;
+    const int expectedDiatonic = 4;
+    const auto transpose = mxtest::makeTranspose( expectedChromatic, std::nullopt, std::nullopt );
+    const auto actual = mx::impl::Converter::convertToTransposeData( *transpose );
+    CHECK_EQUAL( expectedChromatic, actual.chromatic );
+    CHECK_EQUAL( expectedDiatonic, actual.diatonic );
+}
+
+TEST( convertToTransposeData14, Transposition )
+{
+    // in F (down) with no diatonic
+    const int expectedChromatic = -7;
+    const int expectedDiatonic = -4;
+    const auto transpose = mxtest::makeTranspose( expectedChromatic, std::nullopt, std::nullopt );
+    const auto actual = mx::impl::Converter::convertToTransposeData( *transpose );
+    CHECK_EQUAL( expectedChromatic, actual.chromatic );
+    CHECK_EQUAL( expectedDiatonic, actual.diatonic );
+}
+
+TEST( convertToTransposeData15, Transposition )
+{
+    // in Ab (up) with no diatonic
+    const int expectedChromatic = 8;
+    const int expectedDiatonic = 5;
+    const auto transpose = mxtest::makeTranspose( expectedChromatic, std::nullopt, std::nullopt );
+    const auto actual = mx::impl::Converter::convertToTransposeData( *transpose );
+    CHECK_EQUAL( expectedChromatic, actual.chromatic );
+    CHECK_EQUAL( expectedDiatonic, actual.diatonic );
+}
+
+TEST( convertToTransposeData16, Transposition )
+{
+    // in E (down) with no diatonic
+    const int expectedChromatic = -8;
+    const int expectedDiatonic = -5;
+    const auto transpose = mxtest::makeTranspose( expectedChromatic, std::nullopt, std::nullopt );
+    const auto actual = mx::impl::Converter::convertToTransposeData( *transpose );
+    CHECK_EQUAL( expectedChromatic, actual.chromatic );
+    CHECK_EQUAL( expectedDiatonic, actual.diatonic );
+}
+
+TEST( convertToTransposeData17, Transposition )
+{
+    // in A (up) with no diatonic
+    const int expectedChromatic = 9;
+    const int expectedDiatonic = 5;
+    const auto transpose = mxtest::makeTranspose( expectedChromatic, std::nullopt, std::nullopt );
+    const auto actual = mx::impl::Converter::convertToTransposeData( *transpose );
+    CHECK_EQUAL( expectedChromatic, actual.chromatic );
+    CHECK_EQUAL( expectedDiatonic, actual.diatonic );
+}
+
+TEST( convertToTransposeData18, Transposition )
+{
+    // in Eb (down) with no diatonic
+    const int expectedChromatic = -9;
+    const int expectedDiatonic = -5;
+    const auto transpose = mxtest::makeTranspose( expectedChromatic, std::nullopt, std::nullopt );
+    const auto actual = mx::impl::Converter::convertToTransposeData( *transpose );
+    CHECK_EQUAL( expectedChromatic, actual.chromatic );
+    CHECK_EQUAL( expectedDiatonic, actual.diatonic );
+}
+
+TEST( convertToTransposeData19, Transposition )
+{
+    // in Bb (up) with no diatonic
+    const int expectedChromatic = 10;
+    const int expectedDiatonic = 6;
+    const auto transpose = mxtest::makeTranspose( expectedChromatic, std::nullopt, std::nullopt );
+    const auto actual = mx::impl::Converter::convertToTransposeData( *transpose );
+    CHECK_EQUAL( expectedChromatic, actual.chromatic );
+    CHECK_EQUAL( expectedDiatonic, actual.diatonic );
+}
+
+TEST( convertToTransposeData20, Transposition )
+{
+    // in D (down) with no diatonic
+    const int expectedChromatic = -10;
+    const int expectedDiatonic = -6;
+    const auto transpose = mxtest::makeTranspose( expectedChromatic, std::nullopt, std::nullopt );
+    const auto actual = mx::impl::Converter::convertToTransposeData( *transpose );
+    CHECK_EQUAL( expectedChromatic, actual.chromatic );
+    CHECK_EQUAL( expectedDiatonic, actual.diatonic );
+}
+
+TEST( convertToTransposeData21, Transposition )
+{
+    // in B (up) with no diatonic
+    const int expectedChromatic = 11;
+    const int expectedDiatonic = 6;
+    const auto transpose = mxtest::makeTranspose( expectedChromatic, std::nullopt, std::nullopt );
+    const auto actual = mx::impl::Converter::convertToTransposeData( *transpose );
+    CHECK_EQUAL( expectedChromatic, actual.chromatic );
+    CHECK_EQUAL( expectedDiatonic, actual.diatonic );
+}
+
+TEST( convertToTransposeData22, Transposition )
+{
+    // in Db (down) with no diatonic
+    const int expectedChromatic = -11;
+    const int expectedDiatonic = -6;
+    const auto transpose = mxtest::makeTranspose( expectedChromatic, std::nullopt, std::nullopt );
+    const auto actual = mx::impl::Converter::convertToTransposeData( *transpose );
+    CHECK_EQUAL( expectedChromatic, actual.chromatic );
+    CHECK_EQUAL( expectedDiatonic, actual.diatonic );
+}
+
+TEST( convertToTransposeData23, Transposition )
+{
+    // in C (up) with no diatonic and no octave (technically incorrect musicxml)
+    const int expectedChromatic = 12;
+    const int expectedDiatonic = 7;
+    const auto transpose = mxtest::makeTranspose( expectedChromatic, std::nullopt, std::nullopt );
+    const auto actual = mx::impl::Converter::convertToTransposeData( *transpose );
+    CHECK_EQUAL( expectedChromatic, actual.chromatic );
+    CHECK_EQUAL( expectedDiatonic, actual.diatonic );
+}
+
+TEST( convertToTransposeData24, Transposition )
+{
+    // in C (down) with no diatonic and no octave (technically incorrect musicxml)
+    const int expectedChromatic = -12;
+    const int expectedDiatonic = -7;
+    const auto transpose = mxtest::makeTranspose( expectedChromatic, std::nullopt, std::nullopt );
+    const auto actual = mx::impl::Converter::convertToTransposeData( *transpose );
+    CHECK_EQUAL( expectedChromatic, actual.chromatic );
+    CHECK_EQUAL( expectedDiatonic, actual.diatonic );
+}
+
+TEST( convertToTransposeData25, Transposition )
+{
+    // in Db+1 (up) with no diatonic and no octave (technically incorrect musicxml)
+    const int expectedChromatic = 13;
+    const int expectedDiatonic = 8;
+    const auto transpose = mxtest::makeTranspose( expectedChromatic, std::nullopt, std::nullopt );
+    const auto actual = mx::impl::Converter::convertToTransposeData( *transpose );
+    CHECK_EQUAL( expectedChromatic, actual.chromatic );
+    CHECK_EQUAL( expectedDiatonic, actual.diatonic );
+}
+
+TEST( convertToTransposeData26, Transposition )
+{
+    // in B-1 (down) with no diatonic and no octave (technically incorrect musicxml)
+    const int expectedChromatic = -13;
+    const int expectedDiatonic = -8;
+    const auto transpose = mxtest::makeTranspose( expectedChromatic, std::nullopt, std::nullopt );
+    const auto actual = mx::impl::Converter::convertToTransposeData( *transpose );
+    CHECK_EQUAL( expectedChromatic, actual.chromatic );
+    CHECK_EQUAL( expectedDiatonic, actual.diatonic );
+}
+
+TEST( convertToTransposeData27, Transposition )
+{
+    // crazy numbers, both chromatic and diatonic specified (and technically invalid), octave not specified
+    const int expectedChromatic = -130;
+    const int expectedDiatonic = 147;
+    const auto transpose = mxtest::makeTranspose( expectedChromatic, expectedDiatonic, std::nullopt );
+    const auto actual = mx::impl::Converter::convertToTransposeData( *transpose );
+    CHECK_EQUAL( expectedChromatic, actual.chromatic );
+    CHECK_EQUAL( expectedDiatonic, actual.diatonic );
+}
+
+TEST( convertToTransposeData28, Transposition )
+{
+    // crazy numbers, both chromatic and diatonic specified (and technically invalid), octave is specified
+    const int expectedChromatic = -138;
+    const int expectedDiatonic = 147;
+    const int octave = 2;
+    const auto transpose = mxtest::makeTranspose( -162, 133, octave );
+    const auto actual = mx::impl::Converter::convertToTransposeData( *transpose );
+    CHECK_EQUAL( expectedChromatic, actual.chromatic );
+    CHECK_EQUAL( expectedDiatonic, actual.diatonic );
+}
+
+TEST( convertToTransposeData29, Transposition )
+{
+    // normal, correct usage with octave offset, e.g. Tenor Saxophone in Bb
+    const int expectedChromatic = -14;
+    const int expectedDiatonic = -8;
+    const int octave = -1;
+    const auto transpose = mxtest::makeTranspose( -2, -1, octave );
+    const auto actual = mx::impl::Converter::convertToTransposeData( *transpose );
+    CHECK_EQUAL( expectedChromatic, actual.chromatic );
+    CHECK_EQUAL( expectedDiatonic, actual.diatonic );
+}
+
+TEST( convertToTransposeData30, Transposition )
+{
+    // normal, correct usage with octave offset, e.g. Piccolo Clarinet in Bb
+    const int expectedChromatic = 10;
+    const int expectedDiatonic = 6;
+    const int octave = 1;
+    const auto transpose = mxtest::makeTranspose( -2, -1, octave );
+    const auto actual = mx::impl::Converter::convertToTransposeData( *transpose );
+    CHECK_EQUAL( expectedChromatic, actual.chromatic );
+    CHECK_EQUAL( expectedDiatonic, actual.diatonic );
+}
+
+TEST( convertToTransposeData31, Transposition )
+{
+    // complete nonsense input, chromatic is out of range, diatonic is not specified, octave is specified.
+    // the behaviour is undefined, but this test locks down the behaviour as we have it now.
+    const int expectedChromatic = -1306;
+    const int expectedDiatonic = -762;
+    const int octave = -6;
+    const auto transpose = mxtest::makeTranspose( -1234, std::nullopt, octave );
+    const auto actual = mx::impl::Converter::convertToTransposeData( *transpose );
+    CHECK_EQUAL( expectedChromatic, actual.chromatic );
+    CHECK_EQUAL( expectedDiatonic, actual.diatonic );
+}
+
+TEST( Conversion01, Transposition )
+{
+    const auto expectedChromatic = 2;
+    const auto expectedDiatonic = 1;
+    const auto expectedOctave = 0;
+    const auto transposeDataChromatic = 2;
+    const auto transposeDataDiatonic = 1;
+    const auto original = mx::api::TransposeData{ transposeDataChromatic, transposeDataDiatonic };
+    const auto converted = mx::impl::Converter::convertToTranspose( original );
+    REQUIRE( converted != nullptr );
+    CHECK_EQUAL( expectedChromatic, static_cast<int>( converted->getChromatic()->getValue().getValue() ) );
+    CHECK( converted->getHasDiatonic() == ( expectedDiatonic != 0 ) );
+    CHECK_EQUAL( expectedDiatonic, static_cast<int>( converted->getDiatonic()->getValue().getValue() ) );
+    CHECK( converted->getHasOctaveChange() == ( expectedOctave != 0 ) );
+    CHECK_EQUAL( expectedOctave, static_cast<int>( converted->getOctaveChange()->getValue().getValue() ) );
+    const auto final = mx::impl::Converter::convertToTransposeData( *converted );
+    CHECK_EQUAL( transposeDataChromatic, final.chromatic );
+    CHECK_EQUAL( transposeDataDiatonic, final.diatonic );
+    CHECK_EQUAL( original, final );
+}
+
+TEST( Conversion02, Transposition )
+{
+    const auto expectedChromatic = 0;
+    const auto expectedDiatonic = 0;
+    const auto expectedOctave = 1;
+    const auto transposeDataChromatic = 12;
+    const auto transposeDataDiatonic = 7;
+    const auto original = mx::api::TransposeData{ transposeDataChromatic, transposeDataDiatonic };
+    const auto converted = mx::impl::Converter::convertToTranspose( original );
+    REQUIRE( converted != nullptr );
+    CHECK_EQUAL( expectedChromatic, static_cast<int>( converted->getChromatic()->getValue().getValue() ) );
+    CHECK( converted->getHasDiatonic() == ( expectedDiatonic != 0 ) );
+    CHECK_EQUAL( expectedDiatonic, static_cast<int>( converted->getDiatonic()->getValue().getValue() ) );
+    CHECK( converted->getHasOctaveChange() == ( expectedOctave != 0 ) );
+    CHECK_EQUAL( expectedOctave, static_cast<int>( converted->getOctaveChange()->getValue().getValue() ) );
+    const auto final = mx::impl::Converter::convertToTransposeData( *converted );
+    CHECK_EQUAL( transposeDataChromatic, final.chromatic );
+    CHECK_EQUAL( transposeDataDiatonic, final.diatonic );
+    CHECK_EQUAL( original, final );
+}
+
+TEST( Conversion03, Transposition )
+{
+    const auto expectedChromatic = 4;
+    const auto expectedDiatonic = 2;
+    const auto expectedOctave = 1;
+    const auto transposeDataChromatic = 16;
+    const auto transposeDataDiatonic = 9;
+    const auto original = mx::api::TransposeData{ transposeDataChromatic, transposeDataDiatonic };
+    const auto converted = mx::impl::Converter::convertToTranspose( original );
+    REQUIRE( converted != nullptr );
+    CHECK_EQUAL( expectedChromatic, static_cast<int>( converted->getChromatic()->getValue().getValue() ) );
+    CHECK( converted->getHasDiatonic() == ( expectedDiatonic != 0 ) );
+    CHECK_EQUAL( expectedDiatonic, static_cast<int>( converted->getDiatonic()->getValue().getValue() ) );
+    CHECK( converted->getHasOctaveChange() == ( expectedOctave != 0 ) );
+    CHECK_EQUAL( expectedOctave, static_cast<int>( converted->getOctaveChange()->getValue().getValue() ) );
+    const auto final = mx::impl::Converter::convertToTransposeData( *converted );
+    CHECK_EQUAL( transposeDataChromatic, final.chromatic );
+    CHECK_EQUAL( transposeDataDiatonic, final.diatonic );
+    CHECK_EQUAL( original, final );
+}
+
+TEST( Conversion04, Transposition )
+{
+    const auto expectedChromatic = -4;
+    const auto expectedDiatonic = -2;
+    const auto expectedOctave = -1;
+    const auto transposeDataChromatic = -16;
+    const auto transposeDataDiatonic = -9;
+    const auto original = mx::api::TransposeData{ transposeDataChromatic, transposeDataDiatonic };
+    const auto converted = mx::impl::Converter::convertToTranspose( original );
+    REQUIRE( converted != nullptr );
+    CHECK_EQUAL( expectedChromatic, static_cast<int>( converted->getChromatic()->getValue().getValue() ) );
+    CHECK( converted->getHasDiatonic() == ( expectedDiatonic != 0 ) );
+    CHECK_EQUAL( expectedDiatonic, static_cast<int>( converted->getDiatonic()->getValue().getValue() ) );
+    CHECK( converted->getHasOctaveChange() == ( expectedOctave != 0 ) );
+    CHECK_EQUAL( expectedOctave, static_cast<int>( converted->getOctaveChange()->getValue().getValue() ) );
+    const auto final = mx::impl::Converter::convertToTransposeData( *converted );
+    CHECK_EQUAL( transposeDataChromatic, final.chromatic );
+    CHECK_EQUAL( transposeDataDiatonic, final.diatonic );
+    CHECK_EQUAL( original, final );
+}
+
+TEST( Tests01, Transposition )
+{
+    const int chromatic = 2;
+    const int diatonic = 1;
+    const int expectedXmlChromatic = 2;
+    const int expectedXmlDiatonic = 1;
+    const std::optional<int> expectedXmlOctave = std::nullopt;
+    auto score = mxtest::makeScore( 1 );
+    auto& part = score.parts.back();
+    part.transposition = mx::api::TransposeData{ chromatic, diatonic };
+    CHECK( part.transposition->isUsed() );
+    mxtest::checkCoreTransposeElement( score, expectedXmlChromatic, expectedXmlDiatonic, expectedXmlOctave );
+    const auto result = mxtest::roundtrip( score );
+    REQUIRE( result.parts.back().transposition.has_value() );
+    CHECK( result.parts.back().transposition );
+    CHECK( result.parts.back().transposition->isUsed() );
+    CHECK_EQUAL( chromatic, result.parts.back().transposition->chromatic );
+    CHECK_EQUAL( diatonic, result.parts.back().transposition->diatonic );
+}
+
+TEST( Tests02, Transposition )
+{
+    const int chromatic = 11;
+    const int diatonic = 6;
+    const int expectedXmlChromatic = 11;
+    const int expectedXmlDiatonic = 6;
+    const std::optional<int> expectedXmlOctave = std::nullopt;
+    auto score = mxtest::makeScore( 1 );
+    auto& part = score.parts.back();
+    part.transposition = mx::api::TransposeData{ chromatic, diatonic };
+    CHECK( part.transposition->isUsed() );
+    mxtest::checkCoreTransposeElement( score, expectedXmlChromatic, expectedXmlDiatonic, expectedXmlOctave );
+    const auto result = mxtest::roundtrip( score );
+    REQUIRE( result.parts.back().transposition.has_value() );
+    CHECK( result.parts.back().transposition );
+    CHECK( result.parts.back().transposition->isUsed() );
+    CHECK_EQUAL( chromatic, result.parts.back().transposition->chromatic );
+    CHECK_EQUAL( diatonic, result.parts.back().transposition->diatonic );
+}
+
+TEST( Tests03, Transposition )
+{
+    const int chromatic = 12;
+    const int diatonic = 7;
+    const int expectedXmlChromatic = 0;
+    const std::optional<int> expectedXmlDiatonic = std::nullopt;
+    const std::optional<int> expectedXmlOctave = std::nullopt;
+    auto score = mxtest::makeScore( 1 );
+    auto& part = score.parts.back();
+    part.transposition = mx::api::TransposeData{ chromatic, diatonic };
+    CHECK( part.transposition->isUsed() );
+    mxtest::checkCoreTransposeElement( score, expectedXmlChromatic, expectedXmlDiatonic, expectedXmlOctave );
+    const auto result = mxtest::roundtrip( score );
+    REQUIRE( result.parts.back().transposition.has_value() );
+    CHECK( result.parts.back().transposition );
+    CHECK( result.parts.back().transposition->isUsed() );
+    CHECK_EQUAL( chromatic, result.parts.back().transposition->chromatic );
+    CHECK_EQUAL( diatonic, result.parts.back().transposition->diatonic );
+}
+
+TEST( Tests04, Transposition )
+{
+    const int chromatic = 13;
+    const int diatonic = 8;
+    const int expectedXmlChromatic = 1;
+    const int expectedXmlDiatonic = 1;
+    const std::optional<int> expectedXmlOctave = 1;
+    auto score = mxtest::makeScore( 1 );
+    auto& part = score.parts.back();
+    part.transposition = mx::api::TransposeData{ chromatic, diatonic };
+    CHECK( part.transposition->isUsed() );
+    mxtest::checkCoreTransposeElement( score, expectedXmlChromatic, expectedXmlDiatonic, expectedXmlOctave );
+    const auto result = mxtest::roundtrip( score );
+    REQUIRE( result.parts.back().transposition.has_value() );
+    CHECK( result.parts.back().transposition );
+    CHECK( result.parts.back().transposition->isUsed() );
+    CHECK_EQUAL( chromatic, result.parts.back().transposition->chromatic );
+    CHECK_EQUAL( diatonic, result.parts.back().transposition->diatonic );
+}
+
+TEST( Tests05, Transposition )
+{
+    const int chromatic = 14;
+    const int diatonic = 8;
+    const int expectedXmlChromatic = 2;
+    const int expectedXmlDiatonic = 1;
+    const std::optional<int> expectedXmlOctave = 1;
+    auto score = mxtest::makeScore( 1 );
+    auto& part = score.parts.back();
+    part.transposition = mx::api::TransposeData{ chromatic, diatonic };
+    CHECK( part.transposition->isUsed() );
+    mxtest::checkCoreTransposeElement( score, expectedXmlChromatic, expectedXmlDiatonic, expectedXmlOctave );
+    const auto result = mxtest::roundtrip( score );
+    REQUIRE( result.parts.back().transposition.has_value() );
+    CHECK( result.parts.back().transposition );
+    CHECK( result.parts.back().transposition->isUsed() );
+    CHECK_EQUAL( chromatic, result.parts.back().transposition->chromatic );
+    CHECK_EQUAL( diatonic, result.parts.back().transposition->diatonic );
+}
+
+TEST( Tests06, Transposition )
+{
+    // super wonky test case, maybe it doesn't matter if it fails
+    const int chromatic = 14;
+    const int diatonic = -8;
+    const int expectedXmlChromatic = 2;
+    const int expectedXmlDiatonic = -15;
+    const std::optional<int> expectedXmlOctave = 1;
+    auto score = mxtest::makeScore( 1 );
+    auto& part = score.parts.back();
+    part.transposition = mx::api::TransposeData{ chromatic, diatonic };
+    CHECK( part.transposition->isUsed() );
+    mxtest::checkCoreTransposeElement( score, expectedXmlChromatic, expectedXmlDiatonic, expectedXmlOctave );
+    const auto result = mxtest::roundtrip( score );
+    REQUIRE( result.parts.back().transposition.has_value() );
+    CHECK( result.parts.back().transposition );
+    CHECK( result.parts.back().transposition->isUsed() );
+    CHECK_EQUAL( chromatic, result.parts.back().transposition->chromatic );
+    CHECK_EQUAL( diatonic, result.parts.back().transposition->diatonic );
+}
+
+TEST( Tests07, Transposition )
+{
+    const int chromatic = -1;
+    const int diatonic = -1;
+    const int expectedXmlChromatic = -1;
+    const int expectedXmlDiatonic = -1;
+    const std::optional<int> expectedXmlOctave = std::nullopt;
+    auto score = mxtest::makeScore( 1 );
+    auto& part = score.parts.back();
+    part.transposition = mx::api::TransposeData{ chromatic, diatonic };
+    CHECK( part.transposition->isUsed() );
+    mxtest::checkCoreTransposeElement( score, expectedXmlChromatic, expectedXmlDiatonic, expectedXmlOctave );
+    const auto result = mxtest::roundtrip( score );
+    REQUIRE( result.parts.back().transposition.has_value() );
+    CHECK( result.parts.back().transposition );
+    CHECK( result.parts.back().transposition->isUsed() );
+    CHECK_EQUAL( chromatic, result.parts.back().transposition->chromatic );
+    CHECK_EQUAL( diatonic, result.parts.back().transposition->diatonic );
+}
+
+TEST( Tests08, Transposition )
+{
+    const int chromatic = -11;
+    const int diatonic = -6;
+    const int expectedXmlChromatic = -11;
+    const int expectedXmlDiatonic = -6;
+    const std::optional<int> expectedXmlOctave = std::nullopt;
+    auto score = mxtest::makeScore( 1 );
+    auto& part = score.parts.back();
+    part.transposition = mx::api::TransposeData{ chromatic, diatonic };
+    CHECK( part.transposition->isUsed() );
+    mxtest::checkCoreTransposeElement( score, expectedXmlChromatic, expectedXmlDiatonic, expectedXmlOctave );
+    const auto result = mxtest::roundtrip( score );
+    REQUIRE( result.parts.back().transposition.has_value() );
+    CHECK( result.parts.back().transposition );
+    CHECK( result.parts.back().transposition->isUsed() );
+    CHECK_EQUAL( chromatic, result.parts.back().transposition->chromatic );
+    CHECK_EQUAL( diatonic, result.parts.back().transposition->diatonic );
+}
+
+TEST( Tests09, Transposition )
+{
+    const int chromatic = -12;
+    const int diatonic = -7;
+    const int expectedXmlChromatic = 0;
+    const std::optional<int> expectedXmlDiatonic = std::nullopt;
+    const std::optional<int> expectedXmlOctave = -1;
+    auto score = mxtest::makeScore( 1 );
+    auto& part = score.parts.back();
+    part.transposition = mx::api::TransposeData{ chromatic, diatonic };
+    CHECK( part.transposition->isUsed() );
+    mxtest::checkCoreTransposeElement( score, expectedXmlChromatic, expectedXmlDiatonic, expectedXmlOctave );
+    const auto result = mxtest::roundtrip( score );
+    REQUIRE( result.parts.back().transposition.has_value() );
+    CHECK( result.parts.back().transposition );
+    CHECK( result.parts.back().transposition->isUsed() );
+    CHECK_EQUAL( chromatic, result.parts.back().transposition->chromatic );
+    CHECK_EQUAL( diatonic, result.parts.back().transposition->diatonic );
+}
+
+TEST( noMeasures, Transposition )
+{
+    const int chromatic = 2;
+    const int diatonic = 1;
+    const int expectedXmlChromatic = 2;
+    const std::optional<int> expectedXmlDiatonic = 1;
+    const std::optional<int> expectedXmlOctave = std::nullopt;
+    auto score = mxtest::makeScore( 0 ); // NO MEASURES!
+    auto& part = score.parts.back();
+    part.transposition = mx::api::TransposeData{ chromatic, diatonic };
+    CHECK( part.transposition->isUsed() );
+    mxtest::checkCoreTransposeElement( score, expectedXmlChromatic, expectedXmlDiatonic, expectedXmlOctave );
+    const auto result = mxtest::roundtrip( score );
+    REQUIRE( result.parts.back().transposition.has_value() );
+    CHECK( result.parts.back().transposition );
+    CHECK( result.parts.back().transposition->isUsed() );
+    CHECK_EQUAL( chromatic, result.parts.back().transposition->chromatic );
+    CHECK_EQUAL( diatonic, result.parts.back().transposition->diatonic );
+}
+
+TEST( noTransposition, Transposition )
+{
+    const int chromatic = 0;
+    const int diatonic = 0;
+    auto score = mxtest::makeScore( 0 );
+    auto& part = score.parts.back();
+    part.transposition = mx::api::TransposeData{ chromatic, diatonic };
+    CHECK( !part.transposition->isUsed() );
+    const auto result = mxtest::roundtrip( score );
+    CHECK( !result.parts.back().transposition );
+}
+
+TEST( Tests10, Transposition )
+{
+    const int chromatic = -13;
+    const int diatonic = -8;
+    const int expectedXmlChromatic = -1;
+    const std::optional<int> expectedXmlDiatonic = -1;
+    const std::optional<int> expectedXmlOctave = -1;
+    auto score = mxtest::makeScore( 1 );
+    auto& part = score.parts.back();
+    part.transposition = mx::api::TransposeData{ chromatic, diatonic };
+    CHECK( part.transposition->isUsed() );
+    mxtest::checkCoreTransposeElement( score, expectedXmlChromatic, expectedXmlDiatonic, expectedXmlOctave );
+    const auto result = mxtest::roundtrip( score );
+    REQUIRE( result.parts.back().transposition.has_value() );
+    CHECK( result.parts.back().transposition );
+    CHECK( result.parts.back().transposition->isUsed() );
+    CHECK_EQUAL( chromatic, result.parts.back().transposition->chromatic );
+    CHECK_EQUAL( diatonic, result.parts.back().transposition->diatonic );
+}
+
+TEST( Tests11, Transposition )
+{
+    // this is a funky test case. these values are actually nonsense.
+    const int chromatic = -14;
+    const int diatonic = 8;
+    const int expectedXmlChromatic = -2;
+    const std::optional<int> expectedXmlDiatonic = 15;
+    const std::optional<int> expectedXmlOctave = -1;
+    auto score = mxtest::makeScore( 1 );
+    auto& part = score.parts.back();
+    part.transposition = mx::api::TransposeData{ chromatic, diatonic };
+    CHECK( part.transposition->isUsed() );
+    mxtest::checkCoreTransposeElement( score, expectedXmlChromatic, expectedXmlDiatonic, expectedXmlOctave );
+    const auto result = mxtest::roundtrip( score );
+    REQUIRE( result.parts.back().transposition.has_value() );
+    CHECK( result.parts.back().transposition );
+    CHECK( result.parts.back().transposition->isUsed() );
+    CHECK_EQUAL( chromatic, result.parts.back().transposition->chromatic );
+    CHECK_EQUAL( diatonic, result.parts.back().transposition->diatonic );
+}
+
+TEST( ApiRoundTrip, Transposition )
+{
+    const auto original = mxtest::MxFileRepository::loadFile( "transposition.musicxml" );
+    const auto result = mxtest::roundtrip( original );
+    REQUIRE( result.parts.size() == 31 );
+    // manually check some of the part transpositions
+    size_t partIndex = 0;
+    std::string partId = "P" + std::to_string( partIndex + 1 );
+    auto part = result.parts.at( partIndex );
+    CHECK_EQUAL( partId, part.uniqueId );
+    CHECK_WITH_MESSAGE( part.transposition.has_value(), partId + " is missing transposition" );
+    CHECK( part.transposition->isUsed() );
+    CHECK_EQUAL( 12, part.transposition->chromatic );
+    CHECK_EQUAL( 7, part.transposition->diatonic );
+
+    partIndex = 6;
+    partId = "P" + std::to_string( partIndex + 1 );
+    part = result.parts.at( partIndex );
+    CHECK_EQUAL( partId, part.uniqueId );
+    CHECK_WITH_MESSAGE( !part.transposition.has_value(), partId + " should have no transposition" );
+
+    partIndex = 13;
+    partId = "P" + std::to_string( partIndex + 1 );
+    part = result.parts.at( partIndex );
+    CHECK_EQUAL( partId, part.uniqueId );
+    CHECK_WITH_MESSAGE( part.transposition.has_value(), partId + " is missing transposition" );
+    CHECK( part.transposition->isUsed() );
+    CHECK_EQUAL( -9, part.transposition->chromatic );
+    CHECK_EQUAL( -5, part.transposition->diatonic );
+
+    partIndex = 14;
+    partId = "P" + std::to_string( partIndex + 1 );
+    part = result.parts.at( partIndex );
+    CHECK_EQUAL( partId, part.uniqueId );
+    CHECK_WITH_MESSAGE( part.transposition.has_value(), partId + " is missing transposition" );
+    CHECK( part.transposition->isUsed() );
+    CHECK_EQUAL( -14, part.transposition->chromatic );
+    CHECK_EQUAL( -8, part.transposition->diatonic );
+
+    partIndex = 15;
+    partId = "P" + std::to_string( partIndex + 1 );
+    part = result.parts.at( partIndex );
+    CHECK_EQUAL( partId, part.uniqueId );
+    CHECK_WITH_MESSAGE( part.transposition.has_value(), partId + " is missing transposition" );
+    CHECK( part.transposition->isUsed() );
+    CHECK_EQUAL( -21, part.transposition->chromatic );
+    CHECK_EQUAL( -12, part.transposition->diatonic );
+
+    partIndex = 27;
+    partId = "P" + std::to_string( partIndex + 1 );
+    part = result.parts.at( partIndex );
+    CHECK_EQUAL( partId, part.uniqueId );
+    CHECK_WITH_MESSAGE( !part.transposition.has_value(), partId + " should have no transposition" );
+
+    partIndex = 30;
+    partId = "P" + std::to_string( partIndex + 1 );
+    part = result.parts.at( partIndex );
+    CHECK_EQUAL( partId, part.uniqueId );
+    CHECK_WITH_MESSAGE( !part.transposition.has_value(), partId + " should have no transposition" );
+
+    CHECK_EQUAL( original, result );
+}
+
+#endif

--- a/Sourcecode/private/mxtest/file/MxFileRepositoy.cpp
+++ b/Sourcecode/private/mxtest/file/MxFileRepositoy.cpp
@@ -475,6 +475,7 @@ namespace mxtest
         myNameSubdirectoryMap.emplace( "logic01a_homoSapiens.xml", "logicpro" );
         myNameSubdirectoryMap.emplace( "Schubert_der_Mueller.xml", "foundsuite" );
         myNameSubdirectoryMap.emplace( "systems-and-pages.xml", "custom" );
+        myNameSubdirectoryMap.emplace( "transposition.musicxml", "custom" );
 
         // mxl
         myNameSubdirectoryMap.emplace( "Dichterliebe01.mxl", "mxl" );

--- a/Xcode/Mx.xcodeproj/project.pbxproj
+++ b/Xcode/Mx.xcodeproj/project.pbxproj
@@ -3659,6 +3659,7 @@
 		2948959A1FC4011400A06219 /* AppearanceData.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = AppearanceData.cpp; sourceTree = "<group>"; };
 		2975944D1F044C7600DE2F30 /* ChordData.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = ChordData.cpp; sourceTree = "<group>"; };
 		297594591F04783100DE2F30 /* Round.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = Round.h; sourceTree = "<group>"; };
+		297B99C1252A263B0089E958 /* TransposeData.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = TransposeData.h; sourceTree = "<group>"; };
 		29843ACF248C0CA9006A8E34 /* PageData.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = PageData.h; sourceTree = "<group>"; };
 		29843AD0248C0CA9006A8E34 /* PageLayoutData.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = PageLayoutData.h; sourceTree = "<group>"; };
 		29843AD1248C0CA9006A8E34 /* PageMarginsData.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = PageMarginsData.h; sourceTree = "<group>"; };
@@ -6558,7 +6559,6 @@
 		29DC383C225C0D4000814240 /* api-include */ = {
 			isa = PBXGroup;
 			children = (
-				29843AD9248DE951006A8E34 /* DefaultsData.h */,
 				29DC3863225C0DB800814240 /* ApiCommon.h */,
 				29DC3856225C0DB600814240 /* ApiEquality.h */,
 				29DC3841225C0DB400814240 /* AppearanceData.h */,
@@ -6567,6 +6567,7 @@
 				29DC383D225C0DB300814240 /* ClefData.h */,
 				29DC3861225C0DB700814240 /* ColorData.h */,
 				29DC3859225C0DB600814240 /* CurveData.h */,
+				29843AD9248DE951006A8E34 /* DefaultsData.h */,
 				29DC384B225C0DB500814240 /* DirectionData.h */,
 				29DC3840225C0DB400814240 /* DocumentManager.h */,
 				29DC385B225C0DB700814240 /* DurationData.h */,
@@ -6604,6 +6605,7 @@
 				29843AD5248D47E9006A8E34 /* SystemLayoutData.h */,
 				29DC384E225C0DB500814240 /* TempoData.h */,
 				29DC3842225C0DB400814240 /* TimeSignatureData.h */,
+				297B99C1252A263B0089E958 /* TransposeData.h */,
 				29DC3853225C0DB600814240 /* TupletData.h */,
 				29DC384F225C0DB500814240 /* Version.h */,
 				29DC3865225C0DB800814240 /* VoiceData.h */,

--- a/Xcode/MxTest.xcodeproj/project.pbxproj
+++ b/Xcode/MxTest.xcodeproj/project.pbxproj
@@ -8,6 +8,7 @@
 
 /* Begin PBXBuildFile section */
 		29126F0B245A81F700B1F839 /* KeyDataTest.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 29126F0A245A81F700B1F839 /* KeyDataTest.cpp */; };
+		297B99C3252A265F0089E958 /* TranspositionTest.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 297B99C2252A265F0089E958 /* TranspositionTest.cpp */; };
 		29843AD4248C0CCD006A8E34 /* PageDataTest.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 29843AD3248C0CCD006A8E34 /* PageDataTest.cpp */; };
 		29A04F34244FBA62004A5D3C /* NewSystemTest.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 29A04F31244FBA62004A5D3C /* NewSystemTest.cpp */; };
 		29A04F35244FBA62004A5D3C /* PitchDataTest.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 29A04F32244FBA62004A5D3C /* PitchDataTest.cpp */; };
@@ -482,6 +483,7 @@
 
 /* Begin PBXFileReference section */
 		29126F0A245A81F700B1F839 /* KeyDataTest.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = KeyDataTest.cpp; sourceTree = "<group>"; };
+		297B99C2252A265F0089E958 /* TranspositionTest.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = TranspositionTest.cpp; sourceTree = "<group>"; };
 		29843AD3248C0CCD006A8E34 /* PageDataTest.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = PageDataTest.cpp; sourceTree = "<group>"; };
 		29A04F2D244FBA4D004A5D3C /* catchDefines.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = catchDefines.h; sourceTree = "<group>"; };
 		29A04F2E244FBA4D004A5D3C /* unusedParameter.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = unusedParameter.h; sourceTree = "<group>"; };
@@ -1225,6 +1227,7 @@
 				29DC38B1225C0FC100814240 /* ScoreDataCreator.h */,
 				29DC389C225C0FC100814240 /* TestHelpers.h */,
 				29DC38BC225C0FC100814240 /* TimeSignatureApiTest.cpp */,
+				297B99C2252A265F0089E958 /* TranspositionTest.cpp */,
 			);
 			path = api;
 			sourceTree = "<group>";
@@ -1907,6 +1910,7 @@
 				29DC3BCE225C0FC300814240 /* CreditImageTest.cpp in Sources */,
 				29DC3AE8225C0FC200814240 /* FreezingRoundTrip.cpp in Sources */,
 				29DC3C2D225C0FC300814240 /* DashesTest.cpp in Sources */,
+				297B99C3252A265F0089E958 /* TranspositionTest.cpp in Sources */,
 				29DC3BFD225C0FC300814240 /* LayoutGroupTest.cpp in Sources */,
 				29DC3B66225C0FC200814240 /* EndLineTest.cpp in Sources */,
 				29DC3B27225C0FC200814240 /* PerMinuteTest.cpp in Sources */,


### PR DESCRIPTION
Closes #115 

```text
This adds an optional field to PartData named transposition. This allows you to
specify an instruments transposition at the start of the score. MusicXML encodes
this in the measure data so that you can change transpositions throughout a
part. This api implementation only allows you to set the transposition at the
start of the score (the most common use case). Subsequent instrument and
transposition changes are currently unsupported in the api.
```
