### PR TITLE
gen: fix failing core roundtrip tests

### DIFF
--- a/data/README.md
+++ b/data/README.md
@@ -1,0 +1,22 @@
+# data/
+
+MusicXML test inputs and expected-output fixtures.
+
+## `.invalid` marker convention
+
+A file `foo.xml` (or `foo.musicxml`) that is **not** valid MusicXML must be
+accompanied by a sibling marker file `foo.xml.invalid` whose contents
+describe, in prose, why the file is invalid.
+
+The marker tells schema-strict consumers (notably the **core roundtrip**
+suite at `src/private/mxtest/corert/`) to skip the file. `mx::core` is a
+strongly-typed DOM generated from the MusicXML XSD and cannot round-trip
+elements or attributes that are not in the schema; running such a file
+through `fromXDoc` → `toXDoc` is guaranteed to lose content.
+
+The marker is descriptive only — its body is for humans. Presence of the
+file is the signal.
+
+Other suites (e.g. **api import** under `src/private/mxtest/import/`) may
+still include invalid files when they exercise reader leniency on
+malformed input. Those suites ignore the marker.

--- a/data/foundsuite/Deutscher Tanz D.820.1.xml.invalid
+++ b/data/foundsuite/Deutscher Tanz D.820.1.xml.invalid
@@ -1,0 +1,14 @@
+Not valid against the MusicXML XSD.
+
+Confirmed by xmllint --schema docs/musicxml.xsd. Violations:
+
+- midi-program with value 0 (schema midi-128: must be 1..128) at line 49.
+- sound/@dynamics='-1.11' (minInclusive 0) at lines 167 and 469.
+
+The core roundtrip suite trips on the midi-program=0 case: mx::core clamps
+to the schema-legal range (writes 1), causing a text mismatch against the
+original 0. Excluding this file from the schema-strict core roundtrip is
+the right call — the library is conforming to the schema and the input is
+the deviation.
+
+See data/README.md for the .invalid marker convention.

--- a/data/foundsuite/O_Holy_Night-Adam-1871.xml.invalid
+++ b/data/foundsuite/O_Holy_Night-Adam-1871.xml.invalid
@@ -1,0 +1,15 @@
+Not valid against the MusicXML XSD.
+
+Confirmed by xmllint --schema docs/musicxml.xsd. Violations include:
+
+- midi-channel with value 0 (schema midi-16: must be 1..16) at line 23.
+- Many duration elements with value 0 (minExclusive 0), starting at line 9706
+  and continuing for dozens of occurrences.
+
+The core roundtrip suite trips on midi-channel=0: mx::core clamps to the
+schema-legal range (writes 1), causing a text mismatch against the
+original 0. Excluding this file from the schema-strict core roundtrip is
+the right call — the library is conforming to the schema and the input is
+the deviation.
+
+See data/README.md for the .invalid marker convention.

--- a/data/foundsuite/O_Holy_Night.xml.invalid
+++ b/data/foundsuite/O_Holy_Night.xml.invalid
@@ -1,0 +1,20 @@
+Not valid against the MusicXML XSD.
+
+Confirmed by xmllint --schema docs/musicxml.xsd. Violations include:
+
+- midi-channel with value 0 (schema midi-16: must be 1..16) at lines 22, 32,
+  42, 52.
+- midi-program with value 0 (schema midi-128: must be 1..128) at lines 23,
+  33, 43, 53.
+- display-step with value '=' (enum is A..G) at lines 408, 711, 1337, 1791,
+  2025.
+- display-octave with value -104 (minInclusive 0) at adjacent lines.
+- Many duration elements with value 0 (minExclusive 0) starting at line 2584.
+
+The core roundtrip suite trips on midi-channel=0: mx::core clamps to the
+schema-legal range (writes 1), causing a text mismatch against the
+original 0. Excluding this file from the schema-strict core roundtrip is
+the right call — the library is conforming to the schema and the input is
+the deviation.
+
+See data/README.md for the .invalid marker convention.

--- a/data/foundsuite/Rimsky-Korsakov Op11 No4.xml.invalid
+++ b/data/foundsuite/Rimsky-Korsakov Op11 No4.xml.invalid
@@ -1,0 +1,14 @@
+Not valid against the MusicXML XSD.
+
+Confirmed by xmllint --schema docs/musicxml.xsd. Violations:
+
+- sound/@dynamics with value '-1.11' (minInclusive 0) at lines 6224, 8231,
+  11057, 12922, 13151, 13389, 14002.
+
+The core roundtrip suite trips on this attribute: mx::core clamps the
+negative value to the schema-legal range, causing an attribute mismatch
+against the original. Excluding this file from the schema-strict core
+roundtrip is the right call — the library is conforming to the schema and
+the input is the deviation.
+
+See data/README.md for the .invalid marker convention.

--- a/data/lysuite/ly01e_Pitches_ParenthesizedAccidentals.xml.invalid
+++ b/data/lysuite/ly01e_Pitches_ParenthesizedAccidentals.xml.invalid
@@ -1,0 +1,14 @@
+Not valid against the MusicXML XSD.
+
+Confirmed by xmllint --schema docs/musicxml.xsd. Violations:
+
+- accidental element text 'double-flat' is not in the schema enumeration at
+  lines 138, 149, 160, 171. The schema-correct spelling is 'flat-flat'.
+
+The core roundtrip suite trips on this: mx::core sees an unknown enum value
+and falls back to a default ('sharp'), producing a text mismatch against the
+original 'double-flat'. Excluding this file from the schema-strict core
+roundtrip is the right call — the input is using a name that is not in the
+schema enumeration.
+
+See data/README.md for the .invalid marker convention.

--- a/data/lysuite/ly32a_Notations.xml.invalid
+++ b/data/lysuite/ly32a_Notations.xml.invalid
@@ -1,0 +1,13 @@
+Not valid against the MusicXML XSD.
+
+Confirmed by xmllint --schema docs/musicxml.xsd. Violations:
+
+- <fret/> empty at line 900; schema requires xs:nonNegativeInteger.
+- <string/> empty at line 924; schema requires string-number.
+
+The core roundtrip suite trips on the empty <fret/>: mx::core defaults the
+missing integer to 0, producing a text mismatch ('' vs '0') against the
+original empty element. Excluding this file from the schema-strict core
+roundtrip is the right call — the input is omitting required content.
+
+See data/README.md for the .invalid marker convention.

--- a/data/lysuite/ly41g_PartNoId.xml.invalid
+++ b/data/lysuite/ly41g_PartNoId.xml.invalid
@@ -1,0 +1,12 @@
+Not valid against the MusicXML XSD.
+
+Confirmed by xmllint --schema docs/musicxml.xsd. Violation:
+
+- <part> at line 16 is missing the required 'id' attribute.
+
+The filename literally says PartNoId. mx::core's fromXDoc rejects the
+document with "PartAttributes: 'id' is a required attribute but was not
+found" — i.e. the parser is correctly enforcing the schema. Excluding this
+file from the schema-strict core roundtrip is the right call.
+
+See data/README.md for the .invalid marker convention.

--- a/data/lysuite/ly74a_FiguredBass.xml.invalid
+++ b/data/lysuite/ly74a_FiguredBass.xml.invalid
@@ -1,0 +1,13 @@
+Not valid against the MusicXML XSD.
+
+Confirmed by xmllint --schema docs/musicxml.xsd. Violation:
+
+- <figured-bass> at line 90 is missing the required child element <figure>
+  (figured-bass requires at least one figure child per schema).
+
+The core roundtrip suite trips on this: the empty figured-bass round-trips
+to a different child count than the (canonicalized) input. Excluding this
+file from the schema-strict core roundtrip is the right call — the input
+is omitting a required child.
+
+See data/README.md for the .invalid marker convention.

--- a/data/lysuite/ly75a_AccordionRegistrations.xml.invalid
+++ b/data/lysuite/ly75a_AccordionRegistrations.xml.invalid
@@ -1,0 +1,15 @@
+Not valid against the MusicXML XSD.
+
+Confirmed by xmllint --schema docs/musicxml.xsd. Violations:
+
+- <accordion-middle/> empty at line 291 (must be 1..3).
+- <accordion-middle>test</accordion-middle> at line 307 (must be 1..3).
+- <accordion-middle>0</accordion-middle> at line 323 (minInclusive 1).
+- <accordion-middle>5</accordion-middle> at line 339 (maxInclusive 3).
+
+The core roundtrip suite trips on the empty accordion-middle: mx::core
+defaults the missing integer to 0, producing a text mismatch ('' vs '0').
+Excluding this file from the schema-strict core roundtrip is the right
+call — the input is using values outside the schema-allowed range.
+
+See data/README.md for the .invalid marker convention.

--- a/data/musuite/testInvalid.xml.invalid
+++ b/data/musuite/testInvalid.xml.invalid
@@ -1,0 +1,15 @@
+testInvalid.xml is intentionally not a valid MusicXML file.
+
+Per its embedded <miscellaneous-field name="description">: "This file is almost
+identical to testHello.xml, but contains two additional invalid elements to
+test MusicXML validation." Specifically:
+
+- <invalid_element/> appears inside <identification>
+- <another_invalid_element/> appears inside <attributes>
+
+Neither element exists in the MusicXML XSD. mx::core is a strongly-typed DOM
+generated from the schema and has no slot for unknown elements, so fromXDoc
+discards them. The file therefore cannot round-trip losslessly through
+mx::core and is excluded from the core roundtrip suite via this marker.
+
+See data/README.md for the .invalid marker convention.

--- a/data/musuite/test_harmony.xml.invalid
+++ b/data/musuite/test_harmony.xml.invalid
@@ -1,0 +1,18 @@
+Not valid against the MusicXML XSD.
+
+Confirmed by xmllint --schema docs/musicxml.xsd. Violations include:
+
+- <kind> values not in the schema enumeration: '' (empty, line 73), ' '
+  (whitespace, line 82), 'minor-major' (195), 'dominant-seventh' (204, 488,
+  502, 522, 546), 'neapolitan' (316), 'italian' (326), 'french' (335),
+  'german' (344), 'maj69' (355), 'augmented-ninth' (364), 'altered' (374).
+- <degree-type> child appearing where <degree-alter> is expected, at lines
+  388, 401, 597, 610, 614 — element order violates the schema sequence.
+
+The core roundtrip suite trips on the empty <kind/>: mx::core defaults the
+missing enum to 'major', producing a text mismatch ('' vs 'major').
+Excluding this file from the schema-strict core roundtrip is the right
+call — the input is full of values and orderings that are not in the
+schema.
+
+See data/README.md for the .invalid marker convention.

--- a/docs/ai/projects/gen/index.md
+++ b/docs/ai/projects/gen/index.md
@@ -9,22 +9,21 @@ m3_completed: 2026-05-22
 
 ## Goal
 
-Reverse engineer the codegen process that produced `mx/core` from MusicXML XSD. Build a generator
-that re-produces the existing C++ code from `docs/musicxml.xsd`, then point it at MusicXML 4.0 to
-generate updated types.
+Reverse engineer the codegen process that produced `mx/core` from MusicXML XSD. Build a
+generator that re-produces the existing C++ code from `docs/musicxml.xsd`, then point it
+at MusicXML 4.0 to generate updated types.
 
 ## Files
 
-- `plan.md` - milestones and exit criteria
-- `state.md` - current session state and next-session instructions
-- `log.md` - append-only session log
+Standard project layout (see the `/project` skill). No bespoke files or subdirectories.
 
 ## Repo conventions introduced by this project
 
-- `{file}.invalid` marker: a sibling file next to any MusicXML input that is
-  intentionally not valid against the XSD. Body is a human-readable
-  explanation. The core roundtrip suite skips such inputs; api import does
-  not. Convention documented in `data/README.md`.
+- `{file}.invalid` marker (sibling file, human-readable body) marks a MusicXML input that
+  is intentionally not XSD-valid. Honored by the corert suite, ignored by api import.
+  Documented in `data/README.md`. Introduced in M3.
+- The `src/private/mxtest/corert/` core-roundtrip harness (built out during M2/M3) is
+  part of `make test-all` and is the daily driver via `make test-core-dev`.
 
 ## Generator location and how to run
 
@@ -35,40 +34,43 @@ python3 gen/generate.py          # regenerates C++ into src/private/mx/core/elem
 python3 gen/eval.py              # scores diff against checked-in mx/core (secondary signal)
 ```
 
-Workflow: `python3 gen/generate.py && make fmt && make test-all`, then reset:
+Workflow: `python3 gen/generate.py && make fmt && make test-all`. To reset:
 `git checkout -- src/private/mx/core/ && git clean -fd src/private/mx/core/`.
 
 Quality gates: `make fmt && make check && make test-all`.
 
 ## Fitness function
 
-`make test-all` pass/fail. **Always use `make test-all`, never `make test`** — the latter builds
-`dev` and skips the slow `mxtest/file/` round-trippers, under-reporting failures. `make test-all`
-takes >10 minutes. Every iteration ends with a recorded `make test-all` result.
+`make test-all` pass/fail. **Use `make test-all`, never `make test`** — the latter builds
+`dev` and skips the slow `mxtest/file/` round-trippers, under-reporting failures. Every
+iteration that touches `src/private/mx/core/*` ends with a recorded `make test-all` result.
 
 ## Cardinal rules
 
-- Never change tests.
+- Never change tests (test cases). Test harness code is fair game with user authorization.
 - Never change `mx/api`.
 - Minimize changes to `mx/impl`; prefer fixing the generator.
-- Do not autonomously edit `gen/eval_config.yaml`. Flag patterns to the user with sample diff + reasoning.
-- Reset generated `mx/core/` before commit.
+- Do not autonomously edit `gen/eval_config.yaml`. Flag patterns to the user with sample
+  diff + reasoning.
+- Reset generated `mx/core/` before commit if a generator change was tried and reverted.
 
-## Bespoke generator functions
+## Bespoke generator handlers
 
-Six bespoke handlers exist (credit, lyric, part-list, harmony, score-wrapper-family, note,
-direction), registered in `BESPOKE_ELEMENTS` in `gen/generate.py`. They are acceptable when an
-element's shape cannot be expressed by the shared rule-based path, but they must still read the
-parsed XSD model so spec changes propagate. Pattern: "custom algorithm, schema-driven data" — not
-a hardcoded string dump.
+Six bespoke handlers registered in `BESPOKE_ELEMENTS` in `gen/generate.py`: credit, lyric,
+part-list, harmony, score-wrapper-family, note, direction. They are acceptable when an
+element's shape cannot be expressed by the shared rule-based path, but they must still
+read the parsed XSD model so spec changes propagate. Pattern: "custom algorithm,
+schema-driven data" — not a hardcoded string dump.
 
-Always prefer extending a reusable rule-based path (`TREE_ELEMENTS`, `TREE_ELEMENT_CONFIG` flags,
-shared helpers) over a new bespoke handler. If a pattern could plausibly recur for another
-element, the fix belongs in the shared path with a config-driven flag.
+Always prefer extending a reusable rule-based path (`TREE_ELEMENTS`,
+`TREE_ELEMENT_CONFIG` flags, shared helpers) over a new bespoke handler. If a pattern
+could plausibly recur for another element, the fix belongs in the shared path with a
+config-driven flag.
 
 ## Key external files
 
-- `gen/generate.py` — the generator (~2800 lines of Python)
+- `gen/generate.py` — the generator (~14k lines of Python)
 - `gen/eval.py`, `gen/eval_config.yaml` — diff scoring
-- `docs/musicxml.xsd` — input schema (currently MusicXML 3.x; swapped to 4.0 in M5)
-- `src/private/mx/core/elements/` — target output (591 .h/.cpp pairs)
+- `docs/musicxml.xsd` — input schema (currently MusicXML 3.x; swap to 4.0 in M6)
+- `src/private/mx/core/elements/` — target output (~590 .h/.cpp pairs)
+- `src/private/mxtest/corert/` — core-roundtrip harness

--- a/docs/ai/projects/gen/index.md
+++ b/docs/ai/projects/gen/index.md
@@ -18,6 +18,13 @@ generate updated types.
 - `state.md` - current session state and next-session instructions
 - `log.md` - append-only session log
 
+## Repo conventions introduced by this project
+
+- `{file}.invalid` marker: a sibling file next to any MusicXML input that is
+  intentionally not valid against the XSD. Body is a human-readable
+  explanation. The core roundtrip suite skips such inputs; api import does
+  not. Convention documented in `data/README.md`.
+
 ## Generator location and how to run
 
 The generator lives at `gen/` (not under this project directory):

--- a/docs/ai/projects/gen/index.md
+++ b/docs/ai/projects/gen/index.md
@@ -15,7 +15,7 @@ at MusicXML 4.0 to generate updated types.
 
 ## Files
 
-Standard project layout (see the `/project` skill). No bespoke files or subdirectories.
+Standard project layout (see the `/project` skill).
 
 ## Repo conventions introduced by this project
 
@@ -37,17 +37,16 @@ python3 gen/eval.py              # scores diff against checked-in mx/core (secon
 Workflow: `python3 gen/generate.py && make fmt && make test-all`. To reset:
 `git checkout -- src/private/mx/core/ && git clean -fd src/private/mx/core/`.
 
-Quality gates: `make fmt && make check && make test-all`.
+## Fitness function and gates
 
-## Fitness function
-
-`make test-all` pass/fail. **Use `make test-all`, never `make test`** — the latter builds
-`dev` and skips the slow `mxtest/file/` round-trippers, under-reporting failures. Every
-iteration that touches `src/private/mx/core/*` ends with a recorded `make test-all` result.
+`make test-all` pass/fail is authoritative. **Use `make test-all`, never `make test`** —
+the latter builds `dev` and skips the slow `mxtest/file/` round-trippers. Full gate:
+`make fmt && make check && make test-all`. Every iteration that touches
+`src/private/mx/core/*` ends with a recorded `make test-all` result.
 
 ## Cardinal rules
 
-- Never change tests (test cases). Test harness code is fair game with user authorization.
+- Never change test cases. Test harness code is fair game with user authorization.
 - Never change `mx/api`.
 - Minimize changes to `mx/impl`; prefer fixing the generator.
 - Do not autonomously edit `gen/eval_config.yaml`. Flag patterns to the user with sample
@@ -56,11 +55,11 @@ iteration that touches `src/private/mx/core/*` ends with a recorded `make test-a
 
 ## Bespoke generator handlers
 
-Six bespoke handlers registered in `BESPOKE_ELEMENTS` in `gen/generate.py`: credit, lyric,
-part-list, harmony, score-wrapper-family, note, direction. They are acceptable when an
-element's shape cannot be expressed by the shared rule-based path, but they must still
-read the parsed XSD model so spec changes propagate. Pattern: "custom algorithm,
-schema-driven data" — not a hardcoded string dump.
+Six bespoke handlers in `BESPOKE_ELEMENTS` (`gen/generate.py`): credit, lyric, part-list,
+harmony, score-wrapper-family, note, direction. Acceptable when an element's shape cannot
+be expressed by the shared rule-based path, but they must still read the parsed XSD model
+so spec changes propagate. Pattern: "custom algorithm, schema-driven data" — not a
+hardcoded string dump.
 
 Always prefer extending a reusable rule-based path (`TREE_ELEMENTS`,
 `TREE_ELEMENT_CONFIG` flags, shared helpers) over a new bespoke handler. If a pattern

--- a/docs/ai/projects/gen/index.md
+++ b/docs/ai/projects/gen/index.md
@@ -2,6 +2,7 @@
 created: 2026-05-18
 m1_completed: 2026-05-21
 m2_completed: 2026-05-22
+m3_completed: 2026-05-22
 ---
 
 # gen

--- a/docs/ai/projects/gen/log.md
+++ b/docs/ai/projects/gen/log.md
@@ -2,287 +2,83 @@
 
 Append chronologically, oldest on top.
 
-## M1: revgen (2026-05-18 — 2026-05-21, 40 iterations)
+## M1: revgen (2026-05-18 — 2026-05-21, 40 iterations) ✅
 
-Reverse-engineered the codegen. Iteratively shrank `SKIP_ELEMENTS` and `CHOICE_SKIP` to empty.
-Closed 2026-05-21 with the generator producing every C++ class in `mx/core`. Tests failing — the
-commit `d4f25ee6` "src: issues caused by revgen" hand-edits non-generated consumers to keep
-the build working; those hand-edits were the input to M2.
+Reverse-engineered the codegen, iteratively shrinking `SKIP_ELEMENTS` and `CHOICE_SKIP` to
+empty. Closed with the generator producing every C++ class in `mx/core`. Tests were failing;
+commit `d4f25ee6` "src: issues caused by revgen" carries hand-edits to non-generated consumers
+that kept the build working. Those hand-edits were the input to M2.
 
-## M2: fix-gen (2026-05-21 — 2026-05-22)
+## M2: fix-gen (2026-05-21 — 2026-05-22) ✅
 
-Triaged `d4f25ee6` into 6 root-cause issues (A–F), then triaged 62 (later 129 after a clean
-build) `make test-all` failures into clusters. Fixed iteratively, ending at 0 failures.
+Triaged `d4f25ee6` into 6 root causes (A–F) and ~129 `make test-all` failures into clusters
+(R1–R7, D1–D4, plus an isFirst-separator family). Fixed iteratively to 0 failures.
 
-### Triage of `d4f25ee6` hand-edits
+Notable fixes captured as generator config / structural rules:
+- `EXTENSION_OPTIONAL_GROUP_RENAME`, `SUPPRESS_GROUP_SUFFIX`, `WRAPPER_AS_ELEMENT_SYNTH_GROUPS`
+  (MetronomeTuplet group flattening, issue C).
+- `TREE_ELEMENT_CONFIG["key"] = {"parent_imports_choice_groups": True}` emits
+  `Key::import{Traditional,NonTraditional}Key` (issues E/F).
+- Required-set seeding rule in `generate_element_cpp` (`min_occurs>=1, max_occurs!=1, !is_group`)
+  fixed HarpPedals SIGSEGV (R5).
+- `is_container` + `trigger_names` on `TreeChoiceBranch`; `importContainer<X>` dispatch in
+  `generate_tree_parent_cpp` (D1, D4 — Metronome reader).
+- `ATTR_DEFAULT_OVERRIDE` (~17 entries: `lang="it"`, `lineEnd=down`, `number="1"`,
+  `halign`/`justify=center`, …), `CHILD_INIT_VALUE_OVERRIDE` (Scaling, StaffDetails).
+- `_emit_direction_family` bespoke driven by `model.complex_types["direction-type"].content_tree`.
+- `ELEMENT_HAS_CONTENTS_ALWAYS_TRUE` (MeasureLayout, NoteheadText), notehead-text
+  `seed_choice_set`, MeasureLayout explicit child-presence check for `isOneLineOnly`.
 
-- **A — UpDownNone collapsed to UpDown** (WEIRD / Low): Hand-applied MusicXML 4.0 backport
-  in original `mx/core` overwritten by schema-faithful 3.x regen. Deferred to M5; TODO
-  comments left in `mx/impl`.
-- **B — `hasLong` escaped to `hasLong_`** (BUG / Low): Keyword-escape over-applied to the
-  has-prefix flag. Fix: `has_flag_name` strips trailing underscore added by `camel()` for
-  keywords.
-- **C — MetronomeTuplet group flattened** (BUG / High): Regen flattened
-  `TimeModificationNormalTypeNormalDot` into `MetronomeTuplet`, making `<normal-type>`
-  unconditional. Fix: added `EXTENSION_OPTIONAL_GROUP_RENAME` (per-extending-type override) +
-  `SUPPRESS_GROUP_SUFFIX` + `WRAPPER_AS_ELEMENT_SYNTH_GROUPS` so the wrapper survives as a
-  sub-element rather than being inlined.
-- **D — `setPerMinuteOtBeatUnitChoice` typo** (BENIGN): Historical typo in original; accepted
-  small test edit, no generator change.
-- **E/F — Missing `importGroup` overloads for traditional-/non-traditional-key** (BUG /
-  Medium): Fix path option 1: emit `Key::importTraditionalKey` / `Key::importNonTraditionalKey`
-  as private member functions via new `TREE_ELEMENT_CONFIG["key"] = {"parent_imports_choice_groups": True}`.
-  Reverted hand-edits in `FromXElement.{h,cpp}`.
+Deferred WEIRD item: issue A — original `mx/core` had a hand-applied MusicXML 4.0 `UpDownNone`
+backport overwritten by schema-faithful 3.x regen. TODO comments left in
+`mx/impl/NotationsWriter.cpp:398` and `mx/impl/ArpeggiateFunctions.cpp:35`. Belongs to M5/M6.
 
-### Failing-test clusters
-
-Original triage scheme R1–R7 was rewritten mid-M2 as the situation evolved. Final shape:
-
-- **R1 — direction-family parents emit `MX_FROM_XELEMENT_UNUSED`** (19 tests): split into
-  R1a (ArrowGroup needs real `fromXElementImpl` body — added "arrow" to
-  `GROUPS_WITH_REAL_FROM_X_ELEMENT`) and R1b (Direction parent bespoke — added
-  `_emit_direction_family` handler driven by `model.complex_types["direction-type"].content_tree.branches`).
-- **R5 — required-set seeding** (10 tests including HarpPedals SIGSEGV): added structural
-  rule in `generate_element_cpp` for `min_occurs>=1, max_occurs!=1, not is_group` children:
-  ctor pre-seeds default, `hasContents()` returns true, `remove*` gates on `size>1`,
-  `clear*Set` re-seeds.
-- **R3 — group-class `streamContents` inter-child `endl`** (~10 tests): rewrote
-  `generate_group_cpp` separator logic — required-after-required: unconditional endl before;
-  required-after-optional: optional's block emits; index-0 optional: endl after.
-- **R2 — choice-class spurious leading `endl`** (~7 tests): gated on
-  `config.get("skip_parent")` in `generate_choice_class_cpp` so only `direction-type`-style
-  wrapper choices keep the leading endl.
-- **R4 — attribute default initializers** (bulk fix, ~22 tests): seeded 17 entries in
-  `ATTR_DEFAULT_OVERRIDE` (lang="it" defaults, lineEnd=down, number="1", etc.). Continued
-  in i5 with `CHILD_INIT_VALUE_OVERRIDE` for `Scaling`/`StaffDetails`.
-- **hasContents direction cluster** (6 tests): Rest/Unpitched gated optional groups on
-  `myHas`; MeasureLayout/NoteheadText/Slash/BeatRepeat needed
-  `ELEMENT_HAS_CONTENTS_ALWAYS_TRUE` / `CHILD_MIN_OCCURS_OVERRIDE` / notehead-text
-  `seed_choice_set`.
-- **group/tree-group isFirst separator** (i4/i6, ~30 tests): `generate_group_cpp` and
-  `generate_tree_group_cpp` were emitting unconditional `endl` before each set-based child
-  even when all preceding optional singletons were absent. Fixed with `isFirst` flag
-  pattern.
-- **MeasureLayout isOneLineOnly**: explicit child-presence check instead of `hasContents()`
-  for elements with `ELEMENT_HAS_CONTENTS_ALWAYS_TRUE`.
-
-### Final D-cluster (Metronome/Tempo round-trip)
-
-After mass cleanup, 13 failures remained, all metronome/tempo. Re-triaged as D1–D4:
-
-- **D3 — `MetronomeAttributes` missing `halign`/`justify` defaults** (`LeftCenterRight::center`):
-  trivial `ATTR_DEFAULT_OVERRIDE` entries.
-- **D1 — choice classes called `toStream` for empty-`streamName` containers** (BeatUnitPer,
-  NoteRelationNote produced literal `<>...</>`): added `is_container` field to
-  `TreeChoiceBranch`; emit `streamContents` instead of `toStream` for container branches in
-  `generate_tree_choice_cpp`.
-- **D2 — `DirectionWriter.cpp:370` throws on non-BPM tempos**: bisect confirmed pre-revgen
-  `a0500803` did pass these tests, so revgen introduced the regression in the reader/writer
-  path. Subsumed by D4.
-- **D4 — Metronome container-branch `fromXElementImpl` missing**: `generate_tree_parent_cpp`
-  emitted no dispatch for `is_container=True` branches. Synthetic containers have no XML
-  tag, so the reader silently skipped all metronome children. Fix: added `trigger_names`
-  field to `TreeChoiceBranch` (computed from first child element name); emit
-  `importContainer<X>` declarations and bodies in the parent; dispatch in
-  `fromXElementImpl` keyed on trigger names. Generated `Metronome::fromXElementImpl` matches
-  HEAD exactly. 9 → 0 failed. **M2 complete.**
-
-### Lessons / invariants captured
+### Lessons captured (operational invariants)
 
 - `git checkout -- src/private/mx/core/` preserves mtimes; incremental cmake then links
-  partly-old `.o`s, giving stale test counts. Use `make clean && make test-all` for any
-  authoritative measurement.
-- `make test-all` must run with generated files present (Issue A's `UpDownNone`
-  hand-backport in HEAD is incompatible with the schema-faithful regen, so a reset-first
-  build fails to compile).
+  partly-old `.o` files and reports stale test counts. Use `make clean && make test-all`
+  for authoritative measurements.
+- `make test-all` must run with generated files present — HEAD's hand-applied `UpDownNone`
+  backport is incompatible with a schema-faithful regen, so a reset-first build will not
+  compile.
 - When removing a previously-emitted byte from a shared template, survey the whole HEAD
-  population that template emits, not just one or two representative files (R2's
-  DirectionType regression).
-- Bespoke handlers should still read the parsed XSD model — pattern is "custom algorithm,
-  schema-driven data" (Direction's element-name tables derived from
-  `model.complex_types["direction-type"].content_tree.branches`).
+  population that template emits (R2 burned us by regressing DirectionType).
+- Bespoke handlers should still read the parsed XSD model — "custom algorithm,
+  schema-driven data". Direction's element-name tables derive from the parsed
+  `direction-type` content tree.
 
-## M3: fix-core-dev (2026-05-22 — )
+## M3: fix-core-dev (2026-05-22) ✅
 
-### 2026-05-22 16:40 — iteration 1
+Five iterations. Each picked the smallest core-roundtrip diff in `data/testOutput/corert`
+and triaged it. Two outcomes: a hand-rolled mx-side fix, or a `{file}.invalid` marker
+for files that don't conform to the XSD.
 
-Baselines on a clean build: `make test-core-dev` = 31 failed / 361 cases;
-`make test` = 0 failed. Smallest diffs in `data/testOutput/corert` (4 lines each):
-`foundsuite_Invention 2.xml`, `foundsuite_Invention_5.xml`, `musuite_testInvalid.xml`.
+- **i1**: tenths-typed `width` attribute trailing-zero strip. Added `"width"` to
+  `decimalFields` in `src/private/mxtest/import/DecimalFields.h`. Cleared 17 failures.
+  Commit `639d46a3`.
+- **i2**: `musuite/testInvalid.xml` is intentionally invalid; introduced the
+  `{file}.invalid` marker convention (sibling file, human-readable body, honored by the
+  corert harness in `CoreRoundtripImpl.cpp::discoverInputFiles`; api import keeps
+  processing). Documented in `data/README.md`.
+- **i3 (static-analysis sweep)**: ran `xmllint --schema` against the MusicXML XSD on
+  the remaining failing files; marked 10 as `.invalid` where the schema violation
+  explained the round-trip diff. Three real bugs survived: ly22b, ly41e, ly45f.
+- **i3 (cont.)**: ly45f — `CommaSeparatedListOfPositiveIntegers::parse` in the
+  hand-written `src/private/mx/core/CommaSeparatedPositiveIntegers.cpp` discarded
+  the "1, 2, 3" vs "1,2,3" spacing on import. Added a narrow `", "` detection that
+  sets `myIsSpacingDesired`. Commit `461b96d2`.
+- **i4**: ly41e — `XsString::toStream` escaped only `<`, `>`, `&`. A raw `\r` written
+  out was normalized to `\n` on the next read (pugixml `parse_eol`, XML 1.0 §2.11).
+  Added a `'\r'` → `"&#xd;"` case. Hand-written type, no regen. Commit `040b2152`.
+- **i5**: ly22b — XSD `slash` group is `minOccurs="0"` inside `complexType slash` and
+  `complexType beat-repeat`, so empty `<slash/>` is valid. HEAD treated `slash-type` as
+  always-present; revgen preserved this via `CHILD_MIN_OCCURS_OVERRIDE` entries.
+  Removed the overrides, regenerated `Slash.{h,cpp}` and `BeatRepeat.{h,cpp}` with a
+  `myHasSlashType` flag, removed a matching `addChildIfNone` workaround in
+  `src/private/mxtest/import/ExpectedFiles.cpp`. `make test-all` then surfaced 25
+  assertions in 23 `mxtest/core/*Test.cpp` cases that codified the bug; added 6
+  `setHasSlashType(true)` calls across 4 fixture files (the PropertiesTest edit
+  cascades to 11 dependents). Commits `d43a222c` and `9c8efa24`. M3 complete.
 
-Picked Invention 2 (Invention 5 is the same root cause). Diff was
-`<measure width="564.40">` vs `<measure width="564.4">`. `width` is a `tenths`
-(decimal) attribute. `PreciseDecimal::toStream` in the hand-written
-`src/private/mx/core/Decimals.cpp` strips trailing zeros from the decimal portion,
-so `mx::core` writes `564.4`. The corert and api-import pipelines already strip
-trailing zeros from the expected XML for 9 other tenths-typed fields
-(`default-x`, `default-y`, `tenths`, ...) via `mxtest::stripZerosFromDecimalFields`
-+ the `decimalFields` set in `src/private/mxtest/import/DecimalFields.h`. The set
-was missing `"width"`.
-
-User direction: fix on the test side, normalize the expected XML the same way the
-library normalizes its output. Not a generator bug; nothing to regenerate.
-
-Fix: added `"width"` to `decimalFields`. Result: `make test-core-dev` 31 → 14
-failed; `make test` still 0. No new failures introduced. Cleared 17 failures with
-a one-line change, all driven by the same width-attribute pattern across the
-MuseScore/foundsuite corpus.
-
-Committed as `639d46a3` on branch `fix-core-dev`.
-
-## 2026-05-22 16:47
-
-M3 iteration 2. Baselines this session: test-core-dev = 14 failed, test = 0
-failed. Picked smallest diff: musuite/testInvalid.xml (4 lines; two non-XSD
-elements <invalid_element/> and <another_invalid_element/> dropped on
-fromXDoc). Not a generator or library bug: the file is intentionally invalid
-MusicXML, named testInvalid.xml, and self-documents that fact in a
-miscellaneous-field. A strongly-typed schema-generated DOM cannot preserve
-unknown elements without an architectural passthrough we do not want.
-
-Per user direction introduced a repo-wide marker convention: a sibling file
-named {file}.invalid next to any invalid MusicXML input, body is a
-human-readable explanation. Documented in data/README.md. Updated
-src/private/mxtest/corert/CoreRoundtripImpl.cpp::discoverInputFiles to skip
-any file with a sibling .invalid marker. Added
-data/musuite/testInvalid.xml.invalid. Other suites (api import) keep
-processing such files; only the schema-strict core roundtrip honors the
-marker.
-
-## 2026-05-22 16:59
-
-Static analysis sweep of all 13 corert failures against the MusicXML XSD
-using xmllint --schema (with xml.xsd and xlink.xsd downloaded to /tmp and
-the schema imports rewritten to local paths). For each failing file
-compared the schema violations against the corert diff symptom; marked a
-file only when (a) the schema flagged a clear violation and (b) the
-violation explains the round-trip diff.
-
-Ten files met both criteria and got .invalid markers:
-- foundsuite/Deutscher Tanz D.820.1.xml (midi-program=0)
-- foundsuite/O_Holy_Night-Adam-1871.xml (midi-channel=0)
-- foundsuite/O_Holy_Night.xml (midi-channel=0)
-- foundsuite/Rimsky-Korsakov Op11 No4.xml (sound/@dynamics=-1.11)
-- lysuite/ly01e_Pitches_ParenthesizedAccidentals.xml (accidental='double-flat')
-- lysuite/ly32a_Notations.xml (empty <fret/>)
-- lysuite/ly41g_PartNoId.xml (part missing required id)
-- lysuite/ly74a_FiguredBass.xml (figured-bass missing required figure)
-- lysuite/ly75a_AccordionRegistrations.xml (accordion-middle out of range)
-- musuite/test_harmony.xml (kind enum violations, degree-type misorder)
-
-Three failures remained because the files are schema-valid and the diff
-is a real library bug: ly22b_Staff_Notestyles.xml (child count mismatch
-in measure-style), ly41e_StaffGroups_InstrumentNames_Linebroken.xml
-(part-name text mismatch), ly45f_Repeats_InvalidEndings.xml (the schema
-allows both "1, 2, 3" and "1,2,3" via the ending-number pattern; mx::core
-is collapsing the spaces, which is a library bug despite the misleading
-"Invalid" in the filename).
-
-Result: test-core-dev 13 -> 3 failed. test stayed at 0.
-
-## 2026-05-22 17:04
-
-M3 iteration 3 baseline: cleared data/testOutput, ran make test-core-dev
-(3 failed) and make test (0 failed) — matches state.md. Diffed each
-corert pair:
-
-- ly45f_Repeats_InvalidEndings.xml: 8 lines
-- ly41e_StaffGroups_InstrumentNames_Linebroken.xml: 10 lines
-- ly22b_Staff_Notestyles.xml: 24 lines
-
-test_to_fix = ly45f_Repeats_InvalidEndings.xml. Diff is two ending
-@number attributes: expected "1, 2, 3", actual "1,2,3".
-
-Root cause: CommaSeparatedListOfPositiveIntegers in
-src/private/mx/core/CommaSeparatedPositiveIntegers.cpp. parse() runs
-onlyAllow(text, "", "1234567890,-") which strips spaces, then never
-touches myIsSpacingDesired (default false). toStream emits
-"a,b,c" unless myIsSpacingDesired is true. So whether the input had
-spaces is lost on import and the output is always space-less.
-
-The schema's ending-number pattern [1-9][0-9]*(, ?[1-9][0-9]*)* allows
-both "1, 2, 3" and "1,2,3" — they are distinct lexical forms of the same
-value. Round-tripping should preserve which form the input used.
-
-This type is hand-written, not generated (gen/generate.py only maps the
-header path as a dependency; the .h/.cpp are not produced). Fix lives
-directly in CommaSeparatedPositiveIntegers.cpp::parse: detect ", " in
-the raw input and call setUseSpaceBetweenItems(true). Not a gen change,
-not a schema-faithful-defaults question — just a parser losing
-information.
-
-Reporting analysis to user, awaiting direction before fixing.
-
-## 2026-05-22 17:14
-
-Applied fix to CommaSeparatedListOfPositiveIntegers::parse: detect
-digit-comma-space-digit in the raw input and set myIsSpacingDesired
-accordingly. Added #include <cctype>. Detection is intentionally narrow
-(requires digits on both sides of ", ") so the existing
-StringsTest::EndingNumber02 case — which feeds junk like
-"-2,-1,,,,XYZ, 0,  @#$@*&#^1,2,3,3,3,3,3" and expects "1,2,3" out —
-stays green.
-
-Gates: make fmt clean, make check clean, make test-all 3026/3028
-passed (the two remaining failures are the known ly22b and ly41e
-corert cases; no new failures, no regressions). Committed as
-461b96d2 on branch fix-core-dev.
-
-Iteration 3 done. M3 remaining: ly22b (24-line diff, measure-style
-child count) and ly41e (10-line diff, part-name linebroken text). Next
-session picks the smaller — ly41e.
-
-## 2026-05-22 17:22
-
-M3 iteration 4. Baseline confirmed: test-core-dev=2, test=0.
-Smallest core-roundtrip diff was lysuite/ly41e_StaffGroups_InstrumentNames_Linebroken.xml
-(10 lines) as predicted. Root cause: input has &#xd; in <part-name> text;
-mx::core::XsString::toStream escapes only <, >, &. On write, raw \r is emitted,
-then pugixml's parse_eol normalizes \r to \n on the next load, so the in-memory
-"Long\rStaff\rName" becomes "Long\nStaff\nName" after toXDoc. Fix: add a
-'\r' case to XsString::toStream emitting "&#xd;". XsString.cpp is hand-written
-(only its header path is mapped in gen/), so no regen. Risk minimal — escape only
-fires on the output side and only when a \r is actually present in the string.
-
-## 2026-05-22 17:26
-
-Iteration 4 fix landed in commit 040b2152 ("core: escape carriage return as
-&#xd; in XsString writer"). Verified: make fmt clean, make check clean,
-make test-core-dev 1 failed (was 2), make test 0 failed, make test-all
-3027/3028 (was 3026/3028). Only remaining failure is
-lysuite/ly22b_Staff_Notestyles.xml — child-count mismatch inside
-measure-style/slash. That is the iteration 5 target.
-
-## 2026-05-22 17:38
-
-M3 iteration 5 started. Baseline: make test-core-dev = 1 failed (lysuite/ly22b_Staff_Notestyles.xml, child count mismatch in measure-style/slash). make test was 0 at start of M3 iter 4 commit; not re-run this session.
-
-Diagnosed root cause: writer unconditionally emits `<slash-type>eighth</slash-type>` inside every `<slash>` element. XSD has `<xs:group ref="slash" minOccurs="0"/>` inside `complexType slash` (and inside `complexType beat-repeat`), so the entire group is optional and the test input has empty `<slash type="..."/>` with no children. HEAD treats `slash-type` as always-present, no `myHas` flag. Generator preserves this via explicit CHILD_MIN_OCCURS_OVERRIDE entries at gen/generate.py:1083-1084 keyed on (slash, slash-type) and (beat-repeat, slash-type).
-
-Classified as pre-existing hand-rolled bug replicated by revgen — exactly the "defaulting to having an element present when minOccurs=0" category flagged in plan.md M3.
-
-mx/api and mx/impl do not reference Slash, BeatRepeat, or SlashType element classes; only unrelated enums (doubleSlashFlat etc.) carry the substring. No impl/api changes needed.
-
-Confirmed with user: fix both slash and beat-repeat together (single conceptual change), regenerate data/expected/lysuite_ly22b_Staff_Notestyles.xml.expected.xml as the standard api-import fix path.
-
-Plan: drop both override entries, regen mx/core, regen the api-import expected file, run full gate.
-
-## 2026-05-22 18:00
-
-Discovered the actual "buggy assertion" the user anticipated: src/private/mxtest/import/ExpectedFiles.cpp:38-40 patched the test input via `addChildIfNone(*xdoc, "slash", "slash-type", "eighth")` with a comment claiming the input was XSD-invalid. The XSD analysis shows the opposite — the slash group is minOccurs=0, so empty `<slash/>` is fine. Removed the patch (test harness change, pre-authorized in this session). The mx/api / mx/impl layer is untouched; no assertion there to fix.
-
-Generator change: removed both CHILD_MIN_OCCURS_OVERRIDE entries (slash/slash-type and beat-repeat/slash-type) plus their explanatory comment. Regenerated mx/core. Only Slash.{h,cpp} and BeatRepeat.{h,cpp} had semantic diffs (added myHasSlashType + gated emission); other files were pure clang-format whitespace drift resolved by `make fmt`.
-
-Local gates so far: make test-core-dev 350/350 (was 349/350); make test 2717/2717.
-
-## 2026-05-22 18:17
-
-`make test-all` after the gen fix surfaced 25 assertion failures in 23 cases across 12 mxtest/core/*Test.cpp files. None in api-import or core-roundtrip — only the per-element fixture tests that only build under MX_BUILD_CORE_TESTS=ON and that codified the buggy "slash-type emitted by default" behavior.
-
-Two categories:
-- Category A (SlashTest, BeatRepeatTest): default-constructed object asserts buggy stream output.
-- Category B (MeasureStyleTest, PropertiesTest + 9 files cascading via the Properties tgen fixture): setValue without setHasSlashType, leaving the new has-flag false so the writer correctly omits the element, but expected streams still assert it.
-
-User authorized fixing both. Approach: minimal surgical addition of setHasSlashType(true) calls; no new assertions, no removed assertions. Six edits total across four files (SlashTest x2, BeatRepeatTest x2, MeasureStyleTest x2, PropertiesTest x2). The PropertiesTest builder is shared, so its two-line edit cascades to fix 11 of the 12 broken files.
-
-Final gates: make fmt clean, make check passed, make test-all passed (3028/3028, 9914 assertions). M3 milestone complete: lysuite/ly22b_Staff_Notestyles.xml was the last core-roundtrip failure.
+Final state: `make test-core-dev` 350/350, `make test` 2717/2717, `make test-all`
+3028/3028 (9914 assertions), `make check` passed.

--- a/docs/ai/projects/gen/log.md
+++ b/docs/ai/projects/gen/log.md
@@ -129,3 +129,22 @@ a one-line change, all driven by the same width-attribute pattern across the
 MuseScore/foundsuite corpus.
 
 Committed as `639d46a3` on branch `fix-core-dev`.
+
+## 2026-05-22 16:47
+
+M3 iteration 2. Baselines this session: test-core-dev = 14 failed, test = 0
+failed. Picked smallest diff: musuite/testInvalid.xml (4 lines; two non-XSD
+elements <invalid_element/> and <another_invalid_element/> dropped on
+fromXDoc). Not a generator or library bug: the file is intentionally invalid
+MusicXML, named testInvalid.xml, and self-documents that fact in a
+miscellaneous-field. A strongly-typed schema-generated DOM cannot preserve
+unknown elements without an architectural passthrough we do not want.
+
+Per user direction introduced a repo-wide marker convention: a sibling file
+named {file}.invalid next to any invalid MusicXML input, body is a
+human-readable explanation. Documented in data/README.md. Updated
+src/private/mxtest/corert/CoreRoundtripImpl.cpp::discoverInputFiles to skip
+any file with a sibling .invalid marker. Added
+data/musuite/testInvalid.xml.invalid. Other suites (api import) keep
+processing such files; only the schema-strict core roundtrip honors the
+marker.

--- a/docs/ai/projects/gen/log.md
+++ b/docs/ai/projects/gen/log.md
@@ -148,3 +148,34 @@ any file with a sibling .invalid marker. Added
 data/musuite/testInvalid.xml.invalid. Other suites (api import) keep
 processing such files; only the schema-strict core roundtrip honors the
 marker.
+
+## 2026-05-22 16:59
+
+Static analysis sweep of all 13 corert failures against the MusicXML XSD
+using xmllint --schema (with xml.xsd and xlink.xsd downloaded to /tmp and
+the schema imports rewritten to local paths). For each failing file
+compared the schema violations against the corert diff symptom; marked a
+file only when (a) the schema flagged a clear violation and (b) the
+violation explains the round-trip diff.
+
+Ten files met both criteria and got .invalid markers:
+- foundsuite/Deutscher Tanz D.820.1.xml (midi-program=0)
+- foundsuite/O_Holy_Night-Adam-1871.xml (midi-channel=0)
+- foundsuite/O_Holy_Night.xml (midi-channel=0)
+- foundsuite/Rimsky-Korsakov Op11 No4.xml (sound/@dynamics=-1.11)
+- lysuite/ly01e_Pitches_ParenthesizedAccidentals.xml (accidental='double-flat')
+- lysuite/ly32a_Notations.xml (empty <fret/>)
+- lysuite/ly41g_PartNoId.xml (part missing required id)
+- lysuite/ly74a_FiguredBass.xml (figured-bass missing required figure)
+- lysuite/ly75a_AccordionRegistrations.xml (accordion-middle out of range)
+- musuite/test_harmony.xml (kind enum violations, degree-type misorder)
+
+Three failures remained because the files are schema-valid and the diff
+is a real library bug: ly22b_Staff_Notestyles.xml (child count mismatch
+in measure-style), ly41e_StaffGroups_InstrumentNames_Linebroken.xml
+(part-name text mismatch), ly45f_Repeats_InvalidEndings.xml (the schema
+allows both "1, 2, 3" and "1,2,3" via the ending-number pattern; mx::core
+is collapsing the spaces, which is a library bug despite the misleading
+"Invalid" in the filename).
+
+Result: test-core-dev 13 -> 3 failed. test stayed at 0.

--- a/docs/ai/projects/gen/log.md
+++ b/docs/ai/projects/gen/log.md
@@ -274,3 +274,15 @@ Discovered the actual "buggy assertion" the user anticipated: src/private/mxtest
 Generator change: removed both CHILD_MIN_OCCURS_OVERRIDE entries (slash/slash-type and beat-repeat/slash-type) plus their explanatory comment. Regenerated mx/core. Only Slash.{h,cpp} and BeatRepeat.{h,cpp} had semantic diffs (added myHasSlashType + gated emission); other files were pure clang-format whitespace drift resolved by `make fmt`.
 
 Local gates so far: make test-core-dev 350/350 (was 349/350); make test 2717/2717.
+
+## 2026-05-22 18:17
+
+`make test-all` after the gen fix surfaced 25 assertion failures in 23 cases across 12 mxtest/core/*Test.cpp files. None in api-import or core-roundtrip — only the per-element fixture tests that only build under MX_BUILD_CORE_TESTS=ON and that codified the buggy "slash-type emitted by default" behavior.
+
+Two categories:
+- Category A (SlashTest, BeatRepeatTest): default-constructed object asserts buggy stream output.
+- Category B (MeasureStyleTest, PropertiesTest + 9 files cascading via the Properties tgen fixture): setValue without setHasSlashType, leaving the new has-flag false so the writer correctly omits the element, but expected streams still assert it.
+
+User authorized fixing both. Approach: minimal surgical addition of setHasSlashType(true) calls; no new assertions, no removed assertions. Six edits total across four files (SlashTest x2, BeatRepeatTest x2, MeasureStyleTest x2, PropertiesTest x2). The PropertiesTest builder is shared, so its two-line edit cascades to fix 11 of the 12 broken files.
+
+Final gates: make fmt clean, make check passed, make test-all passed (3028/3028, 9914 assertions). M3 milestone complete: lysuite/ly22b_Staff_Notestyles.xml was the last core-roundtrip failure.

--- a/docs/ai/projects/gen/log.md
+++ b/docs/ai/projects/gen/log.md
@@ -179,3 +179,36 @@ is collapsing the spaces, which is a library bug despite the misleading
 "Invalid" in the filename).
 
 Result: test-core-dev 13 -> 3 failed. test stayed at 0.
+
+## 2026-05-22 17:04
+
+M3 iteration 3 baseline: cleared data/testOutput, ran make test-core-dev
+(3 failed) and make test (0 failed) — matches state.md. Diffed each
+corert pair:
+
+- ly45f_Repeats_InvalidEndings.xml: 8 lines
+- ly41e_StaffGroups_InstrumentNames_Linebroken.xml: 10 lines
+- ly22b_Staff_Notestyles.xml: 24 lines
+
+test_to_fix = ly45f_Repeats_InvalidEndings.xml. Diff is two ending
+@number attributes: expected "1, 2, 3", actual "1,2,3".
+
+Root cause: CommaSeparatedListOfPositiveIntegers in
+src/private/mx/core/CommaSeparatedPositiveIntegers.cpp. parse() runs
+onlyAllow(text, "", "1234567890,-") which strips spaces, then never
+touches myIsSpacingDesired (default false). toStream emits
+"a,b,c" unless myIsSpacingDesired is true. So whether the input had
+spaces is lost on import and the output is always space-less.
+
+The schema's ending-number pattern [1-9][0-9]*(, ?[1-9][0-9]*)* allows
+both "1, 2, 3" and "1,2,3" — they are distinct lexical forms of the same
+value. Round-tripping should preserve which form the input used.
+
+This type is hand-written, not generated (gen/generate.py only maps the
+header path as a dependency; the .h/.cpp are not produced). Fix lives
+directly in CommaSeparatedPositiveIntegers.cpp::parse: detect ", " in
+the raw input and call setUseSpaceBetweenItems(true). Not a gen change,
+not a schema-faithful-defaults question — just a parser losing
+information.
+
+Reporting analysis to user, awaiting direction before fixing.

--- a/docs/ai/projects/gen/log.md
+++ b/docs/ai/projects/gen/log.md
@@ -5,80 +5,78 @@ Append chronologically, oldest on top.
 ## M1: revgen (2026-05-18 — 2026-05-21, 40 iterations) ✅
 
 Reverse-engineered the codegen, iteratively shrinking `SKIP_ELEMENTS` and `CHOICE_SKIP` to
-empty. Closed with the generator producing every C++ class in `mx/core`. Tests were failing;
-commit `d4f25ee6` "src: issues caused by revgen" carries hand-edits to non-generated consumers
-that kept the build working. Those hand-edits were the input to M2.
+empty. Closed with the generator producing every C++ class in `mx/core`. Tests still
+failing; commit `d4f25ee6` "src: issues caused by revgen" carries hand-edits to
+non-generated consumers that kept the build working — the input to M2.
 
 ## M2: fix-gen (2026-05-21 — 2026-05-22) ✅
 
 Triaged `d4f25ee6` into 6 root causes (A–F) and ~129 `make test-all` failures into clusters
 (R1–R7, D1–D4, plus an isFirst-separator family). Fixed iteratively to 0 failures.
 
-Notable fixes captured as generator config / structural rules:
-- `EXTENSION_OPTIONAL_GROUP_RENAME`, `SUPPRESS_GROUP_SUFFIX`, `WRAPPER_AS_ELEMENT_SYNTH_GROUPS`
-  (MetronomeTuplet group flattening, issue C).
-- `TREE_ELEMENT_CONFIG["key"] = {"parent_imports_choice_groups": True}` emits
+Notable mechanisms introduced (still in `gen/generate.py`):
+- `EXTENSION_OPTIONAL_GROUP_RENAME`, `SUPPRESS_GROUP_SUFFIX`,
+  `WRAPPER_AS_ELEMENT_SYNTH_GROUPS` (MetronomeTuplet group flattening, issue C).
+- `TREE_ELEMENT_CONFIG["key"] = {"parent_imports_choice_groups": True}` →
   `Key::import{Traditional,NonTraditional}Key` (issues E/F).
-- Required-set seeding rule in `generate_element_cpp` (`min_occurs>=1, max_occurs!=1, !is_group`)
-  fixed HarpPedals SIGSEGV (R5).
-- `is_container` + `trigger_names` on `TreeChoiceBranch`; `importContainer<X>` dispatch in
-  `generate_tree_parent_cpp` (D1, D4 — Metronome reader).
-- `ATTR_DEFAULT_OVERRIDE` (~17 entries: `lang="it"`, `lineEnd=down`, `number="1"`,
-  `halign`/`justify=center`, …), `CHILD_INIT_VALUE_OVERRIDE` (Scaling, StaffDetails).
-- `_emit_direction_family` bespoke driven by `model.complex_types["direction-type"].content_tree`.
+- Required-set seeding rule in `generate_element_cpp`
+  (`min_occurs>=1, max_occurs!=1, !is_group`) fixed HarpPedals SIGSEGV (R5).
+- `is_container` + `trigger_names` on `TreeChoiceBranch`; `importContainer<X>` dispatch
+  in `generate_tree_parent_cpp` (D1, D4 — Metronome reader).
+- `ATTR_DEFAULT_OVERRIDE` (~17 entries), `CHILD_INIT_VALUE_OVERRIDE` (Scaling,
+  StaffDetails).
+- `_emit_direction_family` bespoke driven by
+  `model.complex_types["direction-type"].content_tree`.
 - `ELEMENT_HAS_CONTENTS_ALWAYS_TRUE` (MeasureLayout, NoteheadText), notehead-text
   `seed_choice_set`, MeasureLayout explicit child-presence check for `isOneLineOnly`.
 
-Deferred WEIRD item: issue A — original `mx/core` had a hand-applied MusicXML 4.0 `UpDownNone`
-backport overwritten by schema-faithful 3.x regen. TODO comments left in
-`mx/impl/NotationsWriter.cpp:398` and `mx/impl/ArpeggiateFunctions.cpp:35`. Belongs to M5/M6.
+Deferred: issue A — original `mx/core` had a hand-applied MusicXML 4.0 `UpDownNone`
+backport overwritten by schema-faithful 3.x regen. TODO comments in
+`mx/impl/NotationsWriter.cpp:398` and `mx/impl/ArpeggiateFunctions.cpp:35`. Belongs to
+M5/M6.
 
 ### Lessons captured (operational invariants)
 
 - `git checkout -- src/private/mx/core/` preserves mtimes; incremental cmake then links
   partly-old `.o` files and reports stale test counts. Use `make clean && make test-all`
   for authoritative measurements.
-- `make test-all` must run with generated files present — HEAD's hand-applied `UpDownNone`
-  backport is incompatible with a schema-faithful regen, so a reset-first build will not
-  compile.
+- `make test-all` must run with generated files present — HEAD's `UpDownNone` backport
+  is incompatible with a schema-faithful regen, so a reset-first build will not compile.
 - When removing a previously-emitted byte from a shared template, survey the whole HEAD
   population that template emits (R2 burned us by regressing DirectionType).
 - Bespoke handlers should still read the parsed XSD model — "custom algorithm,
-  schema-driven data". Direction's element-name tables derive from the parsed
-  `direction-type` content tree.
+  schema-driven data".
 
-## M3: fix-core-dev (2026-05-22) ✅
+## M3: fix-core-dev (2026-05-22, 5 iterations) ✅
 
-Five iterations. Each picked the smallest core-roundtrip diff in `data/testOutput/corert`
-and triaged it. Two outcomes: a hand-rolled mx-side fix, or a `{file}.invalid` marker
-for files that don't conform to the XSD.
+Each iteration picked the smallest core-roundtrip diff in `data/testOutput/corert` and
+triaged it: either a hand-rolled mx-side fix or a `{file}.invalid` marker for files that
+don't conform to the XSD. Per-iteration template now lives in `plan.md`.
 
-- **i1**: tenths-typed `width` attribute trailing-zero strip. Added `"width"` to
+- **i1** — tenths-typed `width` attribute trailing-zero strip. Added `"width"` to
   `decimalFields` in `src/private/mxtest/import/DecimalFields.h`. Cleared 17 failures.
   Commit `639d46a3`.
-- **i2**: `musuite/testInvalid.xml` is intentionally invalid; introduced the
-  `{file}.invalid` marker convention (sibling file, human-readable body, honored by the
-  corert harness in `CoreRoundtripImpl.cpp::discoverInputFiles`; api import keeps
-  processing). Documented in `data/README.md`.
-- **i3 (static-analysis sweep)**: ran `xmllint --schema` against the MusicXML XSD on
-  the remaining failing files; marked 10 as `.invalid` where the schema violation
-  explained the round-trip diff. Three real bugs survived: ly22b, ly41e, ly45f.
-- **i3 (cont.)**: ly45f — `CommaSeparatedListOfPositiveIntegers::parse` in the
-  hand-written `src/private/mx/core/CommaSeparatedPositiveIntegers.cpp` discarded
-  the "1, 2, 3" vs "1,2,3" spacing on import. Added a narrow `", "` detection that
-  sets `myIsSpacingDesired`. Commit `461b96d2`.
-- **i4**: ly41e — `XsString::toStream` escaped only `<`, `>`, `&`. A raw `\r` written
-  out was normalized to `\n` on the next read (pugixml `parse_eol`, XML 1.0 §2.11).
-  Added a `'\r'` → `"&#xd;"` case. Hand-written type, no regen. Commit `040b2152`.
-- **i5**: ly22b — XSD `slash` group is `minOccurs="0"` inside `complexType slash` and
-  `complexType beat-repeat`, so empty `<slash/>` is valid. HEAD treated `slash-type` as
-  always-present; revgen preserved this via `CHILD_MIN_OCCURS_OVERRIDE` entries.
-  Removed the overrides, regenerated `Slash.{h,cpp}` and `BeatRepeat.{h,cpp}` with a
-  `myHasSlashType` flag, removed a matching `addChildIfNone` workaround in
+- **i2** — `musuite/testInvalid.xml` is intentionally invalid; introduced the
+  `{file}.invalid` marker convention (honored by `CoreRoundtripImpl.cpp::discoverInputFiles`;
+  api import keeps processing). Documented in `data/README.md`.
+- **i3 (static-analysis sweep)** — ran `xmllint --schema` against MusicXML XSD on
+  remaining failing files; marked 10 as `.invalid` where the schema violation explained
+  the diff. Three real bugs survived: ly22b, ly41e, ly45f.
+- **i3 (cont.)** — ly45f: `CommaSeparatedListOfPositiveIntegers::parse` in hand-written
+  `src/private/mx/core/CommaSeparatedPositiveIntegers.cpp` discarded "1, 2, 3" vs
+  "1,2,3" spacing on import. Added a `", "` detection that sets `myIsSpacingDesired`.
+  Commit `461b96d2`.
+- **i4** — ly41e: `XsString::toStream` escaped only `<`, `>`, `&`. A raw `\r` was
+  normalized to `\n` on the next read (pugixml `parse_eol`, XML 1.0 §2.11). Added
+  `'\r'` → `"&#xd;"`. Hand-written type, no regen. Commit `040b2152`.
+- **i5** — ly22b: XSD `slash` group is `minOccurs="0"` inside complexType `slash` and
+  `beat-repeat`, so empty `<slash/>` is valid. HEAD treated `slash-type` as
+  always-present; revgen preserved this via `CHILD_MIN_OCCURS_OVERRIDE`. Removed the
+  overrides, regenerated `Slash.{h,cpp}` and `BeatRepeat.{h,cpp}` with a `myHasSlashType`
+  flag, removed a matching `addChildIfNone` workaround in
   `src/private/mxtest/import/ExpectedFiles.cpp`. `make test-all` then surfaced 25
   assertions in 23 `mxtest/core/*Test.cpp` cases that codified the bug; added 6
-  `setHasSlashType(true)` calls across 4 fixture files (the PropertiesTest edit
-  cascades to 11 dependents). Commits `d43a222c` and `9c8efa24`. M3 complete.
+  `setHasSlashType(true)` calls across 4 fixture files. Commits `d43a222c`, `9c8efa24`.
 
 Final state: `make test-core-dev` 350/350, `make test` 2717/2717, `make test-all`
-3028/3028 (9914 assertions), `make check` passed.
+3028/3028 (9914 assertions), `make check` passed. PR-merge commit `6c4e18d4`.

--- a/docs/ai/projects/gen/log.md
+++ b/docs/ai/projects/gen/log.md
@@ -231,3 +231,24 @@ corert cases; no new failures, no regressions). Committed as
 Iteration 3 done. M3 remaining: ly22b (24-line diff, measure-style
 child count) and ly41e (10-line diff, part-name linebroken text). Next
 session picks the smaller — ly41e.
+
+## 2026-05-22 17:22
+
+M3 iteration 4. Baseline confirmed: test-core-dev=2, test=0.
+Smallest core-roundtrip diff was lysuite/ly41e_StaffGroups_InstrumentNames_Linebroken.xml
+(10 lines) as predicted. Root cause: input has &#xd; in <part-name> text;
+mx::core::XsString::toStream escapes only <, >, &. On write, raw \r is emitted,
+then pugixml's parse_eol normalizes \r to \n on the next load, so the in-memory
+"Long\rStaff\rName" becomes "Long\nStaff\nName" after toXDoc. Fix: add a
+'\r' case to XsString::toStream emitting "&#xd;". XsString.cpp is hand-written
+(only its header path is mapped in gen/), so no regen. Risk minimal — escape only
+fires on the output side and only when a \r is actually present in the string.
+
+## 2026-05-22 17:26
+
+Iteration 4 fix landed in commit 040b2152 ("core: escape carriage return as
+&#xd; in XsString writer"). Verified: make fmt clean, make check clean,
+make test-core-dev 1 failed (was 2), make test 0 failed, make test-all
+3027/3028 (was 3026/3028). Only remaining failure is
+lysuite/ly22b_Staff_Notestyles.xml — child-count mismatch inside
+measure-style/slash. That is the iteration 5 target.

--- a/docs/ai/projects/gen/log.md
+++ b/docs/ai/projects/gen/log.md
@@ -212,3 +212,22 @@ not a schema-faithful-defaults question — just a parser losing
 information.
 
 Reporting analysis to user, awaiting direction before fixing.
+
+## 2026-05-22 17:14
+
+Applied fix to CommaSeparatedListOfPositiveIntegers::parse: detect
+digit-comma-space-digit in the raw input and set myIsSpacingDesired
+accordingly. Added #include <cctype>. Detection is intentionally narrow
+(requires digits on both sides of ", ") so the existing
+StringsTest::EndingNumber02 case — which feeds junk like
+"-2,-1,,,,XYZ, 0,  @#$@*&#^1,2,3,3,3,3,3" and expects "1,2,3" out —
+stays green.
+
+Gates: make fmt clean, make check clean, make test-all 3026/3028
+passed (the two remaining failures are the known ly22b and ly41e
+corert cases; no new failures, no regressions). Committed as
+461b96d2 on branch fix-core-dev.
+
+Iteration 3 done. M3 remaining: ly22b (24-line diff, measure-style
+child count) and ly41e (10-line diff, part-name linebroken text). Next
+session picks the smaller — ly41e.

--- a/docs/ai/projects/gen/log.md
+++ b/docs/ai/projects/gen/log.md
@@ -252,3 +252,25 @@ make test-core-dev 1 failed (was 2), make test 0 failed, make test-all
 3027/3028 (was 3026/3028). Only remaining failure is
 lysuite/ly22b_Staff_Notestyles.xml — child-count mismatch inside
 measure-style/slash. That is the iteration 5 target.
+
+## 2026-05-22 17:38
+
+M3 iteration 5 started. Baseline: make test-core-dev = 1 failed (lysuite/ly22b_Staff_Notestyles.xml, child count mismatch in measure-style/slash). make test was 0 at start of M3 iter 4 commit; not re-run this session.
+
+Diagnosed root cause: writer unconditionally emits `<slash-type>eighth</slash-type>` inside every `<slash>` element. XSD has `<xs:group ref="slash" minOccurs="0"/>` inside `complexType slash` (and inside `complexType beat-repeat`), so the entire group is optional and the test input has empty `<slash type="..."/>` with no children. HEAD treats `slash-type` as always-present, no `myHas` flag. Generator preserves this via explicit CHILD_MIN_OCCURS_OVERRIDE entries at gen/generate.py:1083-1084 keyed on (slash, slash-type) and (beat-repeat, slash-type).
+
+Classified as pre-existing hand-rolled bug replicated by revgen — exactly the "defaulting to having an element present when minOccurs=0" category flagged in plan.md M3.
+
+mx/api and mx/impl do not reference Slash, BeatRepeat, or SlashType element classes; only unrelated enums (doubleSlashFlat etc.) carry the substring. No impl/api changes needed.
+
+Confirmed with user: fix both slash and beat-repeat together (single conceptual change), regenerate data/expected/lysuite_ly22b_Staff_Notestyles.xml.expected.xml as the standard api-import fix path.
+
+Plan: drop both override entries, regen mx/core, regen the api-import expected file, run full gate.
+
+## 2026-05-22 18:00
+
+Discovered the actual "buggy assertion" the user anticipated: src/private/mxtest/import/ExpectedFiles.cpp:38-40 patched the test input via `addChildIfNone(*xdoc, "slash", "slash-type", "eighth")` with a comment claiming the input was XSD-invalid. The XSD analysis shows the opposite — the slash group is minOccurs=0, so empty `<slash/>` is fine. Removed the patch (test harness change, pre-authorized in this session). The mx/api / mx/impl layer is untouched; no assertion there to fix.
+
+Generator change: removed both CHILD_MIN_OCCURS_OVERRIDE entries (slash/slash-type and beat-repeat/slash-type) plus their explanatory comment. Regenerated mx/core. Only Slash.{h,cpp} and BeatRepeat.{h,cpp} had semantic diffs (added myHasSlashType + gated emission); other files were pure clang-format whitespace drift resolved by `make fmt`.
+
+Local gates so far: make test-core-dev 350/350 (was 349/350); make test 2717/2717.

--- a/docs/ai/projects/gen/log.md
+++ b/docs/ai/projects/gen/log.md
@@ -101,3 +101,31 @@ After mass cleanup, 13 failures remained, all metronome/tempo. Re-triaged as D1�
 - Bespoke handlers should still read the parsed XSD model — pattern is "custom algorithm,
   schema-driven data" (Direction's element-name tables derived from
   `model.complex_types["direction-type"].content_tree.branches`).
+
+## M3: fix-core-dev (2026-05-22 — )
+
+### 2026-05-22 16:40 — iteration 1
+
+Baselines on a clean build: `make test-core-dev` = 31 failed / 361 cases;
+`make test` = 0 failed. Smallest diffs in `data/testOutput/corert` (4 lines each):
+`foundsuite_Invention 2.xml`, `foundsuite_Invention_5.xml`, `musuite_testInvalid.xml`.
+
+Picked Invention 2 (Invention 5 is the same root cause). Diff was
+`<measure width="564.40">` vs `<measure width="564.4">`. `width` is a `tenths`
+(decimal) attribute. `PreciseDecimal::toStream` in the hand-written
+`src/private/mx/core/Decimals.cpp` strips trailing zeros from the decimal portion,
+so `mx::core` writes `564.4`. The corert and api-import pipelines already strip
+trailing zeros from the expected XML for 9 other tenths-typed fields
+(`default-x`, `default-y`, `tenths`, ...) via `mxtest::stripZerosFromDecimalFields`
++ the `decimalFields` set in `src/private/mxtest/import/DecimalFields.h`. The set
+was missing `"width"`.
+
+User direction: fix on the test side, normalize the expected XML the same way the
+library normalizes its output. Not a generator bug; nothing to regenerate.
+
+Fix: added `"width"` to `decimalFields`. Result: `make test-core-dev` 31 → 14
+failed; `make test` still 0. No new failures introduced. Cleared 17 failures with
+a one-line change, all driven by the same width-attribute pattern across the
+MuseScore/foundsuite corpus.
+
+Committed as `639d46a3` on branch `fix-core-dev`.

--- a/docs/ai/projects/gen/plan.md
+++ b/docs/ai/projects/gen/plan.md
@@ -2,80 +2,56 @@
 
 ## Milestone 1: revgen — reverse-engineer codegen ✅
 
-Build a generator that produces every C++ class in `mx/core` from `docs/musicxml.xsd` with no
-skipped elements.
-
-**Complete** (2026-05-21, iteration 40). SKIP_ELEMENTS and CHOICE_SKIP both empty.
+**Complete** (2026-05-21). Generator produces every C++ class in `mx/core` from
+`docs/musicxml.xsd`. `SKIP_ELEMENTS` and `CHOICE_SKIP` empty.
 
 ## Milestone 2: fix-gen — fix generator bugs surfaced as failing tests ✅
 
-**Complete** (2026-05-22). All 2678 tests pass.
+**Complete** (2026-05-22). 2678 tests pass. Triaged `d4f25ee6` hand-edits (6 root causes)
+and ~129 `make test-all` failures (clusters R1–R7, D1–D4, isFirst-separator). All fixes
+landed in the generator; workarounds reverted. One item deferred to M5/M6: HEAD's
+hand-applied MusicXML 4.0 `UpDownNone` backport vs. schema-faithful 3.x regen
+(TODOs in `mx/impl/NotationsWriter.cpp:398`, `mx/impl/ArpeggiateFunctions.cpp:35`).
 
-The commit "src: issues caused by revgen" contained hand-edits to non-generated code (mx/impl,
-mx/core/FromXElement, some tests) that worked around generator bugs. Each was triaged as BUG /
-BENIGN / WEIRD, generator bugs were fixed, and the workarounds reverted.
+## Milestone 3: fix-core-dev — fix bugs surfaced by new core-dev test mode ✅
 
-One WEIRD item deferred to M5: original `mx/core` had a hand-applied MusicXML 4.0 `UpDownNone`
-backport that a schema-faithful 3.x regen overwrites. The `// TODO: fixme - MusicXML 4.0 ...`
-comments in `mx/impl` (NotationsWriter.cpp:398, ArpeggiateFunctions.cpp:35) bookmark this.
+**Complete** (2026-05-22, 5 iterations). All gates green
+(`make test-all` 3028/3028, 9914 assertions). See `log.md` M3 for the per-iteration
+breakdown. Net result: 31 corert failures triaged into 10 `{file}.invalid` markers
+and 4 real fixes (tenths width trailing-zero, comma-list spacing, `\r` escape in
+`XsString`, optional slash-type group). Plus the
+`src/private/mxtest/corert/` harness now exists and is part of `make test-all`.
 
-## Milestone 3: fix-core-dev - fix bugs surfaced by new core-dev test mode ✅
+### M3 session sequence (kept as a reusable template for M4 corert iteration)
 
-**Complete** (2026-05-22). All gates green. Final iteration (5) fixed the `slash`/`beat-repeat`
-slash-type emission bug — the writer unconditionally emitted `<slash-type>eighth</slash-type>` even
-though the XSD `slash` group is `minOccurs="0"`. Removed two `CHILD_MIN_OCCURS_OVERRIDE` entries
-in gen, regenerated `Slash.{h,cpp}` and `BeatRepeat.{h,cpp}` with a `myHasSlashType` flag, removed
-a matching `addChildIfNone` workaround in the api-import test harness, and added 6 surgical
-`setHasSlashType(true)` calls to 4 `mxtest/core/*Test.cpp` fixture files. Commits d43a222c and
-9c8efa24.
-
-### Session sequence (kept for reference)
-
-Session sequence:
-- `rm -rf data/testOutput/*`
-- run `make test-core-dev` : record the number of falures as baseline_core_dev
-- run `make test` : record the number of failures as baseline_test (should be zero)
-- diff each before/after pair in `data/testOutput/corert` and choose the one with the smallest diff.
-  This becomes test_to_fix
-- analyze test_to_fix and try to decide, is this a bug in `gen/*`? For context, bugs in my original
-  hand-rolled gen efforts were dutifly replicated by revgen. So, for example `lang="it"` as default
-  is not a sensible behavior for the library. It is a bug that preexisted before revgen. There are
-  other potential cases, for example defaulting to having an element present when minOcurrs=0 in the
-  spec.
-  - If you think this is a pre-existing bug reproduced by revgen, it might be worth checking with
-    the user to save us all time and tokens, unless you're really sure that a MusicXML file
-    shouldn't be the way that we are treating it right now
-  - If you think this is just a bug in the way revgen decided what to do, that's a no-brainer, it
-    should be fixed
-- When the bug is fixed
-  - run `gen` to regenerate mx/core
-  - `make fmt`
-  - `make check`
-  - `rm -rf data/testOutput/*`
-  - `make test-core-dev` : you must see that you fixed the test you were trying to fix without introducing any new failures
-  - `make test` : should still be at zero failures
-- Commit your work
-- update state.md and any tracking documents you decide to use.
-- report done
+1. `rm -rf data/testOutput/*`
+2. `make test-core-dev` — record `baseline_core_dev`.
+3. `make test` — record `baseline_test` (should be zero).
+4. Diff each before/after pair in `data/testOutput/corert`; pick the smallest. That's
+   `test_to_fix`. One test per session.
+5. Analyze: pre-existing hand-rolled bug replicated by revgen? schema-invalid input?
+   library bug in a hand-written type? Flag pre-existing-bug calls to the user.
+6. Fix. If gen changed, regen mx/core. `make fmt && make check`.
+7. `rm -rf data/testOutput/*`; `make test-core-dev` must show the fixed test green and
+   no new failures; `make test` must stay at zero.
+8. `make test-all` if the change touched `src/private/mx/core/*` (per AGENTS.md).
+9. Commit. Update `state.md` and other tracking.
 
 ## Milestone 4: increase test coverage
 
-The dedicated mx/core-level round-trip harness now exists (the corert suite under
-`src/private/mxtest/corert/`, exercised by `make test-core-dev` and as part of `make test-all`),
-built out during M3. The harness side of the original M4 statement is therefore done.
-
-What remains: add a lot more MusicXML round-trip input files. Public test suites, hand-curated
-edge cases, or generated inputs targeting specific spec features not yet covered. No specific
-design yet — first M4 session should scope this with the user.
+The corert harness is in place. What's missing: more MusicXML round-trip input files.
+Sources to consider — public test suites, hand-curated edge cases targeting spec
+features not yet exercised, generated/fuzzed inputs. No design yet. First M4 session
+scopes this with the user.
 
 ## Milestone 5: better-gen — fix garbage
 
-The gen program is 12k lines of bad Python. Fix it. Use dedicated mx/core round-trip tests as the
-north star for correctness.
+The generator is ~12k lines of bad Python. Refactor. Use the corert suite as the
+correctness oracle.
 
 ## Milestone 6: mxml4-types — generate MusicXML 4.0 types
 
-Replace `docs/musicxml.xsd` with MusicXML 4.0, regenerate, fix all existing tests. Watch for
-backported or bolted-on features (SMuFL, UpDown, etc.) that were added with hacks to 3.0/3.1 but are
-first-class in 4.0. Be backward-compatible with files `mx` may have written using those hacks.
-Restore the `mx/impl` TODOs from revgen.
+Replace `docs/musicxml.xsd` with MusicXML 4.0, regenerate, fix all existing tests.
+Watch for backported / bolted-on features (SMuFL, `UpDown`, …) that were added with
+hacks to 3.0/3.1 but are first-class in 4.0. Be backward-compatible with files mx may
+have written using those hacks. Restore the `mx/impl` TODOs left from revgen.

--- a/docs/ai/projects/gen/plan.md
+++ b/docs/ai/projects/gen/plan.md
@@ -2,27 +2,23 @@
 
 ## Milestone 1: revgen — reverse-engineer codegen ✅
 
-**Complete** (2026-05-21). Generator produces every C++ class in `mx/core` from
-`docs/musicxml.xsd`. `SKIP_ELEMENTS` and `CHOICE_SKIP` empty.
+Complete 2026-05-21. Generator produces every C++ class in `mx/core` from
+`docs/musicxml.xsd`. `SKIP_ELEMENTS` and `CHOICE_SKIP` empty. See `log.md`.
 
-## Milestone 2: fix-gen — fix generator bugs surfaced as failing tests ✅
+## Milestone 2: fix-gen — fix generator bugs surfaced by failing tests ✅
 
-**Complete** (2026-05-22). 2678 tests pass. Triaged `d4f25ee6` hand-edits (6 root causes)
-and ~129 `make test-all` failures (clusters R1–R7, D1–D4, isFirst-separator). All fixes
-landed in the generator; workarounds reverted. One item deferred to M5/M6: HEAD's
-hand-applied MusicXML 4.0 `UpDownNone` backport vs. schema-faithful 3.x regen
-(TODOs in `mx/impl/NotationsWriter.cpp:398`, `mx/impl/ArpeggiateFunctions.cpp:35`).
+Complete 2026-05-22. `make test-all` 3028/3028. All fixes landed in the generator;
+workarounds reverted. One item deferred to M5/M6: HEAD's hand-applied MusicXML 4.0
+`UpDownNone` backport vs. schema-faithful 3.x regen (TODOs in
+`mx/impl/NotationsWriter.cpp:398`, `mx/impl/ArpeggiateFunctions.cpp:35`).
 
 ## Milestone 3: fix-core-dev — fix bugs surfaced by new core-dev test mode ✅
 
-**Complete** (2026-05-22, 5 iterations). All gates green
-(`make test-all` 3028/3028, 9914 assertions). See `log.md` M3 for the per-iteration
-breakdown. Net result: 31 corert failures triaged into 10 `{file}.invalid` markers
-and 4 real fixes (tenths width trailing-zero, comma-list spacing, `\r` escape in
-`XsString`, optional slash-type group). Plus the
-`src/private/mxtest/corert/` harness now exists and is part of `make test-all`.
+Complete 2026-05-22 (5 iterations). 31 corert failures triaged into 10 `{file}.invalid`
+markers and 4 real fixes. The `src/private/mxtest/corert/` harness is now part of
+`make test-all`. See `log.md` M3 for per-iteration breakdown.
 
-### M3 session sequence (kept as a reusable template for M4 corert iteration)
+### Reusable corert-iteration template (for M4)
 
 1. `rm -rf data/testOutput/*`
 2. `make test-core-dev` — record `baseline_core_dev`.
@@ -34,24 +30,24 @@ and 4 real fixes (tenths width trailing-zero, comma-list spacing, `\r` escape in
 6. Fix. If gen changed, regen mx/core. `make fmt && make check`.
 7. `rm -rf data/testOutput/*`; `make test-core-dev` must show the fixed test green and
    no new failures; `make test` must stay at zero.
-8. `make test-all` if the change touched `src/private/mx/core/*` (per AGENTS.md).
+8. `make test-all` if the change touched `src/private/mx/core/*`.
 9. Commit. Update `state.md` and other tracking.
 
 ## Milestone 4: increase test coverage
 
-The corert harness is in place. What's missing: more MusicXML round-trip input files.
-Sources to consider — public test suites, hand-curated edge cases targeting spec
-features not yet exercised, generated/fuzzed inputs. No design yet. First M4 session
-scopes this with the user.
+The corert harness is in place; what's missing is more MusicXML round-trip input
+files. Sources to consider — public test suites, hand-curated edge cases targeting
+spec features not yet exercised, generated/fuzzed inputs. No design yet. First M4
+session scopes this with the user.
 
 ## Milestone 5: better-gen — fix garbage
 
-The generator is ~12k lines of bad Python. Refactor. Use the corert suite as the
+The generator is ~14k lines of bad Python. Refactor. Use the corert suite as the
 correctness oracle.
 
 ## Milestone 6: mxml4-types — generate MusicXML 4.0 types
 
 Replace `docs/musicxml.xsd` with MusicXML 4.0, regenerate, fix all existing tests.
 Watch for backported / bolted-on features (SMuFL, `UpDown`, …) that were added with
-hacks to 3.0/3.1 but are first-class in 4.0. Be backward-compatible with files mx may
-have written using those hacks. Restore the `mx/impl` TODOs left from revgen.
+hacks to 3.0/3.1 but are first-class in 4.0. Be backward-compatible with files mx
+may have written using those hacks. Restore the `mx/impl` TODOs left from revgen.

--- a/docs/ai/projects/gen/plan.md
+++ b/docs/ai/projects/gen/plan.md
@@ -19,7 +19,17 @@ One WEIRD item deferred to M5: original `mx/core` had a hand-applied MusicXML 4.
 backport that a schema-faithful 3.x regen overwrites. The `// TODO: fixme - MusicXML 4.0 ...`
 comments in `mx/impl` (NotationsWriter.cpp:398, ArpeggiateFunctions.cpp:35) bookmark this.
 
-## Milestone 3: fix-core-dev - fix bugs surfaced by new core-dev test mode
+## Milestone 3: fix-core-dev - fix bugs surfaced by new core-dev test mode ✅
+
+**Complete** (2026-05-22). All gates green. Final iteration (5) fixed the `slash`/`beat-repeat`
+slash-type emission bug — the writer unconditionally emitted `<slash-type>eighth</slash-type>` even
+though the XSD `slash` group is `minOccurs="0"`. Removed two `CHILD_MIN_OCCURS_OVERRIDE` entries
+in gen, regenerated `Slash.{h,cpp}` and `BeatRepeat.{h,cpp}` with a `myHasSlashType` flag, removed
+a matching `addChildIfNone` workaround in the api-import test harness, and added 6 surgical
+`setHasSlashType(true)` calls to 4 `mxtest/core/*Test.cpp` fixture files. Commits d43a222c and
+9c8efa24.
+
+### Session sequence (kept for reference)
 
 Session sequence:
 - `rm -rf data/testOutput/*`
@@ -50,8 +60,13 @@ Session sequence:
 
 ## Milestone 4: increase test coverage
 
-Add a lot more MusicXML round-trip input files. Build a dedicated mx/core-level round-trip test
-harness (not just api-level freezing tests). No specific design yet.
+The dedicated mx/core-level round-trip harness now exists (the corert suite under
+`src/private/mxtest/corert/`, exercised by `make test-core-dev` and as part of `make test-all`),
+built out during M3. The harness side of the original M4 statement is therefore done.
+
+What remains: add a lot more MusicXML round-trip input files. Public test suites, hand-curated
+edge cases, or generated inputs targeting specific spec features not yet covered. No specific
+design yet — first M4 session should scope this with the user.
 
 ## Milestone 5: better-gen — fix garbage
 

--- a/docs/ai/projects/gen/plan.md
+++ b/docs/ai/projects/gen/plan.md
@@ -19,19 +19,48 @@ One WEIRD item deferred to M5: original `mx/core` had a hand-applied MusicXML 4.
 backport that a schema-faithful 3.x regen overwrites. The `// TODO: fixme - MusicXML 4.0 ...`
 comments in `mx/impl` (NotationsWriter.cpp:398, ArpeggiateFunctions.cpp:35) bookmark this.
 
-## Milestone 3: increase test coverage
+## Milestone 3: fix-core-dev - fix bugs surfaced by new core-dev test mode
+
+Session sequence:
+- `rm -rf data/testOutput/*`
+- run `make test-core-dev` : record the number of falures as baseline_core_dev
+- run `make test` : record the number of failures as baseline_test (should be zero)
+- diff each before/after pair in `data/testOutput/corert` and choose the one with the smallest diff.
+  This becomes test_to_fix
+- analyze test_to_fix and try to decide, is this a bug in `gen/*`? For context, bugs in my original
+  hand-rolled gen efforts were dutifly replicated by revgen. So, for example `lang="it"` as default
+  is not a sensible behavior for the library. It is a bug that preexisted before revgen. There are
+  other potential cases, for example defaulting to having an element present when minOcurrs=0 in the
+  spec.
+  - If you think this is a pre-existing bug reproduced by revgen, it might be worth checking with
+    the user to save us all time and tokens, unless you're really sure that a MusicXML file
+    shouldn't be the way that we are treating it right now
+  - If you think this is just a bug in the way revgen decided what to do, that's a no-brainer, it
+    should be fixed
+- When the bug is fixed
+  - run `gen` to regenerate mx/core
+  - `make fmt`
+  - `make check`
+  - `rm -rf data/testOutput/*`
+  - `make test-core-dev` : you must see that you fixed the test you were trying to fix without introducing any new failures
+  - `make test` : should still be at zero failures
+- Commit your work
+- update state.md and any tracking documents you decide to use.
+- report done
+
+## Milestone 4: increase test coverage
 
 Add a lot more MusicXML round-trip input files. Build a dedicated mx/core-level round-trip test
 harness (not just api-level freezing tests). No specific design yet.
 
-## Milestone 4: better-gen — fix garbage
+## Milestone 5: better-gen — fix garbage
 
 The gen program is 12k lines of bad Python. Fix it. Use dedicated mx/core round-trip tests as the
 north star for correctness.
 
-## Milestone 5: mxml4-types — generate MusicXML 4.0 types
+## Milestone 6: mxml4-types — generate MusicXML 4.0 types
 
 Replace `docs/musicxml.xsd` with MusicXML 4.0, regenerate, fix all existing tests. Watch for
-backported or bolted-on features (SMuFL, UpDown, etc.) that were added with hacks to 3.0/3.1 but
-are first-class in 4.0. Be backward-compatible with files `mx` may have written using those hacks.
+backported or bolted-on features (SMuFL, UpDown, etc.) that were added with hacks to 3.0/3.1 but are
+first-class in 4.0. Be backward-compatible with files `mx` may have written using those hacks.
 Restore the `mx/impl` TODOs from revgen.

--- a/docs/ai/projects/gen/state.md
+++ b/docs/ai/projects/gen/state.md
@@ -2,62 +2,12 @@
 
 ## Milestone
 
-**M3 complete** (2026-05-22). All gates green: `make test-core-dev` 350/350,
-`make test` 234/234 (2717 assertions), `make test-all` 3028/3028 (9914 assertions),
-`make check` passed. Final M3 commits: `d43a222c`, `9c8efa24`, `6c4e18d4`.
-See `log.md` for detail.
+**M3 complete** (2026-05-22).
 
 ## What the next session should do (M4 kickoff)
 
-Start M4: increase test coverage. The corert harness now exists; what's missing
-is more MusicXML round-trip input files.
-
-First task is scoping with the user, not coding. Topics:
-
-- Where do additional files come from? Public test suites (Lilypond, MuseScore
-  corpora, W3C samples), hand-curated edge cases targeting specific XSD features,
-  generated/fuzzed inputs.
-- What's the coverage goal? Count of files, or coverage of specific spec features
-  not yet exercised? Is there a way to measure XSD-feature coverage of the
-  current corpus?
-- Where do new files live? Existing convention: subdirectories of `data/`,
-  picked up automatically by corert (`CoreRoundtripImpl.cpp::discoverInputFiles`)
-  unless excluded (`expected/`, `testOutput/`, `generalxml/`, `smufl/`) or
-  marked `.invalid`.
-
-Ask the user before designing.
+TODO: edit this
 
 ## Gotchas to carry forward
 
-- **HEAD `UpDownNone` backport** in `ArpeggiateAttributes.h` conflicts with a
-  schema-faithful regen. Stays invisible as long as M4 doesn't regen. Lives until
-  M5/M6.
-- **Hand-written vs generated.** Files directly under `src/private/mx/core/`
-  (e.g. `XsString.cpp`, `CommaSeparatedPositiveIntegers.cpp`) are mostly
-  hand-written; files under `src/private/mx/core/elements/` are codegen output.
-  `gen/generate.py` references hand-written ones by header path only; bugs in
-  them are fixed in-place, no regen.
-- **`make test-all` is the authoritative gate** for changes touching
-  `src/private/mx/core/*`. `make test` skips the slow `mxtest/file/`
-  round-trippers. `make test-core-dev` is the daily driver for core-only work.
-- **Generator formatting drift.** Even with no semantic gen changes,
-  `python3 gen/generate.py` can produce different clang-format line wrapping
-  than HEAD. Always `make fmt` after regenerating; expect only the
-  semantically-changed files to remain in `git diff` afterwards.
-- **Test cases vs test harness.** "Never change tests" applies to test cases.
-  Harness code (normalization, discovery, expected-file generation) is fair
-  game with user authorization; default to flagging before changing.
-- **Validating against MusicXML XSD with `xmllint`.** The schema imports
-  `xml.xsd` and `xlink.xsd` from URLs that 404. Workaround:
-  `curl -sSf -o /tmp/xml.xsd https://www.w3.org/2001/xml.xsd`,
-  `curl -sSf -o /tmp/xlink.xsd https://www.w3.org/1999/xlink.xsd`,
-  copy `docs/musicxml.xsd` to `/tmp/mx.xsd` and `sed` the two `schemaLocation`
-  values to the local paths, then `xmllint --noout --schema /tmp/mx.xsd <file>`.
-- **`.invalid` marker convention.** Sibling file `{file}.invalid` next to any
-  MusicXML input that is intentionally not schema-valid. Body is a
-  human-readable explanation. Corert skips them; api import does not.
-  Documented in `data/README.md`.
-- **`make fmt` runs in Docker** and may time out on first pull. Retry.
-- **`CHILD_MIN_OCCURS_OVERRIDE` is now empty** but the mechanism remains.
-  Useful escape hatch if another hand-rolled "always-present optional"
-  surfaces.
+TODO: edit this

--- a/docs/ai/projects/gen/state.md
+++ b/docs/ai/projects/gen/state.md
@@ -2,90 +2,92 @@
 
 ## Milestone
 
-**M3: fix-core-dev** in progress. After iteration 4:
-`make test-core-dev` = 1 failed (down from 2); `make test` = 0 failed;
-`make test-all` = 1 failed (3027/3028 cases).
+**M3: fix-core-dev** complete (2026-05-22). All gates green:
+- `make test-core-dev` = 350/350
+- `make test` = 234/234 (2717 assertions)
+- `make test-all` = 3028/3028 (9914 assertions)
+- `make check` passed
 
-## What the previous session did (M3 iteration 4)
+## What the previous session did (M3 iteration 5, final)
 
-Iteration 4 picked the smallest core-roundtrip diff,
-`lysuite/ly41e_StaffGroups_InstrumentNames_Linebroken.xml` (10-line
-diff). The `<part-name>` text content contained `&#xd;` character
-references (literal CR bytes); on round-trip those became `\n`.
+Tackled the last core-roundtrip failure
+`lysuite/ly22b_Staff_Notestyles.xml`: writer was unconditionally
+emitting `<slash-type>eighth</slash-type>` inside every `<slash>` and
+`<beat-repeat>` element. XSD analysis showed the `slash` group is
+`minOccurs="0"` inside both `complexType slash` and `complexType
+beat-repeat`, so the whole group (including required-within-group
+`slash-type`) is optional. HEAD treated `slash-type` as
+always-present, and the generator preserved this via two
+`CHILD_MIN_OCCURS_OVERRIDE` entries at gen/generate.py:1083-1084.
 
-Root cause: `mx::core::XsString::toStream` in
-`src/private/mx/core/XsString.cpp` escaped only `<`, `>`, `&`. A raw
-`\r` written to the output stream is normalized to `\n` by the next
-parser pass (pugixml `parse_eol`, per XML 1.0 §2.11). The reader path
-was already correct — pugixml expands `&#xd;` into a raw `\r` after
-EOL normalization runs, so `myValue` held the right bytes; only the
-writer dropped them.
+This was exactly the "pre-existing hand-rolled bug replicated by
+revgen" category flagged in plan.md M3.
 
-Fix: added a `'\r'` case emitting `"&#xd;"` to the escape switch.
-Hand-written type, no regen needed. Committed as `040b2152`.
+Three changes (commit d43a222c "fix gen code"):
+1. Removed both `CHILD_MIN_OCCURS_OVERRIDE` entries; regenerated
+   `mx/core`. Only `Slash.{h,cpp}` and `BeatRepeat.{h,cpp}` got
+   semantic diffs (myHasSlashType flag + gated emission); the other
+   ~227 files were pure clang-format drift resolved by `make fmt`.
+2. `src/private/mxtest/import/ExpectedFiles.cpp` had
+   `addChildIfNone(*xdoc, "slash", "slash-type", "eighth")` with a
+   comment claiming the input was XSD-invalid. The opposite is true;
+   removed the patch. This was the "buggy assertion" the user
+   anticipated finding — turned out to be in the api-import test
+   harness, not in `mx/api` (which doesn't reference these elements).
 
-## One remaining failure
+One follow-up change (commit 9c8efa24 "mxtest/core: set
+has-slash-type flag explicitly..."): `make test-all` then surfaced 25
+assertion failures in 23 `mxtest/core/*Test.cpp` cases. None in
+api-import or core-roundtrip — only per-element fixture tests built
+under `MX_BUILD_CORE_TESTS=ON`. Two categories: tests that
+default-constructed a Slash/BeatRepeat and asserted the buggy
+default stream (SlashTest, BeatRepeatTest); and fixtures that called
+`getSlashType()->setValue(...)` without `setHasSlashType(true)`
+(MeasureStyleTest, PropertiesTest + 9 cascades through the shared
+`tgenProperties` builder). User authorized minimal surgical
+`setHasSlashType(true)` additions; 6 edits across 4 files (the
+PropertiesTest edit cascades to 11 files).
 
-`lysuite/ly22b_Staff_Notestyles.xml` (24-line diff): child count
-mismatch inside `measure-style` at
-`/score-partwise/part[2]/measure[0]/attributes[2]/measure-style[0]/slash[0]`.
-This is the last `make test-core-dev` failure and the last
-`make test-all` failure. **Next session target.**
+## What the next session should do (M4)
 
-## What the next session should do (M3 iteration 5)
+Start M4: increase test coverage. From plan.md: "Add a lot more
+MusicXML round-trip input files. Build a dedicated mx/core-level
+round-trip test harness (not just api-level freezing tests). No
+specific design yet."
 
-Per `plan.md` M3 session sequence:
+The dedicated core round-trip harness now exists (the corert suite
+under `src/private/mxtest/corert/`, exercised by `make
+test-core-dev` and as part of `make test-all`). M4's design needs
+revision: the harness exists, what's missing is more coverage.
+First session task is probably scoping: where do additional
+MusicXML files come from (public test suites, generated fuzzing
+inputs, hand-curated edge cases)? What's the goal — N more files
+of a particular shape, or coverage of specific spec features not
+yet exercised?
 
-1. `rm -rf data/testOutput/*`
-2. `make test-core-dev` — record failure count as baseline_core_dev
-   (expect 1).
-3. `make test` — expect 0.
-4. Diff `lysuite_ly22b_Staff_Notestyles.xml.{expected,actual}.xml` in
-   `data/testOutput/corert` — it's the only failure. That is
-   `test_to_fix`. Report to user with one-paragraph analysis. One test
-   per session.
-5. Wait for user direction before fixing. This one has a child-count
-   mismatch inside `measure-style/slash`, which suggests it could be
-   either: a missing optional child the writer is emitting, or an
-   optional child the reader is not emitting; check both the XSD shape
-   of `measure-style` (sequence vs choice, minOccurs) and the
-   generated `MeasureStyle.cpp` / `Slash.cpp` against the input file.
-6. After fix: if the fix was in `gen/`, regen `mx/core`; otherwise
-   skip regen. Then `make fmt`, `make check`, `make test-core-dev`,
-   `make test`, `make test-all` (since the fix will almost certainly
-   touch `src/private/mx/core/`).
+Ask the user before designing.
 
 ## Gotchas
 
-- **`.invalid` marker convention**: if a corert failure is caused by
-  intentionally invalid MusicXML, the right move is a `{file}.invalid`
-  marker, not code. ly22b looks like a real bug (child-count
-  mismatch, not a structural validity issue), but confirm by running
-  `xmllint --noout --schema /tmp/mx.xsd
-  data/lysuite/ly22b_Staff_Notestyles.xml` first.
-- **Validating against the MusicXML XSD with xmllint**: the XSD
-  imports `http://www.musicxml.org/xsd/xml.xsd` and `xlink.xsd` which
-  404 today. Workaround:
-  - `curl -sSf -o /tmp/xml.xsd https://www.w3.org/2001/xml.xsd`
-  - `curl -sSf -o /tmp/xlink.xsd https://www.w3.org/1999/xlink.xsd`
-  - copy `docs/musicxml.xsd` to `/tmp/mx.xsd` and `sed` the two
-    `schemaLocation` values to `/tmp/xml.xsd` and `/tmp/xlink.xsd`.
-  - then `xmllint --noout --schema /tmp/mx.xsd <file>`.
-- **One test per session.** Do not try to fix multiple failures in
-  one session even if they share a root cause.
+- **HEAD `UpDownNone` backport** in `ArpeggiateAttributes.h` still
+  conflicts with a schema-faithful regen. Invisible as long as M4
+  doesn't trigger a regen. M5 territory.
 - **Hand-written vs generated.** Files directly under
-  `src/private/mx/core/` (e.g. `XsString.cpp`,
-  `CommaSeparatedPositiveIntegers.cpp`) are mostly hand-written; files
-  under `src/private/mx/core/elements/` are codegen output.
-  `gen/generate.py` only references the hand-written ones by header
-  path. Bugs in hand-written types are fixed in-place, no regen.
-- **Don't touch tests carelessly.** "Never change tests" applies to
-  test cases. Test infrastructure (normalization, harness, discovery)
-  is fair game when authorized; default to flagging before changing.
-- **`make test-all` is the M2 gate; `make test-core-dev` is the M3
-  daily driver.** Anything under `src/private/mx/core/` requires
-  `test-all` per AGENTS.md.
-- **HEAD has a hand-applied UpDownNone backport** in
-  `ArpeggiateAttributes.h` that conflicts with a schema-faithful
-  regen. Invisible as long as M3 changes don't require regen.
-- **`make fmt` runs in Docker** and may time out on first pull. Retry.
+  `src/private/mx/core/` are mostly hand-written; files under
+  `src/private/mx/core/elements/` are codegen output.
+- **`make test-all` is the M2/M3 gate**; `make test-core-dev` is
+  the daily driver for core-only changes.
+- **Generator non-determinism / formatting drift.** Even with no
+  semantic gen changes, `python3 gen/generate.py` can produce
+  files with different clang-format line wrapping than HEAD.
+  Always run `make fmt` after regenerating; expect only the
+  semantically-changed files to remain in `git diff` after that.
+- **Test harness is fair game with authorization** (e.g.,
+  `ExpectedFiles.cpp` in this session). Test cases are not —
+  but per M3 charter, tests that purely codify the bug being
+  fixed are eligible for minimal adjustment with explicit user
+  approval.
+- **`make fmt` runs in Docker** and may time out on first pull.
+- **CHILD_MIN_OCCURS_OVERRIDE is now empty** but the mechanism
+  remains in gen/generate.py. Useful escape hatch if another
+  hand-rolled override surfaces in M4/M5.

--- a/docs/ai/projects/gen/state.md
+++ b/docs/ai/projects/gen/state.md
@@ -2,92 +2,62 @@
 
 ## Milestone
 
-**M3: fix-core-dev** complete (2026-05-22). All gates green:
-- `make test-core-dev` = 350/350
-- `make test` = 234/234 (2717 assertions)
-- `make test-all` = 3028/3028 (9914 assertions)
-- `make check` passed
+**M3 complete** (2026-05-22). All gates green: `make test-core-dev` 350/350,
+`make test` 234/234 (2717 assertions), `make test-all` 3028/3028 (9914 assertions),
+`make check` passed. Final M3 commits: `d43a222c`, `9c8efa24`, `6c4e18d4`.
+See `log.md` for detail.
 
-## What the previous session did (M3 iteration 5, final)
+## What the next session should do (M4 kickoff)
 
-Tackled the last core-roundtrip failure
-`lysuite/ly22b_Staff_Notestyles.xml`: writer was unconditionally
-emitting `<slash-type>eighth</slash-type>` inside every `<slash>` and
-`<beat-repeat>` element. XSD analysis showed the `slash` group is
-`minOccurs="0"` inside both `complexType slash` and `complexType
-beat-repeat`, so the whole group (including required-within-group
-`slash-type`) is optional. HEAD treated `slash-type` as
-always-present, and the generator preserved this via two
-`CHILD_MIN_OCCURS_OVERRIDE` entries at gen/generate.py:1083-1084.
+Start M4: increase test coverage. The corert harness now exists; what's missing
+is more MusicXML round-trip input files.
 
-This was exactly the "pre-existing hand-rolled bug replicated by
-revgen" category flagged in plan.md M3.
+First task is scoping with the user, not coding. Topics:
 
-Three changes (commit d43a222c "fix gen code"):
-1. Removed both `CHILD_MIN_OCCURS_OVERRIDE` entries; regenerated
-   `mx/core`. Only `Slash.{h,cpp}` and `BeatRepeat.{h,cpp}` got
-   semantic diffs (myHasSlashType flag + gated emission); the other
-   ~227 files were pure clang-format drift resolved by `make fmt`.
-2. `src/private/mxtest/import/ExpectedFiles.cpp` had
-   `addChildIfNone(*xdoc, "slash", "slash-type", "eighth")` with a
-   comment claiming the input was XSD-invalid. The opposite is true;
-   removed the patch. This was the "buggy assertion" the user
-   anticipated finding — turned out to be in the api-import test
-   harness, not in `mx/api` (which doesn't reference these elements).
-
-One follow-up change (commit 9c8efa24 "mxtest/core: set
-has-slash-type flag explicitly..."): `make test-all` then surfaced 25
-assertion failures in 23 `mxtest/core/*Test.cpp` cases. None in
-api-import or core-roundtrip — only per-element fixture tests built
-under `MX_BUILD_CORE_TESTS=ON`. Two categories: tests that
-default-constructed a Slash/BeatRepeat and asserted the buggy
-default stream (SlashTest, BeatRepeatTest); and fixtures that called
-`getSlashType()->setValue(...)` without `setHasSlashType(true)`
-(MeasureStyleTest, PropertiesTest + 9 cascades through the shared
-`tgenProperties` builder). User authorized minimal surgical
-`setHasSlashType(true)` additions; 6 edits across 4 files (the
-PropertiesTest edit cascades to 11 files).
-
-## What the next session should do (M4)
-
-Start M4: increase test coverage. From plan.md: "Add a lot more
-MusicXML round-trip input files. Build a dedicated mx/core-level
-round-trip test harness (not just api-level freezing tests). No
-specific design yet."
-
-The dedicated core round-trip harness now exists (the corert suite
-under `src/private/mxtest/corert/`, exercised by `make
-test-core-dev` and as part of `make test-all`). M4's design needs
-revision: the harness exists, what's missing is more coverage.
-First session task is probably scoping: where do additional
-MusicXML files come from (public test suites, generated fuzzing
-inputs, hand-curated edge cases)? What's the goal — N more files
-of a particular shape, or coverage of specific spec features not
-yet exercised?
+- Where do additional files come from? Public test suites (Lilypond, MuseScore
+  corpora, W3C samples), hand-curated edge cases targeting specific XSD features,
+  generated/fuzzed inputs.
+- What's the coverage goal? Count of files, or coverage of specific spec features
+  not yet exercised? Is there a way to measure XSD-feature coverage of the
+  current corpus?
+- Where do new files live? Existing convention: subdirectories of `data/`,
+  picked up automatically by corert (`CoreRoundtripImpl.cpp::discoverInputFiles`)
+  unless excluded (`expected/`, `testOutput/`, `generalxml/`, `smufl/`) or
+  marked `.invalid`.
 
 Ask the user before designing.
 
-## Gotchas
+## Gotchas to carry forward
 
-- **HEAD `UpDownNone` backport** in `ArpeggiateAttributes.h` still
-  conflicts with a schema-faithful regen. Invisible as long as M4
-  doesn't trigger a regen. M5 territory.
-- **Hand-written vs generated.** Files directly under
-  `src/private/mx/core/` are mostly hand-written; files under
-  `src/private/mx/core/elements/` are codegen output.
-- **`make test-all` is the M2/M3 gate**; `make test-core-dev` is
-  the daily driver for core-only changes.
-- **Generator non-determinism / formatting drift.** Even with no
-  semantic gen changes, `python3 gen/generate.py` can produce
-  files with different clang-format line wrapping than HEAD.
-  Always run `make fmt` after regenerating; expect only the
-  semantically-changed files to remain in `git diff` after that.
-- **Test harness is fair game with authorization** (e.g.,
-  `ExpectedFiles.cpp` in this session). Test cases are not —
-  but per M3 charter, tests that purely codify the bug being
-  fixed are eligible for minimal adjustment with explicit user
-  approval.
-- **`make fmt` runs in Docker** and may time out on first pull.
-- **CHILD_MIN_OCCURS_OVERRIDE is now empty** but the mechanism
-  remains in gen/generate.py. Useful escape hatch if another
-  hand-rolled override surfaces in M4/M5.
+- **HEAD `UpDownNone` backport** in `ArpeggiateAttributes.h` conflicts with a
+  schema-faithful regen. Stays invisible as long as M4 doesn't regen. Lives until
+  M5/M6.
+- **Hand-written vs generated.** Files directly under `src/private/mx/core/`
+  (e.g. `XsString.cpp`, `CommaSeparatedPositiveIntegers.cpp`) are mostly
+  hand-written; files under `src/private/mx/core/elements/` are codegen output.
+  `gen/generate.py` references hand-written ones by header path only; bugs in
+  them are fixed in-place, no regen.
+- **`make test-all` is the authoritative gate** for changes touching
+  `src/private/mx/core/*`. `make test` skips the slow `mxtest/file/`
+  round-trippers. `make test-core-dev` is the daily driver for core-only work.
+- **Generator formatting drift.** Even with no semantic gen changes,
+  `python3 gen/generate.py` can produce different clang-format line wrapping
+  than HEAD. Always `make fmt` after regenerating; expect only the
+  semantically-changed files to remain in `git diff` afterwards.
+- **Test cases vs test harness.** "Never change tests" applies to test cases.
+  Harness code (normalization, discovery, expected-file generation) is fair
+  game with user authorization; default to flagging before changing.
+- **Validating against MusicXML XSD with `xmllint`.** The schema imports
+  `xml.xsd` and `xlink.xsd` from URLs that 404. Workaround:
+  `curl -sSf -o /tmp/xml.xsd https://www.w3.org/2001/xml.xsd`,
+  `curl -sSf -o /tmp/xlink.xsd https://www.w3.org/1999/xlink.xsd`,
+  copy `docs/musicxml.xsd` to `/tmp/mx.xsd` and `sed` the two `schemaLocation`
+  values to the local paths, then `xmllint --noout --schema /tmp/mx.xsd <file>`.
+- **`.invalid` marker convention.** Sibling file `{file}.invalid` next to any
+  MusicXML input that is intentionally not schema-valid. Body is a
+  human-readable explanation. Corert skips them; api import does not.
+  Documented in `data/README.md`.
+- **`make fmt` runs in Docker** and may time out on first pull. Retry.
+- **`CHILD_MIN_OCCURS_OVERRIDE` is now empty** but the mechanism remains.
+  Useful escape hatch if another hand-rolled "always-present optional"
+  surfaces.

--- a/docs/ai/projects/gen/state.md
+++ b/docs/ai/projects/gen/state.md
@@ -2,98 +2,98 @@
 
 ## Milestone
 
-**M3: fix-core-dev** in progress. After iteration 2 + sweep:
-`make test-core-dev` = 3 failed (down from 13); `make test` = 0 failed.
+**M3: fix-core-dev** in progress. After iteration 3:
+`make test-core-dev` = 2 failed (down from 3); `make test` = 0 failed;
+`make test-all` = 2 failed (3026/3028 cases).
 
-## What the previous session did (M3 iteration 2 + invalid-marker sweep)
+## What the previous session did (M3 iteration 3)
 
-Iteration 2 picked the smallest core-roundtrip diff
-(`musuite/testInvalid.xml`, 4 lines, two non-XSD elements dropped on
-`fromXDoc`). Not a bug — the file is intentionally invalid MusicXML and
-self-documents that fact. A strongly-typed schema-generated DOM cannot
-preserve unknown elements without an architectural passthrough we do not
-want.
+Iteration 3 picked the smallest core-roundtrip diff,
+`lysuite/ly45f_Repeats_InvalidEndings.xml` (8 lines). The `ending`
+element's `number` attribute was round-tripping `"1, 2, 3"` →
+`"1,2,3"`. The XSD `ending-number` pattern
+`[1-9][0-9]*(, ?[1-9][0-9]*)*` allows both forms; the library was
+losing the lexical choice on import.
 
-Per user direction introduced a repo-wide marker convention: a sibling
-file `{file}.invalid` next to any invalid MusicXML input, body is a
-human-readable explanation. Documented in `data/README.md`. Updated
-`src/private/mxtest/corert/CoreRoundtripImpl.cpp::discoverInputFiles` to
-skip any input with a sibling `.invalid` marker. Committed as
-`b62b663f`.
+Root cause: `CommaSeparatedListOfPositiveIntegers::parse` in
+`src/private/mx/core/CommaSeparatedPositiveIntegers.cpp` ran
+`onlyAllow(text, "", "1234567890,-")` (strips spaces) before
+tokenising and never set `myIsSpacingDesired`, so output always took
+the compact form. `toStream` already handled both forms; only import
+needed the fix.
 
-Sweep: ran xmllint --schema against the MusicXML XSD (with xml.xsd /
-xlink.xsd downloaded locally to /tmp and schema imports rewritten in a
-working copy at /tmp/mx.xsd) for every failing corert input. For each
-file, cross-checked the schema violation against the corert diff
-symptom. Marked a file only when the schema violation explains the
-round-trip diff. Ten more files got markers; three remained as genuine
-library bugs on schema-valid input.
+The type is hand-written, not generated — `gen/generate.py` only maps
+its header path as a dependency. Fix lives directly in the .cpp.
 
-## Three remaining real bugs (candidates for iteration 3+)
+Fix: scan the raw input for digit-comma-space-digit and set
+`myIsSpacingDesired` accordingly. Narrow detection (requires digits on
+both sides of `", "`) so the existing
+`StringsTest::EndingNumber02` case — which feeds junk and expects
+`"1,2,3"` out — stays green. Added `#include <cctype>`. Committed as
+`461b96d2`.
 
-These are schema-valid inputs whose round-trip diff is a real library
-bug. Pick the smallest next session.
+## Two remaining real bugs
 
-1. `lysuite/ly41e_StaffGroups_InstrumentNames_Linebroken.xml` (10-line
-   diff): `part-name` text mismatch. Likely the library normalizing
-   linebroken text content.
-2. `lysuite/ly45f_Repeats_InvalidEndings.xml` (8-line diff): ending
-   `number` attribute `"1, 2, 3"` round-trips as `"1,2,3"`. Despite the
-   "Invalid" in the filename, the schema's `ending-number` pattern
-   `[1-9][0-9]*(, ?[1-9][0-9]*)*` allows both forms. Library is dropping
-   spaces.
-3. `lysuite/ly22b_Staff_Notestyles.xml` (24-line diff): child count
+1. `lysuite/ly41e_StaffGroups_InstrumentNames_Linebroken.xml`
+   (10-line diff): `part-name` text mismatch. Library normalizing
+   linebroken text content. **Next session target.**
+2. `lysuite/ly22b_Staff_Notestyles.xml` (24-line diff): child count
    mismatch inside `measure-style` (attributes block, measure[0]).
 
-## What the next session should do (M3 iteration 3)
+## What the next session should do (M3 iteration 4)
 
 Per `plan.md` M3 session sequence:
 
 1. `rm -rf data/testOutput/*`
 2. `make test-core-dev` — record failure count as baseline_core_dev
-   (should be 3).
+   (should be 2).
 3. `make test` — should be 0.
-4. Diff each pair in `data/testOutput/corert` and pick the smallest diff.
-   That is `test_to_fix`. Report it to the user with a one-paragraph
-   analysis. One test per session.
+4. Diff each pair in `data/testOutput/corert` and pick the smallest.
+   That is `test_to_fix` (expected: `ly41e_StaffGroups_...`). Report
+   to user with one-paragraph analysis. One test per session.
 5. Wait for user direction before fixing.
 6. After fix: regen `mx/core` if the fix was in `gen/`, `make fmt`,
-   `make check`, then re-run baselines.
+   `make check`, then re-run `make test-core-dev` and `make test`. If
+   the fix touched anything under `src/private/mx/core/`, also run
+   `make test-all` (the AGENTS.md rule).
 
 ## Gotchas
 
 - **`.invalid` marker convention**: if you encounter a test failure
-  caused by intentionally invalid MusicXML input, the right move is
-  usually a `{file}.invalid` marker, not a code change. The sweep this
-  session covered every file failing under iteration 2's baseline, so a
-  *new* corert failure is most likely a real library bug; still confirm
-  by reading the file and running xmllint --schema against
-  `/tmp/mx.xsd` (or rebuild it from `docs/musicxml.xsd` per the recipe
-  below).
-- **Validating against the MusicXML XSD with xmllint**: the XSD imports
-  `http://www.musicxml.org/xsd/xml.xsd` and `xlink.xsd` which 404 today.
-  Workaround used this session:
+  caused by intentionally invalid MusicXML input, the right move is a
+  `{file}.invalid` marker, not a code change. The iteration-2 sweep
+  covered every then-failing file, so a *new* corert failure is most
+  likely a real library bug; confirm by reading the file and running
+  xmllint --schema against `/tmp/mx.xsd` (recipe below).
+- **Validating against the MusicXML XSD with xmllint**: the XSD
+  imports `http://www.musicxml.org/xsd/xml.xsd` and `xlink.xsd` which
+  404 today. Workaround:
   - `curl -sSf -o /tmp/xml.xsd https://www.w3.org/2001/xml.xsd`
   - `curl -sSf -o /tmp/xlink.xsd https://www.w3.org/1999/xlink.xsd`
   - copy `docs/musicxml.xsd` to `/tmp/mx.xsd` and `sed` the two
-    `schemaLocation` values to point at `/tmp/xml.xsd` and
-    `/tmp/xlink.xsd`.
+    `schemaLocation` values to `/tmp/xml.xsd` and `/tmp/xlink.xsd`.
   - then `xmllint --noout --schema /tmp/mx.xsd <file>`.
-- **One test per session.** Do not try to fix multiple failures in one
-  session even if they share a root cause; the user wants explicit
-  attention on each.
-- **Don't touch tests carelessly.** The cardinal rule "never change
-  tests" applies to test cases. Test infrastructure (normalization
-  helpers, harness code, discovery rules) is fair game when the user
-  authorizes; default to flagging before changing.
-- **`make test-all` is the M2 gate, `make test-core-dev` is the M3 daily
-  driver.** `make test-core-dev` is faster and surfaces the corert
-  failures; `make test` (api import + others) must also stay at zero
-  each iteration.
+- **One test per session.** Do not try to fix multiple failures in
+  one session even if they share a root cause.
+- **Hand-written types vs generated types.** Some `mx/core` files
+  (e.g. `CommaSeparatedPositiveIntegers.cpp`, `EndingNumber.h`) are
+  hand-written and only referenced as a dependency mapping in
+  `gen/generate.py`. Bugs in those files are fixed in the .cpp/.h
+  directly, no regen. Check whether the file appears under
+  `src/private/mx/core/elements/` (generated) vs the parent
+  `src/private/mx/core/` (mostly hand-written core types).
+- **Don't touch tests carelessly.** The "never change tests" rule
+  applies to test cases. Test infrastructure (normalization helpers,
+  harness code, discovery rules) is fair game when authorized;
+  default to flagging before changing.
+- **`make test-all` is the M2 gate, `make test-core-dev` is the M3
+  daily driver.** test-core-dev surfaces the corert failures fast;
+  `make test` (api import + others) must also stay at zero each
+  iteration. If a fix touches anything under
+  `src/private/mx/core/`, also run `make test-all` per AGENTS.md.
 - **HEAD has a hand-applied UpDownNone backport** in
-  `ArpeggiateAttributes.h` that conflicts with a schema-faithful regen.
-  As long as M3 changes do not require regen this is invisible; if a
-  generator fix is needed, follow M2's workflow (`python3 gen/generate.py
-  && make fmt` THEN test, reset after).
+  `ArpeggiateAttributes.h` that conflicts with a schema-faithful
+  regen. As long as M3 changes do not require regen this is
+  invisible; if a generator fix is needed, follow M2's workflow.
 - **`make fmt` runs in Docker** and may time out on first pull
   (registry latency). Just retry.

--- a/docs/ai/projects/gen/state.md
+++ b/docs/ai/projects/gen/state.md
@@ -2,52 +2,98 @@
 
 ## Milestone
 
-**M3: fix-core-dev** in progress. After iteration 1: `make test-core-dev` = 14 failed
-(down from 31); `make test` = 0 failed.
+**M3: fix-core-dev** in progress. After iteration 2 + sweep:
+`make test-core-dev` = 3 failed (down from 13); `make test` = 0 failed.
 
-## What the previous session did (M3 iteration 1)
+## What the previous session did (M3 iteration 2 + invalid-marker sweep)
 
-Picked the smallest core-roundtrip diff (`foundsuite_Invention 2.xml`, 4 lines:
-`width="564.40"` vs `width="564.4"`). Root cause: hand-written
-`PreciseDecimal::toStream` in `src/private/mx/core/Decimals.cpp` strips trailing zeros
-on tenths-typed values. The test harness already normalizes 9 other tenths fields
-via `mxtest::stripZerosFromDecimalFields` (set in
-`src/private/mxtest/import/DecimalFields.h`); `width` was missing from the set.
+Iteration 2 picked the smallest core-roundtrip diff
+(`musuite/testInvalid.xml`, 4 lines, two non-XSD elements dropped on
+`fromXDoc`). Not a bug — the file is intentionally invalid MusicXML and
+self-documents that fact. A strongly-typed schema-generated DOM cannot
+preserve unknown elements without an architectural passthrough we do not
+want.
 
-Per user direction, fixed on the test side rather than changing the library's decimal
-serialization. Added `"width"` to `decimalFields`. Cleared 17 failures (all driven by
-the same pattern across MuseScore/foundsuite files). Committed as `639d46a3`.
+Per user direction introduced a repo-wide marker convention: a sibling
+file `{file}.invalid` next to any invalid MusicXML input, body is a
+human-readable explanation. Documented in `data/README.md`. Updated
+`src/private/mxtest/corert/CoreRoundtripImpl.cpp::discoverInputFiles` to
+skip any input with a sibling `.invalid` marker. Committed as
+`b62b663f`.
 
-## What the next session should do (M3 iteration 2)
+Sweep: ran xmllint --schema against the MusicXML XSD (with xml.xsd /
+xlink.xsd downloaded locally to /tmp and schema imports rewritten in a
+working copy at /tmp/mx.xsd) for every failing corert input. For each
+file, cross-checked the schema violation against the corert diff
+symptom. Marked a file only when the schema violation explains the
+round-trip diff. Ten more files got markers; three remained as genuine
+library bugs on schema-valid input.
+
+## Three remaining real bugs (candidates for iteration 3+)
+
+These are schema-valid inputs whose round-trip diff is a real library
+bug. Pick the smallest next session.
+
+1. `lysuite/ly41e_StaffGroups_InstrumentNames_Linebroken.xml` (10-line
+   diff): `part-name` text mismatch. Likely the library normalizing
+   linebroken text content.
+2. `lysuite/ly45f_Repeats_InvalidEndings.xml` (8-line diff): ending
+   `number` attribute `"1, 2, 3"` round-trips as `"1,2,3"`. Despite the
+   "Invalid" in the filename, the schema's `ending-number` pattern
+   `[1-9][0-9]*(, ?[1-9][0-9]*)*` allows both forms. Library is dropping
+   spaces.
+3. `lysuite/ly22b_Staff_Notestyles.xml` (24-line diff): child count
+   mismatch inside `measure-style` (attributes block, measure[0]).
+
+## What the next session should do (M3 iteration 3)
 
 Per `plan.md` M3 session sequence:
 
 1. `rm -rf data/testOutput/*`
-2. `make test-core-dev` — record failure count as baseline_core_dev (should be 14).
+2. `make test-core-dev` — record failure count as baseline_core_dev
+   (should be 3).
 3. `make test` — should be 0.
-4. Diff each pair in `data/testOutput/corert` and pick the smallest diff. That is
-   `test_to_fix`. Report it to the user with a one-paragraph analysis (root cause:
-   generator bug, pre-existing library quirk, etc.). One test per session.
+4. Diff each pair in `data/testOutput/corert` and pick the smallest diff.
+   That is `test_to_fix`. Report it to the user with a one-paragraph
+   analysis. One test per session.
 5. Wait for user direction before fixing.
 6. After fix: regen `mx/core` if the fix was in `gen/`, `make fmt`,
    `make check`, then re-run baselines.
 
 ## Gotchas
 
-- **One test per session.** Do not try to fix multiple failures in one session even
-  if they share a root cause; the user wants explicit attention on each. A single
-  targeted fix may incidentally clear other failures with the same root cause
-  (iteration 1 cleared 17 with a one-line `decimalFields` addition) \u2014 that's
-  fine, but the focus and analysis must be on the one chosen test.
-- **Don't touch tests carelessly.** The cardinal rule "never change tests" applies
-  to test cases. Test infrastructure (normalization helpers, harness code) is
-  fair game when the user authorizes; default to flagging before changing.
-- **`make test-all` is the M2 gate, `make test-core-dev` is the M3 daily driver.**
-  `make test-core-dev` is faster and surfaces the corert failures; `make test`
-  (api import + others) must also stay at zero each iteration.
-- **HEAD has a hand-applied UpDownNone backport** in `ArpeggiateAttributes.h`
-  that conflicts with a schema-faithful regen. As long as M3 changes do not
-  require regen this is invisible; if a generator fix is needed, follow M2's
-  workflow (`python3 gen/generate.py && make fmt` THEN test, reset after).
-- **`make fmt` runs in Docker** and may time out on first pull (registry latency).
-  Just retry.
+- **`.invalid` marker convention**: if you encounter a test failure
+  caused by intentionally invalid MusicXML input, the right move is
+  usually a `{file}.invalid` marker, not a code change. The sweep this
+  session covered every file failing under iteration 2's baseline, so a
+  *new* corert failure is most likely a real library bug; still confirm
+  by reading the file and running xmllint --schema against
+  `/tmp/mx.xsd` (or rebuild it from `docs/musicxml.xsd` per the recipe
+  below).
+- **Validating against the MusicXML XSD with xmllint**: the XSD imports
+  `http://www.musicxml.org/xsd/xml.xsd` and `xlink.xsd` which 404 today.
+  Workaround used this session:
+  - `curl -sSf -o /tmp/xml.xsd https://www.w3.org/2001/xml.xsd`
+  - `curl -sSf -o /tmp/xlink.xsd https://www.w3.org/1999/xlink.xsd`
+  - copy `docs/musicxml.xsd` to `/tmp/mx.xsd` and `sed` the two
+    `schemaLocation` values to point at `/tmp/xml.xsd` and
+    `/tmp/xlink.xsd`.
+  - then `xmllint --noout --schema /tmp/mx.xsd <file>`.
+- **One test per session.** Do not try to fix multiple failures in one
+  session even if they share a root cause; the user wants explicit
+  attention on each.
+- **Don't touch tests carelessly.** The cardinal rule "never change
+  tests" applies to test cases. Test infrastructure (normalization
+  helpers, harness code, discovery rules) is fair game when the user
+  authorizes; default to flagging before changing.
+- **`make test-all` is the M2 gate, `make test-core-dev` is the M3 daily
+  driver.** `make test-core-dev` is faster and surfaces the corert
+  failures; `make test` (api import + others) must also stay at zero
+  each iteration.
+- **HEAD has a hand-applied UpDownNone backport** in
+  `ArpeggiateAttributes.h` that conflicts with a schema-faithful regen.
+  As long as M3 changes do not require regen this is invisible; if a
+  generator fix is needed, follow M2's workflow (`python3 gen/generate.py
+  && make fmt` THEN test, reset after).
+- **`make fmt` runs in Docker** and may time out on first pull
+  (registry latency). Just retry.

--- a/docs/ai/projects/gen/state.md
+++ b/docs/ai/projects/gen/state.md
@@ -2,26 +2,52 @@
 
 ## Milestone
 
-**M1 and M2 complete.** `make test-all`: 0 failed (2678 cases, 9914 assertions).
+**M3: fix-core-dev** in progress. After iteration 1: `make test-core-dev` = 14 failed
+(down from 31); `make test` = 0 failed.
 
-## What the next session should do
+## What the previous session did (M3 iteration 1)
 
-**Milestone 3: increase test coverage.** Per `plan.md`: more MusicXML round-trip files and a
-dedicated mx/core-level round-trip harness.
+Picked the smallest core-roundtrip diff (`foundsuite_Invention 2.xml`, 4 lines:
+`width="564.40"` vs `width="564.4"`). Root cause: hand-written
+`PreciseDecimal::toStream` in `src/private/mx/core/Decimals.cpp` strips trailing zeros
+on tenths-typed values. The test harness already normalizes 9 other tenths fields
+via `mxtest::stripZerosFromDecimalFields` (set in
+`src/private/mxtest/import/DecimalFields.h`); `width` was missing from the set.
 
-No design yet. Next session should:
-1. Review existing test suite to understand coverage gaps.
-2. Propose a coverage plan to the user.
-3. Wait for user direction before implementing.
+Per user direction, fixed on the test side rather than changing the library's decimal
+serialization. Added `"width"` to `decimalFields`. Cleared 17 failures (all driven by
+the same pattern across MuseScore/foundsuite files). Committed as `639d46a3`.
+
+## What the next session should do (M3 iteration 2)
+
+Per `plan.md` M3 session sequence:
+
+1. `rm -rf data/testOutput/*`
+2. `make test-core-dev` — record failure count as baseline_core_dev (should be 14).
+3. `make test` — should be 0.
+4. Diff each pair in `data/testOutput/corert` and pick the smallest diff. That is
+   `test_to_fix`. Report it to the user with a one-paragraph analysis (root cause:
+   generator bug, pre-existing library quirk, etc.). One test per session.
+5. Wait for user direction before fixing.
+6. After fix: regen `mx/core` if the fix was in `gen/`, `make fmt`,
+   `make check`, then re-run baselines.
 
 ## Gotchas
 
-- **`make test-all` must run WITH generated files present.** HEAD's `ArpeggiateAttributes.h` has
-  a hand-applied `UpDownNone direction` (MusicXML 4.0 backport) but `NotationsWriter.cpp` assigns
-  `UpDown::down` — incompatible. The generator emits `UpDown` (from 3.x XSD), so the build only
-  succeeds with generated files present. Workflow: `python3 gen/generate.py && make fmt` THEN
-  `make test-all`. Reset AFTER it passes.
-- **`git checkout -- src/private/mx/core/` preserves mtimes**, so incremental cmake builds skip
-  recompiling unchanged-mtime .cpp files. Stale-build measurements bit us mid-M2. Use
-  `make clean && make test-all` for an authoritative count.
-- **Use `make test-all`, never `make test`.** Build target for tests is `make core`.
+- **One test per session.** Do not try to fix multiple failures in one session even
+  if they share a root cause; the user wants explicit attention on each. A single
+  targeted fix may incidentally clear other failures with the same root cause
+  (iteration 1 cleared 17 with a one-line `decimalFields` addition) \u2014 that's
+  fine, but the focus and analysis must be on the one chosen test.
+- **Don't touch tests carelessly.** The cardinal rule "never change tests" applies
+  to test cases. Test infrastructure (normalization helpers, harness code) is
+  fair game when the user authorizes; default to flagging before changing.
+- **`make test-all` is the M2 gate, `make test-core-dev` is the M3 daily driver.**
+  `make test-core-dev` is faster and surfaces the corert failures; `make test`
+  (api import + others) must also stay at zero each iteration.
+- **HEAD has a hand-applied UpDownNone backport** in `ArpeggiateAttributes.h`
+  that conflicts with a schema-faithful regen. As long as M3 changes do not
+  require regen this is invisible; if a generator fix is needed, follow M2's
+  workflow (`python3 gen/generate.py && make fmt` THEN test, reset after).
+- **`make fmt` runs in Docker** and may time out on first pull (registry latency).
+  Just retry.

--- a/docs/ai/projects/gen/state.md
+++ b/docs/ai/projects/gen/state.md
@@ -2,69 +2,67 @@
 
 ## Milestone
 
-**M3: fix-core-dev** in progress. After iteration 3:
-`make test-core-dev` = 2 failed (down from 3); `make test` = 0 failed;
-`make test-all` = 2 failed (3026/3028 cases).
+**M3: fix-core-dev** in progress. After iteration 4:
+`make test-core-dev` = 1 failed (down from 2); `make test` = 0 failed;
+`make test-all` = 1 failed (3027/3028 cases).
 
-## What the previous session did (M3 iteration 3)
+## What the previous session did (M3 iteration 4)
 
-Iteration 3 picked the smallest core-roundtrip diff,
-`lysuite/ly45f_Repeats_InvalidEndings.xml` (8 lines). The `ending`
-element's `number` attribute was round-tripping `"1, 2, 3"` →
-`"1,2,3"`. The XSD `ending-number` pattern
-`[1-9][0-9]*(, ?[1-9][0-9]*)*` allows both forms; the library was
-losing the lexical choice on import.
+Iteration 4 picked the smallest core-roundtrip diff,
+`lysuite/ly41e_StaffGroups_InstrumentNames_Linebroken.xml` (10-line
+diff). The `<part-name>` text content contained `&#xd;` character
+references (literal CR bytes); on round-trip those became `\n`.
 
-Root cause: `CommaSeparatedListOfPositiveIntegers::parse` in
-`src/private/mx/core/CommaSeparatedPositiveIntegers.cpp` ran
-`onlyAllow(text, "", "1234567890,-")` (strips spaces) before
-tokenising and never set `myIsSpacingDesired`, so output always took
-the compact form. `toStream` already handled both forms; only import
-needed the fix.
+Root cause: `mx::core::XsString::toStream` in
+`src/private/mx/core/XsString.cpp` escaped only `<`, `>`, `&`. A raw
+`\r` written to the output stream is normalized to `\n` by the next
+parser pass (pugixml `parse_eol`, per XML 1.0 §2.11). The reader path
+was already correct — pugixml expands `&#xd;` into a raw `\r` after
+EOL normalization runs, so `myValue` held the right bytes; only the
+writer dropped them.
 
-The type is hand-written, not generated — `gen/generate.py` only maps
-its header path as a dependency. Fix lives directly in the .cpp.
+Fix: added a `'\r'` case emitting `"&#xd;"` to the escape switch.
+Hand-written type, no regen needed. Committed as `040b2152`.
 
-Fix: scan the raw input for digit-comma-space-digit and set
-`myIsSpacingDesired` accordingly. Narrow detection (requires digits on
-both sides of `", "`) so the existing
-`StringsTest::EndingNumber02` case — which feeds junk and expects
-`"1,2,3"` out — stays green. Added `#include <cctype>`. Committed as
-`461b96d2`.
+## One remaining failure
 
-## Two remaining real bugs
+`lysuite/ly22b_Staff_Notestyles.xml` (24-line diff): child count
+mismatch inside `measure-style` at
+`/score-partwise/part[2]/measure[0]/attributes[2]/measure-style[0]/slash[0]`.
+This is the last `make test-core-dev` failure and the last
+`make test-all` failure. **Next session target.**
 
-1. `lysuite/ly41e_StaffGroups_InstrumentNames_Linebroken.xml`
-   (10-line diff): `part-name` text mismatch. Library normalizing
-   linebroken text content. **Next session target.**
-2. `lysuite/ly22b_Staff_Notestyles.xml` (24-line diff): child count
-   mismatch inside `measure-style` (attributes block, measure[0]).
-
-## What the next session should do (M3 iteration 4)
+## What the next session should do (M3 iteration 5)
 
 Per `plan.md` M3 session sequence:
 
 1. `rm -rf data/testOutput/*`
 2. `make test-core-dev` — record failure count as baseline_core_dev
-   (should be 2).
-3. `make test` — should be 0.
-4. Diff each pair in `data/testOutput/corert` and pick the smallest.
-   That is `test_to_fix` (expected: `ly41e_StaffGroups_...`). Report
-   to user with one-paragraph analysis. One test per session.
-5. Wait for user direction before fixing.
-6. After fix: regen `mx/core` if the fix was in `gen/`, `make fmt`,
-   `make check`, then re-run `make test-core-dev` and `make test`. If
-   the fix touched anything under `src/private/mx/core/`, also run
-   `make test-all` (the AGENTS.md rule).
+   (expect 1).
+3. `make test` — expect 0.
+4. Diff `lysuite_ly22b_Staff_Notestyles.xml.{expected,actual}.xml` in
+   `data/testOutput/corert` — it's the only failure. That is
+   `test_to_fix`. Report to user with one-paragraph analysis. One test
+   per session.
+5. Wait for user direction before fixing. This one has a child-count
+   mismatch inside `measure-style/slash`, which suggests it could be
+   either: a missing optional child the writer is emitting, or an
+   optional child the reader is not emitting; check both the XSD shape
+   of `measure-style` (sequence vs choice, minOccurs) and the
+   generated `MeasureStyle.cpp` / `Slash.cpp` against the input file.
+6. After fix: if the fix was in `gen/`, regen `mx/core`; otherwise
+   skip regen. Then `make fmt`, `make check`, `make test-core-dev`,
+   `make test`, `make test-all` (since the fix will almost certainly
+   touch `src/private/mx/core/`).
 
 ## Gotchas
 
-- **`.invalid` marker convention**: if you encounter a test failure
-  caused by intentionally invalid MusicXML input, the right move is a
-  `{file}.invalid` marker, not a code change. The iteration-2 sweep
-  covered every then-failing file, so a *new* corert failure is most
-  likely a real library bug; confirm by reading the file and running
-  xmllint --schema against `/tmp/mx.xsd` (recipe below).
+- **`.invalid` marker convention**: if a corert failure is caused by
+  intentionally invalid MusicXML, the right move is a `{file}.invalid`
+  marker, not code. ly22b looks like a real bug (child-count
+  mismatch, not a structural validity issue), but confirm by running
+  `xmllint --noout --schema /tmp/mx.xsd
+  data/lysuite/ly22b_Staff_Notestyles.xml` first.
 - **Validating against the MusicXML XSD with xmllint**: the XSD
   imports `http://www.musicxml.org/xsd/xml.xsd` and `xlink.xsd` which
   404 today. Workaround:
@@ -75,25 +73,19 @@ Per `plan.md` M3 session sequence:
   - then `xmllint --noout --schema /tmp/mx.xsd <file>`.
 - **One test per session.** Do not try to fix multiple failures in
   one session even if they share a root cause.
-- **Hand-written types vs generated types.** Some `mx/core` files
-  (e.g. `CommaSeparatedPositiveIntegers.cpp`, `EndingNumber.h`) are
-  hand-written and only referenced as a dependency mapping in
-  `gen/generate.py`. Bugs in those files are fixed in the .cpp/.h
-  directly, no regen. Check whether the file appears under
-  `src/private/mx/core/elements/` (generated) vs the parent
-  `src/private/mx/core/` (mostly hand-written core types).
-- **Don't touch tests carelessly.** The "never change tests" rule
-  applies to test cases. Test infrastructure (normalization helpers,
-  harness code, discovery rules) is fair game when authorized;
-  default to flagging before changing.
-- **`make test-all` is the M2 gate, `make test-core-dev` is the M3
-  daily driver.** test-core-dev surfaces the corert failures fast;
-  `make test` (api import + others) must also stay at zero each
-  iteration. If a fix touches anything under
-  `src/private/mx/core/`, also run `make test-all` per AGENTS.md.
+- **Hand-written vs generated.** Files directly under
+  `src/private/mx/core/` (e.g. `XsString.cpp`,
+  `CommaSeparatedPositiveIntegers.cpp`) are mostly hand-written; files
+  under `src/private/mx/core/elements/` are codegen output.
+  `gen/generate.py` only references the hand-written ones by header
+  path. Bugs in hand-written types are fixed in-place, no regen.
+- **Don't touch tests carelessly.** "Never change tests" applies to
+  test cases. Test infrastructure (normalization, harness, discovery)
+  is fair game when authorized; default to flagging before changing.
+- **`make test-all` is the M2 gate; `make test-core-dev` is the M3
+  daily driver.** Anything under `src/private/mx/core/` requires
+  `test-all` per AGENTS.md.
 - **HEAD has a hand-applied UpDownNone backport** in
   `ArpeggiateAttributes.h` that conflicts with a schema-faithful
-  regen. As long as M3 changes do not require regen this is
-  invisible; if a generator fix is needed, follow M2's workflow.
-- **`make fmt` runs in Docker** and may time out on first pull
-  (registry latency). Just retry.
+  regen. Invisible as long as M3 changes don't require regen.
+- **`make fmt` runs in Docker** and may time out on first pull. Retry.

--- a/gen/generate.py
+++ b/gen/generate.py
@@ -1076,13 +1076,7 @@ ELEMENT_HAS_CONTENTS_ALWAYS_TRUE = {
 # (parent_element_xml_name, child_element_xml_name). Use this when XSD group
 # inlining propagates minOccurs=0 from the enclosing group to an element that
 # HEAD treats as unconditionally present (no getHas/setHas accessors).
-CHILD_MIN_OCCURS_OVERRIDE = {
-    # The `slash` group (used by both slash and beat-repeat) has minOccurs="0",
-    # which causes group inlining to set min_occurs=0 on slash-type. HEAD treats
-    # slash-type as always-present (minOccurs=1 within the group), so override.
-    ("slash", "slash-type"): 1,
-    ("beat-repeat", "slash-type"): 1,
-}
+CHILD_MIN_OCCURS_OVERRIDE = {}
 
 
 def _apply_child_min_occurs_override(elem_name: str, children: list) -> list:

--- a/src/private/mx/core/CommaSeparatedPositiveIntegers.cpp
+++ b/src/private/mx/core/CommaSeparatedPositiveIntegers.cpp
@@ -5,6 +5,8 @@
 #include "mx/core/CommaSeparatedPositiveIntegers.h"
 #include "mx/core/StringUtils.h"
 
+#include <cctype>
+
 namespace mx
 {
 namespace core
@@ -64,6 +66,24 @@ void CommaSeparatedListOfPositiveIntegers::setValues(const std::set<int> &values
 
 void CommaSeparatedListOfPositiveIntegers::parse(const StringType &commaSeparatedText)
 {
+    // Detect whether the input used the spaced form (e.g. "1, 2, 3") versus the compact
+    // form ("1,2,3"). Both are valid per the MusicXML ending-number pattern
+    // [1-9][0-9]*(, ?[1-9][0-9]*)*, so preserve the lexical choice on round-trip.
+    // Look for a digit-comma-space-digit sequence, which is the spaced form of the
+    // XSD pattern. This avoids being fooled by junk input (e.g. ", 0" inside garbage)
+    // and only flips the flag when the input actually conforms to the spaced form.
+    bool sawSpacedForm = false;
+    for (size_t i = 1; i + 2 < commaSeparatedText.size(); ++i)
+    {
+        if (commaSeparatedText[i] == ',' && commaSeparatedText[i + 1] == ' ' &&
+            std::isdigit(static_cast<unsigned char>(commaSeparatedText[i - 1])) &&
+            std::isdigit(static_cast<unsigned char>(commaSeparatedText[i + 2])))
+        {
+            sawSpacedForm = true;
+            break;
+        }
+    }
+    myIsSpacingDesired = sawSpacedForm;
     StringType cleaned = onlyAllow(commaSeparatedText, "", "1234567890,-");
     myValues.clear();
     std::istringstream iss(cleaned);

--- a/src/private/mx/core/XsString.cpp
+++ b/src/private/mx/core/XsString.cpp
@@ -57,6 +57,15 @@ std::ostream &toStream(std::ostream &os, const XsString &xsstring, bool useXmlEs
             os << "&amp;";
             break;
 
+        case '\r':
+            // Per XML 1.0 §2.11 (End-of-line handling), a literal 0x0D byte in
+            // element text content is normalized to 0x0A on the next parse. To
+            // preserve a carriage return through an XML round-trip, emit it as
+            // the numeric character reference &#xd; — character references are
+            // not subject to EOL normalization.
+            os << "&#xd;";
+            break;
+
         default:
             os << c;
             break;

--- a/src/private/mx/core/elements/BeatRepeat.cpp
+++ b/src/private/mx/core/elements/BeatRepeat.cpp
@@ -13,7 +13,8 @@ namespace mx
 namespace core
 {
 BeatRepeat::BeatRepeat()
-    : myAttributes(std::make_shared<BeatRepeatAttributes>()), mySlashType(makeSlashType()), mySlashDotSet()
+    : myAttributes(std::make_shared<BeatRepeatAttributes>()), mySlashType(makeSlashType()), myHasSlashType(false),
+      mySlashDotSet()
 {
 }
 
@@ -35,20 +36,30 @@ std::ostream &BeatRepeat::streamName(std::ostream &os) const
 
 bool BeatRepeat::hasContents() const
 {
-    return true;
+    return myHasSlashType || mySlashDotSet.size() > 0;
 }
 
 std::ostream &BeatRepeat::streamContents(std::ostream &os, const int indentLevel, bool &isOneLineOnly) const
 {
-    isOneLineOnly = false;
-    os << std::endl;
-    mySlashType->toStream(os, indentLevel + 1);
+    if (myHasSlashType)
+    {
+        os << std::endl;
+        mySlashType->toStream(os, indentLevel + 1);
+    }
     for (auto x : mySlashDotSet)
     {
         os << std::endl;
         x->toStream(os, indentLevel + 1);
     }
-    os << std::endl;
+    if (myHasSlashType || mySlashDotSet.size() > 0)
+    {
+        isOneLineOnly = false;
+        os << std::endl;
+    }
+    else
+    {
+        isOneLineOnly = true;
+    }
     return os;
 }
 
@@ -76,6 +87,16 @@ void BeatRepeat::setSlashType(const SlashTypePtr &value)
     {
         mySlashType = value;
     }
+}
+
+bool BeatRepeat::getHasSlashType() const
+{
+    return myHasSlashType;
+}
+
+void BeatRepeat::setHasSlashType(const bool value)
+{
+    myHasSlashType = value;
 }
 
 const SlashDotSet &BeatRepeat::getSlashDotSet() const
@@ -117,12 +138,11 @@ bool BeatRepeat::fromXElementImpl(std::ostream &message, ::ezxml::XElement &xele
 {
     bool isSuccess = true;
     isSuccess &= myAttributes->fromXElement(message, xelement);
-    bool isSlashTypeFound = false;
 
     auto endIter = xelement.end();
     for (auto it = xelement.begin(); it != endIter; ++it)
     {
-        if (importElement(message, *it, isSuccess, *mySlashType, isSlashTypeFound))
+        if (importElement(message, *it, isSuccess, *mySlashType, myHasSlashType))
         {
             continue;
         }

--- a/src/private/mx/core/elements/BeatRepeat.h
+++ b/src/private/mx/core/elements/BeatRepeat.h
@@ -40,9 +40,11 @@ class BeatRepeat : public ElementInterface
     BeatRepeatAttributesPtr getAttributes() const;
     void setAttributes(const BeatRepeatAttributesPtr &attributes);
 
-    /* _________ SlashType minOccurs = 1, maxOccurs = 1 _________ */
+    /* _________ SlashType minOccurs = 0, maxOccurs = 1 _________ */
     SlashTypePtr getSlashType() const;
     void setSlashType(const SlashTypePtr &value);
+    bool getHasSlashType() const;
+    void setHasSlashType(const bool value);
 
     /* _________ SlashDot minOccurs = 0, maxOccurs = unbounded _________ */
     const SlashDotSet &getSlashDotSet() const;
@@ -57,6 +59,7 @@ class BeatRepeat : public ElementInterface
   private:
     BeatRepeatAttributesPtr myAttributes;
     SlashTypePtr mySlashType;
+    bool myHasSlashType;
     SlashDotSet mySlashDotSet;
 };
 } // namespace core

--- a/src/private/mx/core/elements/Slash.cpp
+++ b/src/private/mx/core/elements/Slash.cpp
@@ -12,7 +12,9 @@ namespace mx
 {
 namespace core
 {
-Slash::Slash() : myAttributes(std::make_shared<SlashAttributes>()), mySlashType(makeSlashType()), mySlashDotSet()
+Slash::Slash()
+    : myAttributes(std::make_shared<SlashAttributes>()), mySlashType(makeSlashType()), myHasSlashType(false),
+      mySlashDotSet()
 {
 }
 
@@ -34,20 +36,30 @@ std::ostream &Slash::streamName(std::ostream &os) const
 
 bool Slash::hasContents() const
 {
-    return true;
+    return myHasSlashType || mySlashDotSet.size() > 0;
 }
 
 std::ostream &Slash::streamContents(std::ostream &os, const int indentLevel, bool &isOneLineOnly) const
 {
-    isOneLineOnly = false;
-    os << std::endl;
-    mySlashType->toStream(os, indentLevel + 1);
+    if (myHasSlashType)
+    {
+        os << std::endl;
+        mySlashType->toStream(os, indentLevel + 1);
+    }
     for (auto x : mySlashDotSet)
     {
         os << std::endl;
         x->toStream(os, indentLevel + 1);
     }
-    os << std::endl;
+    if (myHasSlashType || mySlashDotSet.size() > 0)
+    {
+        isOneLineOnly = false;
+        os << std::endl;
+    }
+    else
+    {
+        isOneLineOnly = true;
+    }
     return os;
 }
 
@@ -75,6 +87,16 @@ void Slash::setSlashType(const SlashTypePtr &value)
     {
         mySlashType = value;
     }
+}
+
+bool Slash::getHasSlashType() const
+{
+    return myHasSlashType;
+}
+
+void Slash::setHasSlashType(const bool value)
+{
+    myHasSlashType = value;
 }
 
 const SlashDotSet &Slash::getSlashDotSet() const
@@ -116,12 +138,11 @@ bool Slash::fromXElementImpl(std::ostream &message, ::ezxml::XElement &xelement)
 {
     bool isSuccess = true;
     isSuccess &= myAttributes->fromXElement(message, xelement);
-    bool isSlashTypeFound = false;
 
     auto endIter = xelement.end();
     for (auto it = xelement.begin(); it != endIter; ++it)
     {
-        if (importElement(message, *it, isSuccess, *mySlashType, isSlashTypeFound))
+        if (importElement(message, *it, isSuccess, *mySlashType, myHasSlashType))
         {
             continue;
         }

--- a/src/private/mx/core/elements/Slash.h
+++ b/src/private/mx/core/elements/Slash.h
@@ -40,9 +40,11 @@ class Slash : public ElementInterface
     SlashAttributesPtr getAttributes() const;
     void setAttributes(const SlashAttributesPtr &attributes);
 
-    /* _________ SlashType minOccurs = 1, maxOccurs = 1 _________ */
+    /* _________ SlashType minOccurs = 0, maxOccurs = 1 _________ */
     SlashTypePtr getSlashType() const;
     void setSlashType(const SlashTypePtr &value);
+    bool getHasSlashType() const;
+    void setHasSlashType(const bool value);
 
     /* _________ SlashDot minOccurs = 0, maxOccurs = unbounded _________ */
     const SlashDotSet &getSlashDotSet() const;
@@ -57,6 +59,7 @@ class Slash : public ElementInterface
   private:
     SlashAttributesPtr myAttributes;
     SlashTypePtr mySlashType;
+    bool myHasSlashType;
     SlashDotSet mySlashDotSet;
 };
 } // namespace core

--- a/src/private/mxtest/core/BeatRepeatTest.cpp
+++ b/src/private/mxtest/core/BeatRepeatTest.cpp
@@ -16,6 +16,7 @@ using namespace mxtest;
 TEST(Test01, BeatRepeat)
 {
     BeatRepeat object;
+    object.setHasSlashType(true);
     stringstream expected;
     streamLine(expected, 1, R"(<beat-repeat type="start">)");
     streamLine(expected, 2, R"(<slash-type>eighth</slash-type>)");
@@ -35,6 +36,7 @@ TEST(Test02, BeatRepeat)
     object.getAttributes()->hasUseDots = true;
     object.getAttributes()->useDots = YesNo::yes;
     object.getAttributes()->hasSlashes = true;
+    object.setHasSlashType(true);
     object.addSlashDot(makeSlashDot());
     object.addSlashDot(makeSlashDot());
     stringstream expected;

--- a/src/private/mxtest/core/MeasureStyleTest.cpp
+++ b/src/private/mxtest/core/MeasureStyleTest.cpp
@@ -32,6 +32,7 @@ TEST(Test02, MeasureStyle)
 {
     MeasureStyle object;
     object.getMeasureStyleChoice()->setChoice(MeasureStyleChoice::Choice::beatRepeat);
+    object.getMeasureStyleChoice()->getBeatRepeat()->setHasSlashType(true);
     object.getMeasureStyleChoice()->getBeatRepeat()->addSlashDot(makeSlashDot());
     object.getAttributes()->hasColor = true;
     object.getAttributes()->color = Color{76, 58, 201, 43};
@@ -54,6 +55,7 @@ TEST(Test03, MeasureStyle)
 {
     MeasureStyle object;
     object.getMeasureStyleChoice()->setChoice(MeasureStyleChoice::Choice::slash);
+    object.getMeasureStyleChoice()->getSlash()->setHasSlashType(true);
     stringstream expected;
     streamLine(expected, 1, R"(<measure-style>)");
     streamLine(expected, 2, R"(<slash type="start">)");

--- a/src/private/mxtest/core/PropertiesTest.cpp
+++ b/src/private/mxtest/core/PropertiesTest.cpp
@@ -111,6 +111,7 @@ PropertiesPtr tgenProperties(TestMode v)
         o->addDirective(dir);
         auto ms = makeMeasureStyle();
         ms->getMeasureStyleChoice()->setChoice(MeasureStyleChoice::Choice::slash);
+        ms->getMeasureStyleChoice()->getSlash()->setHasSlashType(true);
         ms->getMeasureStyleChoice()->getSlash()->getSlashType()->setValue(NoteTypeValue::eighth);
         o->addMeasureStyle(ms);
     }
@@ -166,6 +167,7 @@ PropertiesPtr tgenProperties(TestMode v)
         o->addDirective(dir);
         auto ms = makeMeasureStyle();
         ms->getMeasureStyleChoice()->setChoice(MeasureStyleChoice::Choice::slash);
+        ms->getMeasureStyleChoice()->getSlash()->setHasSlashType(true);
         ms->getMeasureStyleChoice()->getSlash()->getSlashType()->setValue(NoteTypeValue::eighth);
         o->addMeasureStyle(ms);
     }

--- a/src/private/mxtest/core/SlashTest.cpp
+++ b/src/private/mxtest/core/SlashTest.cpp
@@ -16,6 +16,7 @@ using namespace mxtest;
 TEST(Test01, Slash)
 {
     Slash object;
+    object.setHasSlashType(true);
     stringstream expected;
     streamLine(expected, 1, R"(<slash type="start">)");
     streamLine(expected, 2, R"(<slash-type>eighth</slash-type>)");
@@ -36,6 +37,7 @@ TEST(Test02, Slash)
     object.getAttributes()->useDots = YesNo::yes;
     object.getAttributes()->hasUseStems = true;
     object.getAttributes()->useStems = YesNo::yes;
+    object.setHasSlashType(true);
     object.addSlashDot(makeSlashDot());
     object.addSlashDot(makeSlashDot());
     stringstream expected;

--- a/src/private/mxtest/corert/CoreRoundtripImpl.cpp
+++ b/src/private/mxtest/corert/CoreRoundtripImpl.cpp
@@ -60,6 +60,17 @@ bool hasXmlExtension(const std::filesystem::path &p)
     return ext == ".xml" || ext == ".musicxml";
 }
 
+// A file is marked invalid (and therefore unfit for schema-strict round-trip)
+// when a sibling file with the same name plus a trailing `.invalid` extension
+// exists. See data/README.md for the convention.
+bool hasInvalidMarker(const std::filesystem::path &p)
+{
+    std::filesystem::path marker = p;
+    marker += ".invalid";
+    std::error_code ec;
+    return std::filesystem::exists(marker, ec);
+}
+
 // Set the root `version` attribute to mx::core's supported MusicXML version.
 // Equivalent in shape to mxtest/import's setRootMusicXmlVersion but without
 // the doctype cross-check (which we apply via setDoctype below based on the
@@ -275,6 +286,10 @@ std::vector<std::string> discoverInputFiles()
             continue;
         }
         if (!hasXmlExtension(p))
+        {
+            continue;
+        }
+        if (hasInvalidMarker(p))
         {
             continue;
         }

--- a/src/private/mxtest/import/DecimalFields.h
+++ b/src/private/mxtest/import/DecimalFields.h
@@ -21,9 +21,9 @@
 namespace mxtest
 {
 
-const std::set<std::string> decimalFields = {"top-system-distance", "dynamics",       "left-margin",
-                                             "right-margin",        "staff-distance", "system-distance",
-                                             "default-y",           "default-x",      "tenths"};
+const std::set<std::string> decimalFields = {
+    "top-system-distance", "dynamics",  "left-margin", "right-margin", "staff-distance",
+    "system-distance",     "default-y", "default-x",   "tenths",       "width"};
 
 inline int trailingCharsToStrip(const std::string &value)
 {

--- a/src/private/mxtest/import/ExpectedFiles.cpp
+++ b/src/private/mxtest/import/ExpectedFiles.cpp
@@ -35,10 +35,6 @@ void generateExpectedFile(const std::string &subdir, const std::string &fileName
     // ly01e_Pitches_ParenthesizedAccidentals incorrectly uses "double-flat" which should be "flat-flat" instead
     convertValues(*xdoc, "accidental", "double-flat", "flat-flat");
 
-    // lysuite_ly22b_Staff_Notestyles.xml incorrectly has <slash> elements that are missing required attribute
-    // 'use-stems' and child element 'slash-type'
-    addChildIfNone(*xdoc, "slash", "slash-type", "eighth");
-
     // ly32b_Atriculations_Texts.xml cas a 'color' attribute on the 'words' element
     // I have examined the xsd thoughouly and I believe this is illegal
     removeAttribute(*xdoc, "words", "color");


### PR DESCRIPTION
Milestone 3 of the gen project (#58). Closes the loop on the Milestone 2 regenerator (codenamed `revgen` for reverse engineering codegen): gets the full test suite green and improves how we handle MusicXML inputs that don't conform to the XSD.

## What

- `make test-all` green: 3028/3028, 9914 assertions. `make test-core-dev` 350/350.
- Three bugs in hand-written core fixed:
  - `XsString` writer didn't escape `\r`, so carriage returns were normalized to `\n` on the next read (XML 1.0 §2.11).
  - `CommaSeparatedListOfPositiveIntegers::parse` discarded `", "` vs `","` spacing on import.
  - `slash-type` was treated as always-present, but the XSD allows empty `<slash/>` and `<beat-repeat/>`. Removed the `CHILD_MIN_OCCURS_OVERRIDE` and regenerated.
- One harness fix: `width` is tenths-typed, so the import harness now strips its trailing zeros like other decimal fields.

## Why

Many failing core-roundtrip cases were inputs that violate the MusicXML XSD. Diffing a round-trip against a schema-invalid input is not a useful signal. Introduced a `{file}.invalid` sibling-file convention (body documents the violation), honored by corert and ignored by api import. Documented in `data/README.md`. Eleven inputs marked `.invalid`.

The suite is now a meaningful fitness function for the next milestone: pointing the generator at MusicXML 4.0.

## Deferred

MusicXML 4.0 `UpDownNone` backport (M2 issue A). TODOs in `mx/impl/NotationsWriter.cpp:398` and `mx/impl/ArpeggiateFunctions.cpp:35`.
