### PR TITLE
fix build-for-apple.sh script and add xcode build cache

### DIFF
--- a/.github/cache-bust
+++ b/.github/cache-bust
@@ -1,0 +1,4 @@
+# this file provides a manual way to clear out github actions caches. any change
+# to this file will cause all github action caches to miss. increment the number
+# below by 1 if you need to clear the caches.
+1

--- a/.github/workflows/ccpp.yml
+++ b/.github/workflows/ccpp.yml
@@ -6,10 +6,10 @@ jobs:
   linux:
     name: Linux
     runs-on: ubuntu-latest
-    
+
     steps:
     - uses: actions/checkout@v2
-    
+
     - name: Cmake
       run: |
               [ "$(git rev-parse --abbrev-ref HEAD)" == "master" ] && \
@@ -19,81 +19,90 @@ jobs:
       run: |
               export CORE_COUNT=$(nproc --all) && echo "CORE_COUNT: $CORE_COUNT" && \
               lscpu
-                       
+
     - name: Build
       run: export CORE_COUNT=$(nproc --all) && make -j$CORE_COUNT
-      
+
     - name: Run Examples
       run: ./mxread && ./mxwrite
-      
+
     - name: Run Tests
       run: ./mxtest
-  
+
   windows:
     name: Windows
     runs-on: windows-latest
-    
+
     steps:
     - uses: actions/checkout@v2
-    
+
     - name: Cmake
       run: |
           cmake -DMX_BUILD_EXAMPLES=on -DMX_BUILD_TESTS=on -DMX_BUILD_CORE_TESTS=off .
-    
+
     - name: Build
       run: |
           cmake --build .
 
     - name: List Directory
       run: dir
-    
-    #- name: List Debug Dir
-    #  run: cd x64 -and dir
-      
+
     - name: Run Example mxwrite
       run: Debug\mxwrite.exe
-    
+
     - name: Run Example mxread
       run: Debug\mxread.exe
-    
+
     - name: Run Tests
       run: Debug\mxtest.exe
-  
+
   macos:
     name: macOS
     runs-on: macos-latest
-    
+
     steps:
     - uses: actions/checkout@v2
-    
+
     - name: Cmake
       run: |
           cmake -DMX_BUILD_EXAMPLES=on -DMX_BUILD_TESTS=on -DMX_BUILD_CORE_TESTS=off .
-    
+
     - name: Build
       run: |
           cmake --build .
-    
+
     - name: Run Example mxwrite
       run: ./mxwrite
-    
+
     - name: Run Example mxread
       run: ./mxread
-    
+
     - name: Run Tests
       run: ./mxtest
 
   xcode:
     name: Xcode
     runs-on: macos-latest
-    
+
     steps:
     - uses: actions/checkout@v2
-    
+
+    - name: Build Cache
+      uses: actions/cache@v2
+      env:
+        cache-name: cargo-home
+      with:
+        path: ./xcode-build
+        key: ${{ hashFiles('.github/cache-bust') }}-${{ hashFiles('Xcode/mx.xcworkspace', 'Xcode/Mx.xcodeproj', 'Xcode/MxTest.xcodeproj') }}-${{ hashFiles('Sourcecode/*') }}
+        restore-keys: |
+          ${{ hashFiles('.github/cache-bust') }}-${{ hashFiles('Xcode/mx.xcworkspace', 'Xcode/Mx.xcodeproj', 'Xcode/MxTest.xcodeproj') }}-
+          ${{ hashFiles('.github/cache-bust') }}-
+
     - name: Build
       run: |
           DevScripts/build-for-apple.sh \
-          --outdir ./xcode-build-artifacts \
+          --outdir ./xcode-out \
+          --build-dir ./xcode-build \
           --test false \
           --configuration Release \
-          --cleanup true
+          --cleanup false

--- a/DevScripts/build-for-apple.sh
+++ b/DevScripts/build-for-apple.sh
@@ -59,7 +59,7 @@ parse_args() {
     case "${1}" in
       # required
       --outdir ) shift; OUTDIR="${1}" ;;
-      
+
       # optional
       --build-dir ) shift; BUILD_DIR="${1}" ;;
       --test ) shift; TEST="${1}" ;;
@@ -98,6 +98,7 @@ parse_args() {
 
 delete_build_dir() {
   if [ "${CLEANUP}" = "true" ]; then
+    echo "deleting build dir"
     rm -rf "${BUILD_DIR}"
   fi;
 }
@@ -164,15 +165,20 @@ build_for_macos() {
 }
 
 create_ios_fat_binary() {
+  echo "create_ios_fat_binary"
+  rm -f "/tmp/MxiOS-x86_64"
+  lipo "${ios_simulator_build_binary}" -extract x86_64 -output "/tmp/MxiOS-x86_64"
+
   lipo -create -output "${ios_binary_temp_path}" \
     "${ios_build_binary}" \
-    "${ios_simulator_build_binary}"
+    "/tmp/MxiOS-x86_64"
 
     # in the ios framework, replace the 'skinny' binary with the 'fat' one
     cp -f "${ios_binary_temp_path}" "${ios_build_binary}"
 }
 
 move_outputs() {
+  echo "move_outputs"
   rm -rf "${OUTDIR}/${ios_framework_name}"
   rm -rf "${OUTDIR}/${macos_framework_name}"
   mv -f "${ios_build_path}/" "${OUTDIR}/"
@@ -187,11 +193,11 @@ main() {
 
   mkdir -p "${BUILD_DIR}"
   mkdir -p "${OUTDIR}"
-  
+
   if [ "${TEST}" = "true" ]; then
-    do_tests    
+    do_tests
   fi;
-  
+
   build_for_ios
   build_for_macos
   create_ios_fat_binary


### PR DESCRIPTION
fixes #119 

```text
fix build-for-apple.sh

Seems like i386 is no more, so now we combine x86_64 from the simulator
build with arm64 from the iOS build. (And that is kind of a weird thing
to do since the simulator build has arm64 and x86_64, which is what we
want in the end.)
```

```text
add build caching for xcode ci

The Xcode CI run is long, slow and uses a lot of compute. Add build
caching to be a bit more frugal.
```