### PR TITLE
Stop writing example.musicxml to the repo root (fixes #150)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -123,9 +123,12 @@ endef
 
 # Run the three example programs from the given mode dir ($1). The test
 # targets run these too, so the examples are exercised everywhere tests run.
+# mxwrite is told to write into data/testOutput so we don't leave an untracked
+# example.musicxml at the repo root (issue #150).
 define run_examples
+	@mkdir -p data/testOutput
 	$(call run_bin,$(1),mxread,)
-	$(call run_bin,$(1),mxwrite,)
+	$(call run_bin,$(1),mxwrite,./data/testOutput/example.musicxml)
 	$(call run_bin,$(1),mxhide,)
 endef
 

--- a/README.md
+++ b/README.md
@@ -301,8 +301,10 @@ int main(int argc, const char * argv[])
     std::cout << std::endl;
     #endif
 
-    // write to a file
-    mgr.writeToFile( documentID, "./example.musicxml" );
+    // write to a file. argv[1] overrides the default output path so the build
+    // system can send the file to a gitignored location (see issue #150).
+    const std::string outputPath = ( argc > 1 ) ? argv[1] : "./example.musicxml";
+    mgr.writeToFile( documentID, outputPath );
 
     // we need to explicitly delete the object held by the manager
     mgr.destroyDocument( documentID );

--- a/data/testOutput/.gitignore
+++ b/data/testOutput/.gitignore
@@ -1,3 +1,4 @@
 *.csv
+*.musicxml
 *.txt
 *.xml

--- a/src/private/mx/examples/Write.cpp
+++ b/src/private/mx/examples/Write.cpp
@@ -120,8 +120,11 @@ int main(int argc, const char *argv[])
     std::cout << std::endl;
 #endif
 
-    // write to a file
-    mgr.writeToFile(documentID, "./example.musicxml");
+    // write to a file. argv[1] overrides the default output path so the build
+    // system can send the file to a gitignored location during automated runs;
+    // see issue #150.
+    const std::string outputPath = (argc > 1) ? argv[1] : "./example.musicxml";
+    mgr.writeToFile(documentID, outputPath);
 
     // we need to explicitly delete the object held by the manager
     mgr.destroyDocument(documentID);

--- a/src/private/mxtest/api/DocumentManagerTest.cpp
+++ b/src/private/mxtest/api/DocumentManagerTest.cpp
@@ -187,7 +187,9 @@ TEST( sillyTest, DocumentManager )
     score.encoding.encodingDate.day = 30;
     score.copyright = "© 2016 by Matthew James Briggs";
     auto documentId = DocumentManager::getInstance().createFromScore( score );
-    DocumentManager::getInstance().writeToFile( documentId, "./sillytest.xml" );
+    const std::string sillyOutputPath = mxtest::getResourcesDirectoryPath() + "testOutput" +
+                                        mxtest::FILE_PATH_SEPARATOR + "sillytest.xml";
+    DocumentManager::getInstance().writeToFile( documentId, sillyOutputPath );
     DocumentManager::getInstance().destroyDocument( documentId );
 }
 T_END

--- a/src/private/mxtest/api/RoundTrip.h
+++ b/src/private/mxtest/api/RoundTrip.h
@@ -7,6 +7,7 @@
 #include "mx/api/DocumentManager.h"
 #include "mxtest/control/CompileControl.h"
 #include "mxtest/file/MxFileRepository.h"
+#include "mxtest/file/Path.h"
 #include <sstream>
 
 namespace mxtest
@@ -21,7 +22,8 @@ inline void roundTrip()
     auto scoreData = docMgr.getData(docId);
     docMgr.destroyDocument(docId);
     docId = docMgr.createFromScore(scoreData);
-    docMgr.writeToFile(docId, "./output.xml");
+    const std::string outputPath = getResourcesDirectoryPath() + "testOutput" + FILE_PATH_SEPARATOR + "output.xml";
+    docMgr.writeToFile(docId, outputPath);
     docMgr.destroyDocument(docId);
 }
 


### PR DESCRIPTION
Fixes #150.

The `mxwrite` example program previously hard-coded its output to
`./example.musicxml`, which left an untracked file at the repo root
every time examples ran (i.e. for every `make test` / `make test-all`
invocation).

## Changes

- **`src/private/mx/examples/Write.cpp`** \u2014 `mxwrite` now accepts an
  optional output path via `argv[1]`, defaulting to
  `./example.musicxml` so the README's illustrative path still works
  when a user runs the binary by hand.
- **`Makefile`** \u2014 `run_examples` now passes
  `./data/testOutput/example.musicxml` to `mxwrite` and ensures the
  directory exists. `data/testOutput/` is already gitignored.
- **`data/testOutput/.gitignore`** \u2014 added `*.musicxml` (it only
  covered `*.xml`, `*.csv`, `*.txt` before).
- **`src/private/mxtest/api/DocumentManagerTest.cpp`** and
  **`src/private/mxtest/api/RoundTrip.h`** \u2014 two other `writeToFile`
  calls that also dumped XML at the repo root (`sillytest.xml` and
  `output.xml`) now write into `data/testOutput` via
  `mxtest::getResourcesDirectoryPath()`.
- **`README.md`** \u2014 the example code snippet matches the updated
  `Write.cpp`.

## Verification

Ran locally:

- `make fmt` \u2014 clean
- `make check` \u2014 `=== check passed ===`
- `make test-all` \u2014 `All tests passed (9914 assertions in 2678 test cases)`

After the full run, no `example.musicxml`, `example.xml`,
`sillytest.xml`, or `output.xml` remain at the repo root.

This supersedes #151.