### PR TITLE
Improve arpeggiate reading

### DIFF
--- a/Sourcecode/private/mx/core/Enums.cpp
+++ b/Sourcecode/private/mx/core/Enums.cpp
@@ -3830,6 +3830,42 @@ namespace mx
             return toStream( os, value );
         }
 
+        /// UpDownNone /////////////////////////////////////////////////////////////////////////////////
+
+        UpDownNone parseUpDownNone( const std::string& value )
+        {
+            const auto opt = tryParseUpDownNone( value );
+            return opt.value_or( UpDownNone::none );
+        }
+
+        std::optional<UpDownNone> tryParseUpDownNone( const std::string& value )
+        {
+            if( value == "up" ) { return UpDownNone::up; }
+            else if( value == "down" ) { return UpDownNone::down; }
+            return std::optional<UpDownNone>{};
+        }
+
+        std::string toString( const UpDownNone value )
+        {
+            switch ( value )
+            {
+                case UpDownNone::up: { return "up"; }
+                case UpDownNone::down: { return "down"; }
+                default: break;
+            }
+            return "up";
+        }
+
+        std::ostream& toStream( std::ostream& os, const UpDownNone value )
+        {
+            return os << toString( value );
+        }
+
+        std::ostream& operator<<( std::ostream& os, const UpDownNone value )
+        {
+            return toStream( os, value );
+        }
+    
         /// UpDownStopContinue /////////////////////////////////////////////////////////////////////
 
         UpDownStopContinue parseUpDownStopContinue( const std::string& value )

--- a/Sourcecode/private/mx/core/Enums.h
+++ b/Sourcecode/private/mx/core/Enums.h
@@ -1899,6 +1899,24 @@ namespace mx
         std::ostream& toStream( std::ostream& os, const UpDownStopContinue value );
         std::ostream& operator<<( std::ostream& os, const UpDownStopContinue value );
 
+        /// UpDownNone /////////////////////////////////////////////////////////////////////
+        ///
+        /// The up-down-none type is used for octave-shift elements, indicating the
+        /// direction of the shift from their true pitched values because of printing difficulty.
+        ///
+        enum class UpDownNone
+        {
+            up = 0,
+            down = 1,
+            none = 2
+        };
+
+        UpDownNone parseUpDownNone( const std::string& value );
+        std::optional<UpDownNone> tryParseUpDownNone( const std::string& value );
+        std::string toString( const UpDownNone value );
+        std::ostream& toStream( std::ostream& os, const UpDownNone value );
+        std::ostream& operator<<( std::ostream& os, const UpDownNone value );
+    
         /// UprightInverted ////////////////////////////////////////////////////////////////////////
         ///
         /// The upright-inverted type describes the appearance of a fermata element. The value is

--- a/Sourcecode/private/mx/core/elements/ArpeggiateAttributes.cpp
+++ b/Sourcecode/private/mx/core/elements/ArpeggiateAttributes.cpp
@@ -67,7 +67,7 @@ namespace mx
             for( ; it != endIter; ++it )
             {
                 if( parseAttribute( message, it, className, isSuccess, number, hasNumber, "number" ) ) { continue; }
-                if( parseAttribute( message, it, className, isSuccess, direction, hasDirection, "direction", &parseUpDown ) ) { continue; }
+                if( parseAttribute( message, it, className, isSuccess, direction, hasDirection, "direction", &parseUpDownNone ) ) { continue; }
                 if( parseAttribute( message, it, className, isSuccess, defaultX, hasDefaultX, "default-x" ) ) { continue; }
                 if( parseAttribute( message, it, className, isSuccess, defaultY, hasDefaultY, "default-y" ) ) { continue; }
                 if( parseAttribute( message, it, className, isSuccess, relativeX, hasRelativeX, "relative-x" ) ) { continue; }

--- a/Sourcecode/private/mx/core/elements/ArpeggiateAttributes.h
+++ b/Sourcecode/private/mx/core/elements/ArpeggiateAttributes.h
@@ -28,7 +28,7 @@ namespace mx
             virtual bool hasValues() const;
             virtual std::ostream& toStream( std::ostream& os ) const;
             NumberLevel number;
-            UpDown direction;
+            UpDownNone direction;
             TenthsValue defaultX;
             TenthsValue defaultY;
             TenthsValue relativeX;

--- a/Sourcecode/private/mx/impl/ArpeggiateFunctions.cpp
+++ b/Sourcecode/private/mx/impl/ArpeggiateFunctions.cpp
@@ -26,13 +26,17 @@ namespace mx
                 
                 switch (attr->direction)
                 {
-                    case core::UpDown::up:
+                    case core::UpDownNone::up:
                         markType = api::MarkType::arpeggiateUp;
                         break;
                         
-                    case core::UpDown::down:
+                    case core::UpDownNone::down:
                         markType = api::MarkType::arpeggiateDown;
                         break;
+
+                case core::UpDownNone::none:
+                    markType = api::MarkType::arpeggiate;
+                    break;
                 }
             }
             api::MarkData markData{ markType };

--- a/Sourcecode/private/mx/impl/DirectionWriter.cpp
+++ b/Sourcecode/private/mx/impl/DirectionWriter.cpp
@@ -332,6 +332,33 @@ namespace mx
                     addDirectionType( outDirType, directionPtr );
                 }
             }
+            
+            if( myDirectionData.segnos.size() > 0 ) {
+
+                for( const auto& rehearsal : myDirectionData.segnos ) {
+                    auto outDirType = core::makeDirectionType();
+                    outDirType->setChoice( core::DirectionType::Choice::segno );
+                    this->addDirectionType( outDirType, directionPtr );
+                }
+            }
+
+            if( myDirectionData.codas.size() > 0 ) {
+
+                for( const auto& rehearsal : myDirectionData.codas ) {
+                    auto outDirType = core::makeDirectionType();
+                    outDirType->setChoice( core::DirectionType::Choice::coda );
+                    this->addDirectionType( outDirType, directionPtr );
+                }
+            }
+
+            if( myDirectionData.rehearsals.size() > 0 ) {
+                
+                for( const auto& rehearsal : myDirectionData.rehearsals ) {
+                    auto outDirType = core::makeDirectionType();
+                    outDirType->setChoice( core::DirectionType::Choice::rehearsal );
+                    this->addDirectionType( outDirType, directionPtr );
+                }
+            }
 
             if( myIsFirstDirectionTypeAdded )
             {

--- a/Sourcecode/private/mx/impl/DirectionWriter.cpp
+++ b/Sourcecode/private/mx/impl/DirectionWriter.cpp
@@ -332,33 +332,6 @@ namespace mx
                     addDirectionType( outDirType, directionPtr );
                 }
             }
-            
-            if( myDirectionData.segnos.size() > 0 ) {
-
-                for( const auto& rehearsal : myDirectionData.segnos ) {
-                    auto outDirType = core::makeDirectionType();
-                    outDirType->setChoice( core::DirectionType::Choice::segno );
-                    this->addDirectionType( outDirType, directionPtr );
-                }
-            }
-
-            if( myDirectionData.codas.size() > 0 ) {
-
-                for( const auto& rehearsal : myDirectionData.codas ) {
-                    auto outDirType = core::makeDirectionType();
-                    outDirType->setChoice( core::DirectionType::Choice::coda );
-                    this->addDirectionType( outDirType, directionPtr );
-                }
-            }
-
-            if( myDirectionData.rehearsals.size() > 0 ) {
-                
-                for( const auto& rehearsal : myDirectionData.rehearsals ) {
-                    auto outDirType = core::makeDirectionType();
-                    outDirType->setChoice( core::DirectionType::Choice::rehearsal );
-                    this->addDirectionType( outDirType, directionPtr );
-                }
-            }
 
             if( myIsFirstDirectionTypeAdded )
             {

--- a/Sourcecode/private/mx/impl/NotationsWriter.cpp
+++ b/Sourcecode/private/mx/impl/NotationsWriter.cpp
@@ -4,6 +4,7 @@
 
 #include "mx/impl/NotationsWriter.h"
 #include "mx/core/elements/Accent.h"
+#include "mx/core/elements/Arpeggiate.h"
 #include "mx/core/elements/Arrow.h"
 #include "mx/core/elements/Articulations.h"
 #include "mx/core/elements/ArticulationsChoice.h"
@@ -30,6 +31,7 @@
 #include "mx/core/elements/InvertedMordent.h"
 #include "mx/core/elements/InvertedTurn.h"
 #include "mx/core/elements/Mordent.h"
+#include "mx/core/elements/NonArpeggiate.h"
 #include "mx/core/elements/Notations.h"
 #include "mx/core/elements/NotationsChoice.h"
 #include "mx/core/elements/OpenString.h"
@@ -351,10 +353,43 @@ namespace mx
                         attr.hasType = true;
                         attr.type = core::UprightInverted::inverted;
                     }
+                }
+                else if( isMarkNonArpeggiate( mark.markType) )
+                {
+                    auto nonArpeggiateNotationsChoice = core::makeNotationsChoice();
+                    myOutNotations->addNotationsChoice( nonArpeggiateNotationsChoice );
+                    nonArpeggiateNotationsChoice->setChoice( core::NotationsChoice::Choice::nonArpeggiate );
+                    auto& nonArpeggiate = *nonArpeggiateNotationsChoice->getNonArpeggiate();
+                    auto& attr = *nonArpeggiate.getAttributes();
+                    impl::setAttributesFromMarkData( mark, attr );
+                }
+                else if( isMarkArpeggiate( mark.markType ) )
+                {
+                    auto arpeggiateNotationsChoice = core::makeNotationsChoice();
+                    myOutNotations->addNotationsChoice( arpeggiateNotationsChoice );
+                    arpeggiateNotationsChoice->setChoice( core::NotationsChoice::Choice::arpeggiate );
+                    auto& arpeggiate = *arpeggiateNotationsChoice->getArpeggiate();
+                    auto& attr = *arpeggiate.getAttributes();
+                    impl::setAttributesFromMarkData( mark, attr );
                     
+                    if( mark.markType == api::MarkType::arpeggiate )
+                    {
+                        attr.direction = core::UpDownNone::none;
+                        attr.hasDirection = false;
+                    }
+                    else if( mark.markType == api::MarkType::arpeggiateUp )
+                    {
+                        attr.direction = core::UpDownNone::up;
+                        attr.hasDirection = true;
+                    }
+                    else if( mark.markType == api::MarkType::arpeggiateDown )
+                    {
+                        attr.direction = core::UpDownNone::down;
+                        attr.hasDirection = true;
+                    }
                 }
             }
-            
+
             if( articulations->getArticulationsChoiceSet().size() > 0 )
             {
                 myOutNotations->addNotationsChoice( articulationsNotationChoice );


### PR DESCRIPTION
The Core::UpDown can't be used as the apreggiate reader will set the direction type to Up, which is not correct. The default arpeggiate does not have an arrow indicating up, so we need to introduce a "none" type.