### PR TITLE
test: restore omitted 3.1 and 4.0 synthetic coverage files

### DIFF
--- a/docs/ai/projects/gen/synthetic-files/3.1/accidental.3.1.xml
+++ b/docs/ai/projects/gen/synthetic-files/3.1/accidental.3.1.xml
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<score-partwise version="3.1">
+  <part-list>
+    <part-group type="start">
+      <footnote>x</footnote>
+      <level>x</level>
+    </part-group>
+    <score-part id="id1">
+      <part-name>x</part-name>
+    </score-part>
+    <part-group type="start">
+      <footnote>x</footnote>
+      <level>x</level>
+    </part-group>
+  </part-list>
+  <part id="id1">
+    <measure number="x">
+      <note>
+        <grace />
+        <pitch>
+          <step>A</step>
+          <octave>1</octave>
+        </pitch>
+        <footnote>x</footnote>
+        <level>x</level>
+        <voice>1</voice>
+        <accidental cautionary="yes" editorial="yes" parentheses="yes" bracket="yes" size="full" default-x="1" default-y="1" relative-x="1" relative-y="1" font-family="x" font-style="normal" font-size="1" font-weight="normal" color="#FF000000" smufl="accidentalSharp">sharp</accidental>
+        <staff>1</staff>
+      </note>
+    </measure>
+  </part>
+</score-partwise>

--- a/docs/ai/projects/gen/synthetic-files/3.1/accordion-registration.3.1.xml
+++ b/docs/ai/projects/gen/synthetic-files/3.1/accordion-registration.3.1.xml
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<score-partwise version="3.1">
+  <part-list>
+    <part-group type="start">
+      <footnote>x</footnote>
+      <level>x</level>
+    </part-group>
+    <score-part id="id1">
+      <part-name>x</part-name>
+    </score-part>
+    <part-group type="start">
+      <footnote>x</footnote>
+      <level>x</level>
+    </part-group>
+  </part-list>
+  <part id="id1">
+    <measure number="x">
+      <direction>
+        <direction-type>
+          <accordion-registration default-x="1" default-y="1" relative-x="1" relative-y="1" font-family="x" font-style="normal" font-size="1" font-weight="normal" color="#FF000000" halign="left" valign="top" id="id3" />
+        </direction-type>
+        <footnote>x</footnote>
+        <level>x</level>
+        <voice>1</voice>
+        <staff>1</staff>
+      </direction>
+    </measure>
+  </part>
+</score-partwise>

--- a/docs/ai/projects/gen/synthetic-files/3.1/arpeggiate.3.1.xml
+++ b/docs/ai/projects/gen/synthetic-files/3.1/arpeggiate.3.1.xml
@@ -1,0 +1,36 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<score-partwise version="3.1">
+  <part-list>
+    <part-group type="start">
+      <footnote>x</footnote>
+      <level>x</level>
+    </part-group>
+    <score-part id="id1">
+      <part-name>x</part-name>
+    </score-part>
+    <part-group type="start">
+      <footnote>x</footnote>
+      <level>x</level>
+    </part-group>
+  </part-list>
+  <part id="id1">
+    <measure number="x">
+      <note>
+        <grace />
+        <pitch>
+          <step>A</step>
+          <octave>1</octave>
+        </pitch>
+        <footnote>x</footnote>
+        <level>x</level>
+        <voice>1</voice>
+        <staff>1</staff>
+        <notations>
+          <footnote>x</footnote>
+          <level>x</level>
+          <arpeggiate number="1" direction="up" default-x="1" default-y="1" relative-x="1" relative-y="1" placement="above" color="#FF000000" id="id3" />
+        </notations>
+      </note>
+    </measure>
+  </part>
+</score-partwise>

--- a/docs/ai/projects/gen/synthetic-files/3.1/arrow.3.1.xml
+++ b/docs/ai/projects/gen/synthetic-files/3.1/arrow.3.1.xml
@@ -1,0 +1,40 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<score-partwise version="3.1">
+  <part-list>
+    <part-group type="start">
+      <footnote>x</footnote>
+      <level>x</level>
+    </part-group>
+    <score-part id="id1">
+      <part-name>x</part-name>
+    </score-part>
+    <part-group type="start">
+      <footnote>x</footnote>
+      <level>x</level>
+    </part-group>
+  </part-list>
+  <part id="id1">
+    <measure number="x">
+      <note>
+        <grace />
+        <pitch>
+          <step>A</step>
+          <octave>1</octave>
+        </pitch>
+        <footnote>x</footnote>
+        <level>x</level>
+        <voice>1</voice>
+        <staff>1</staff>
+        <notations>
+          <footnote>x</footnote>
+          <level>x</level>
+          <technical>
+            <arrow default-x="1" default-y="1" relative-x="1" relative-y="1" font-family="x" font-style="normal" font-size="1" font-weight="normal" color="#FF000000" placement="above" smufl="noteheadBlack">
+              <arrow-direction>left</arrow-direction>
+            </arrow>
+          </technical>
+        </notations>
+      </note>
+    </measure>
+  </part>
+</score-partwise>

--- a/docs/ai/projects/gen/synthetic-files/3.1/arrowhead.3.1.xml
+++ b/docs/ai/projects/gen/synthetic-files/3.1/arrowhead.3.1.xml
@@ -1,0 +1,41 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<score-partwise version="3.1">
+  <part-list>
+    <part-group type="start">
+      <footnote>x</footnote>
+      <level>x</level>
+    </part-group>
+    <score-part id="id1">
+      <part-name>x</part-name>
+    </score-part>
+    <part-group type="start">
+      <footnote>x</footnote>
+      <level>x</level>
+    </part-group>
+  </part-list>
+  <part id="id1">
+    <measure number="x">
+      <note>
+        <grace />
+        <pitch>
+          <step>A</step>
+          <octave>1</octave>
+        </pitch>
+        <footnote>x</footnote>
+        <level>x</level>
+        <voice>1</voice>
+        <staff>1</staff>
+        <notations>
+          <footnote>x</footnote>
+          <level>x</level>
+          <technical>
+            <arrow>
+              <arrow-direction>left</arrow-direction>
+              <arrowhead />
+            </arrow>
+          </technical>
+        </notations>
+      </note>
+    </measure>
+  </part>
+</score-partwise>

--- a/docs/ai/projects/gen/synthetic-files/3.1/articulations.3.1.xml
+++ b/docs/ai/projects/gen/synthetic-files/3.1/articulations.3.1.xml
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<score-partwise version="3.1">
+  <part-list>
+    <part-group type="start">
+      <footnote>x</footnote>
+      <level>x</level>
+    </part-group>
+    <score-part id="id1">
+      <part-name>x</part-name>
+    </score-part>
+    <part-group type="start">
+      <footnote>x</footnote>
+      <level>x</level>
+    </part-group>
+  </part-list>
+  <part id="id1">
+    <measure number="x">
+      <note>
+        <grace />
+        <pitch>
+          <step>A</step>
+          <octave>1</octave>
+        </pitch>
+        <footnote>x</footnote>
+        <level>x</level>
+        <voice>1</voice>
+        <staff>1</staff>
+        <notations>
+          <footnote>x</footnote>
+          <level>x</level>
+          <articulations id="id3">
+            <accent />
+          </articulations>
+        </notations>
+      </note>
+    </measure>
+  </part>
+</score-partwise>

--- a/docs/ai/projects/gen/synthetic-files/3.1/barline.3.1.xml
+++ b/docs/ai/projects/gen/synthetic-files/3.1/barline.3.1.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<score-partwise version="3.1">
+  <part-list>
+    <part-group type="start">
+      <footnote>x</footnote>
+      <level>x</level>
+    </part-group>
+    <score-part id="id1">
+      <part-name>x</part-name>
+    </score-part>
+    <part-group type="start">
+      <footnote>x</footnote>
+      <level>x</level>
+    </part-group>
+  </part-list>
+  <part id="id1">
+    <measure number="x">
+      <barline location="right" segno="x" coda="x" divisions="1" id="id3">
+        <footnote>x</footnote>
+        <level>x</level>
+      </barline>
+    </measure>
+  </part>
+</score-partwise>

--- a/docs/ai/projects/gen/synthetic-files/3.1/beam.3.1.xml
+++ b/docs/ai/projects/gen/synthetic-files/3.1/beam.3.1.xml
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<score-partwise version="3.1">
+  <part-list>
+    <part-group type="start">
+      <footnote>x</footnote>
+      <level>x</level>
+    </part-group>
+    <score-part id="id1">
+      <part-name>x</part-name>
+    </score-part>
+    <part-group type="start">
+      <footnote>x</footnote>
+      <level>x</level>
+    </part-group>
+  </part-list>
+  <part id="id1">
+    <measure number="x">
+      <note>
+        <grace />
+        <pitch>
+          <step>A</step>
+          <octave>1</octave>
+        </pitch>
+        <footnote>x</footnote>
+        <level>x</level>
+        <voice>1</voice>
+        <staff>1</staff>
+        <beam number="1" repeater="yes" fan="accel" color="#FF000000" id="id3">begin</beam>
+      </note>
+    </measure>
+  </part>
+</score-partwise>

--- a/docs/ai/projects/gen/synthetic-files/3.1/beat-unit-tied.3.1.xml
+++ b/docs/ai/projects/gen/synthetic-files/3.1/beat-unit-tied.3.1.xml
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<score-partwise version="3.1">
+  <part-list>
+    <part-group type="start">
+      <footnote>x</footnote>
+      <level>x</level>
+    </part-group>
+    <score-part id="id1">
+      <part-name>x</part-name>
+    </score-part>
+    <part-group type="start">
+      <footnote>x</footnote>
+      <level>x</level>
+    </part-group>
+  </part-list>
+  <part id="id1">
+    <measure number="x">
+      <direction>
+        <direction-type>
+          <metronome>
+            <beat-unit>1024th</beat-unit>
+            <beat-unit-tied>
+              <beat-unit>1024th</beat-unit>
+            </beat-unit-tied>
+            <per-minute>x</per-minute>
+          </metronome>
+        </direction-type>
+        <footnote>x</footnote>
+        <level>x</level>
+        <voice>1</voice>
+        <staff>1</staff>
+      </direction>
+    </measure>
+  </part>
+</score-partwise>

--- a/docs/ai/projects/gen/synthetic-files/3.1/bracket.3.1.xml
+++ b/docs/ai/projects/gen/synthetic-files/3.1/bracket.3.1.xml
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<score-partwise version="3.1">
+  <part-list>
+    <part-group type="start">
+      <footnote>x</footnote>
+      <level>x</level>
+    </part-group>
+    <score-part id="id1">
+      <part-name>x</part-name>
+    </score-part>
+    <part-group type="start">
+      <footnote>x</footnote>
+      <level>x</level>
+    </part-group>
+  </part-list>
+  <part id="id1">
+    <measure number="x">
+      <direction>
+        <direction-type>
+          <bracket type="start" number="1" line-end="up" end-length="1" line-type="solid" dash-length="1" space-length="1" default-x="1" default-y="1" relative-x="1" relative-y="1" color="#FF000000" id="id3" />
+        </direction-type>
+        <footnote>x</footnote>
+        <level>x</level>
+        <voice>1</voice>
+        <staff>1</staff>
+      </direction>
+    </measure>
+  </part>
+</score-partwise>

--- a/docs/ai/projects/gen/synthetic-files/3.1/brass-bend.3.1.xml
+++ b/docs/ai/projects/gen/synthetic-files/3.1/brass-bend.3.1.xml
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<score-partwise version="3.1">
+  <part-list>
+    <part-group type="start">
+      <footnote>x</footnote>
+      <level>x</level>
+    </part-group>
+    <score-part id="id1">
+      <part-name>x</part-name>
+    </score-part>
+    <part-group type="start">
+      <footnote>x</footnote>
+      <level>x</level>
+    </part-group>
+  </part-list>
+  <part id="id1">
+    <measure number="x">
+      <note>
+        <grace />
+        <pitch>
+          <step>A</step>
+          <octave>1</octave>
+        </pitch>
+        <footnote>x</footnote>
+        <level>x</level>
+        <voice>1</voice>
+        <staff>1</staff>
+        <notations>
+          <footnote>x</footnote>
+          <level>x</level>
+          <technical>
+            <brass-bend default-x="1" default-y="1" relative-x="1" relative-y="1" font-family="x" font-style="normal" font-size="1" font-weight="normal" color="#FF000000" placement="above" />
+          </technical>
+        </notations>
+      </note>
+    </measure>
+  </part>
+</score-partwise>

--- a/docs/ai/projects/gen/synthetic-files/3.1/clef.3.1.xml
+++ b/docs/ai/projects/gen/synthetic-files/3.1/clef.3.1.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<score-partwise version="3.1">
+  <part-list>
+    <part-group type="start">
+      <footnote>x</footnote>
+      <level>x</level>
+    </part-group>
+    <score-part id="id1">
+      <part-name>x</part-name>
+    </score-part>
+    <part-group type="start">
+      <footnote>x</footnote>
+      <level>x</level>
+    </part-group>
+  </part-list>
+  <part id="id1">
+    <measure number="x">
+      <attributes>
+        <footnote>x</footnote>
+        <level>x</level>
+        <clef number="1" additional="yes" size="full" after-barline="yes" default-x="1" default-y="1" relative-x="1" relative-y="1" font-family="x" font-style="normal" font-size="1" font-weight="normal" color="#FF000000" print-object="yes" id="id3">
+          <sign>G</sign>
+        </clef>
+      </attributes>
+    </measure>
+  </part>
+</score-partwise>

--- a/docs/ai/projects/gen/synthetic-files/3.1/coda.3.1.xml
+++ b/docs/ai/projects/gen/synthetic-files/3.1/coda.3.1.xml
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<score-partwise version="3.1">
+  <part-list>
+    <part-group type="start">
+      <footnote>x</footnote>
+      <level>x</level>
+    </part-group>
+    <score-part id="id1">
+      <part-name>x</part-name>
+    </score-part>
+    <part-group type="start">
+      <footnote>x</footnote>
+      <level>x</level>
+    </part-group>
+  </part-list>
+  <part id="id1">
+    <measure number="x">
+      <direction>
+        <direction-type>
+          <coda default-x="1" default-y="1" relative-x="1" relative-y="1" font-family="x" font-style="normal" font-size="1" font-weight="normal" color="#FF000000" halign="left" valign="top" id="id3" smufl="coda" />
+        </direction-type>
+        <footnote>x</footnote>
+        <level>x</level>
+        <voice>1</voice>
+        <staff>1</staff>
+      </direction>
+    </measure>
+  </part>
+</score-partwise>

--- a/docs/ai/projects/gen/synthetic-files/3.1/credit-image.3.1.xml
+++ b/docs/ai/projects/gen/synthetic-files/3.1/credit-image.3.1.xml
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<score-partwise version="3.1">
+  <credit>
+    <credit-image source="http://example.com" type="x" height="1" width="1" default-x="1" default-y="1" relative-x="1" relative-y="1" halign="left" valign="top" id="id1" />
+  </credit>
+  <part-list>
+    <part-group type="start">
+      <footnote>x</footnote>
+      <level>x</level>
+    </part-group>
+    <score-part id="id2">
+      <part-name>x</part-name>
+    </score-part>
+    <part-group type="start">
+      <footnote>x</footnote>
+      <level>x</level>
+    </part-group>
+  </part-list>
+  <part id="id2">
+    <measure number="x">
+      <note>
+        <grace />
+        <pitch>
+          <step>A</step>
+          <octave>1</octave>
+        </pitch>
+        <footnote>x</footnote>
+        <level>x</level>
+        <voice>1</voice>
+        <staff>1</staff>
+      </note>
+    </measure>
+  </part>
+</score-partwise>

--- a/docs/ai/projects/gen/synthetic-files/3.1/credit-symbol.3.1.xml
+++ b/docs/ai/projects/gen/synthetic-files/3.1/credit-symbol.3.1.xml
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<score-partwise version="3.1">
+  <credit>
+    <credit-symbol justify="left" default-x="1" default-y="1" relative-x="1" relative-y="1" font-family="x" font-style="normal" font-size="1" font-weight="normal" color="#FF000000" halign="left" valign="top" underline="1" overline="1" line-through="1" rotation="1" letter-spacing="1" line-height="1" dir="ltr" enclosure="rectangle" id="id1">noteheadBlack</credit-symbol>
+    <credit-words>x</credit-words>
+  </credit>
+  <part-list>
+    <part-group type="start">
+      <footnote>x</footnote>
+      <level>x</level>
+    </part-group>
+    <score-part id="id2">
+      <part-name>x</part-name>
+    </score-part>
+    <part-group type="start">
+      <footnote>x</footnote>
+      <level>x</level>
+    </part-group>
+  </part-list>
+  <part id="id2">
+    <measure number="x">
+      <note>
+        <grace />
+        <pitch>
+          <step>A</step>
+          <octave>1</octave>
+        </pitch>
+        <footnote>x</footnote>
+        <level>x</level>
+        <voice>1</voice>
+        <staff>1</staff>
+      </note>
+    </measure>
+  </part>
+</score-partwise>

--- a/docs/ai/projects/gen/synthetic-files/3.1/credit-words.3.1.xml
+++ b/docs/ai/projects/gen/synthetic-files/3.1/credit-words.3.1.xml
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<score-partwise version="3.1">
+  <credit>
+    <credit-words default-x="1" default-y="1" relative-x="1" relative-y="1" font-family="x" font-style="normal" font-size="1" font-weight="normal" color="#FF000000" justify="left" halign="left" valign="top" underline="1" overline="1" line-through="1" rotation="1" letter-spacing="1" line-height="1" xml:lang="en" xml:space="preserve" dir="ltr" enclosure="rectangle" id="id1">x</credit-words>
+    <credit-words>x</credit-words>
+  </credit>
+  <part-list>
+    <part-group type="start">
+      <footnote>x</footnote>
+      <level>x</level>
+    </part-group>
+    <score-part id="id2">
+      <part-name>x</part-name>
+    </score-part>
+    <part-group type="start">
+      <footnote>x</footnote>
+      <level>x</level>
+    </part-group>
+  </part-list>
+  <part id="id2">
+    <measure number="x">
+      <note>
+        <grace />
+        <pitch>
+          <step>A</step>
+          <octave>1</octave>
+        </pitch>
+        <footnote>x</footnote>
+        <level>x</level>
+        <voice>1</voice>
+        <staff>1</staff>
+      </note>
+    </measure>
+  </part>
+</score-partwise>

--- a/docs/ai/projects/gen/synthetic-files/3.1/credit.3.1.xml
+++ b/docs/ai/projects/gen/synthetic-files/3.1/credit.3.1.xml
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<score-partwise version="3.1">
+  <credit page="1" id="id1">
+    <credit-image source="http://example.com" type="x" />
+  </credit>
+  <part-list>
+    <part-group type="start">
+      <footnote>x</footnote>
+      <level>x</level>
+    </part-group>
+    <score-part id="id2">
+      <part-name>x</part-name>
+    </score-part>
+    <part-group type="start">
+      <footnote>x</footnote>
+      <level>x</level>
+    </part-group>
+  </part-list>
+  <part id="id2">
+    <measure number="x">
+      <note>
+        <grace />
+        <pitch>
+          <step>A</step>
+          <octave>1</octave>
+        </pitch>
+        <footnote>x</footnote>
+        <level>x</level>
+        <voice>1</voice>
+        <staff>1</staff>
+      </note>
+    </measure>
+  </part>
+</score-partwise>

--- a/docs/ai/projects/gen/synthetic-files/3.1/damp-all.3.1.xml
+++ b/docs/ai/projects/gen/synthetic-files/3.1/damp-all.3.1.xml
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<score-partwise version="3.1">
+  <part-list>
+    <part-group type="start">
+      <footnote>x</footnote>
+      <level>x</level>
+    </part-group>
+    <score-part id="id1">
+      <part-name>x</part-name>
+    </score-part>
+    <part-group type="start">
+      <footnote>x</footnote>
+      <level>x</level>
+    </part-group>
+  </part-list>
+  <part id="id1">
+    <measure number="x">
+      <direction>
+        <direction-type>
+          <damp-all default-x="1" default-y="1" relative-x="1" relative-y="1" font-family="x" font-style="normal" font-size="1" font-weight="normal" color="#FF000000" halign="left" valign="top" id="id3" />
+        </direction-type>
+        <footnote>x</footnote>
+        <level>x</level>
+        <voice>1</voice>
+        <staff>1</staff>
+      </direction>
+    </measure>
+  </part>
+</score-partwise>

--- a/docs/ai/projects/gen/synthetic-files/3.1/damp.3.1.xml
+++ b/docs/ai/projects/gen/synthetic-files/3.1/damp.3.1.xml
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<score-partwise version="3.1">
+  <part-list>
+    <part-group type="start">
+      <footnote>x</footnote>
+      <level>x</level>
+    </part-group>
+    <score-part id="id1">
+      <part-name>x</part-name>
+    </score-part>
+    <part-group type="start">
+      <footnote>x</footnote>
+      <level>x</level>
+    </part-group>
+  </part-list>
+  <part id="id1">
+    <measure number="x">
+      <direction>
+        <direction-type>
+          <damp default-x="1" default-y="1" relative-x="1" relative-y="1" font-family="x" font-style="normal" font-size="1" font-weight="normal" color="#FF000000" halign="left" valign="top" id="id3" />
+        </direction-type>
+        <footnote>x</footnote>
+        <level>x</level>
+        <voice>1</voice>
+        <staff>1</staff>
+      </direction>
+    </measure>
+  </part>
+</score-partwise>

--- a/docs/ai/projects/gen/synthetic-files/3.1/dashes.3.1.xml
+++ b/docs/ai/projects/gen/synthetic-files/3.1/dashes.3.1.xml
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<score-partwise version="3.1">
+  <part-list>
+    <part-group type="start">
+      <footnote>x</footnote>
+      <level>x</level>
+    </part-group>
+    <score-part id="id1">
+      <part-name>x</part-name>
+    </score-part>
+    <part-group type="start">
+      <footnote>x</footnote>
+      <level>x</level>
+    </part-group>
+  </part-list>
+  <part id="id1">
+    <measure number="x">
+      <direction>
+        <direction-type>
+          <dashes type="start" number="1" dash-length="1" space-length="1" default-x="1" default-y="1" relative-x="1" relative-y="1" color="#FF000000" id="id3" />
+        </direction-type>
+        <footnote>x</footnote>
+        <level>x</level>
+        <voice>1</voice>
+        <staff>1</staff>
+      </direction>
+    </measure>
+  </part>
+</score-partwise>

--- a/docs/ai/projects/gen/synthetic-files/3.1/direction-type.3.1.xml
+++ b/docs/ai/projects/gen/synthetic-files/3.1/direction-type.3.1.xml
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<score-partwise version="3.1">
+  <part-list>
+    <part-group type="start">
+      <footnote>x</footnote>
+      <level>x</level>
+    </part-group>
+    <score-part id="id1">
+      <part-name>x</part-name>
+    </score-part>
+    <part-group type="start">
+      <footnote>x</footnote>
+      <level>x</level>
+    </part-group>
+  </part-list>
+  <part id="id1">
+    <measure number="x">
+      <direction>
+        <direction-type id="id3">
+          <rehearsal>x</rehearsal>
+        </direction-type>
+        <footnote>x</footnote>
+        <level>x</level>
+        <voice>1</voice>
+        <staff>1</staff>
+      </direction>
+    </measure>
+  </part>
+</score-partwise>

--- a/docs/ai/projects/gen/synthetic-files/3.1/direction.3.1.xml
+++ b/docs/ai/projects/gen/synthetic-files/3.1/direction.3.1.xml
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<score-partwise version="3.1">
+  <part-list>
+    <part-group type="start">
+      <footnote>x</footnote>
+      <level>x</level>
+    </part-group>
+    <score-part id="id1">
+      <part-name>x</part-name>
+    </score-part>
+    <part-group type="start">
+      <footnote>x</footnote>
+      <level>x</level>
+    </part-group>
+  </part-list>
+  <part id="id1">
+    <measure number="x">
+      <direction placement="above" directive="yes" id="id3">
+        <direction-type>
+          <rehearsal>x</rehearsal>
+        </direction-type>
+        <footnote>x</footnote>
+        <level>x</level>
+        <voice>1</voice>
+        <staff>1</staff>
+      </direction>
+    </measure>
+  </part>
+</score-partwise>

--- a/docs/ai/projects/gen/synthetic-files/3.1/doit.3.1.xml
+++ b/docs/ai/projects/gen/synthetic-files/3.1/doit.3.1.xml
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<score-partwise version="3.1">
+  <part-list>
+    <part-group type="start">
+      <footnote>x</footnote>
+      <level>x</level>
+    </part-group>
+    <score-part id="id1">
+      <part-name>x</part-name>
+    </score-part>
+    <part-group type="start">
+      <footnote>x</footnote>
+      <level>x</level>
+    </part-group>
+  </part-list>
+  <part id="id1">
+    <measure number="x">
+      <note>
+        <grace />
+        <pitch>
+          <step>A</step>
+          <octave>1</octave>
+        </pitch>
+        <footnote>x</footnote>
+        <level>x</level>
+        <voice>1</voice>
+        <staff>1</staff>
+        <notations>
+          <footnote>x</footnote>
+          <level>x</level>
+          <articulations>
+            <doit line-shape="straight" line-type="solid" line-length="short" dash-length="1" space-length="1" default-x="1" default-y="1" relative-x="1" relative-y="1" font-family="x" font-style="normal" font-size="1" font-weight="normal" color="#FF000000" placement="above" />
+          </articulations>
+        </notations>
+      </note>
+    </measure>
+  </part>
+</score-partwise>

--- a/docs/ai/projects/gen/synthetic-files/3.1/dynamics.3.1.xml
+++ b/docs/ai/projects/gen/synthetic-files/3.1/dynamics.3.1.xml
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<score-partwise version="3.1">
+  <part-list>
+    <part-group type="start">
+      <footnote>x</footnote>
+      <level>x</level>
+    </part-group>
+    <score-part id="id1">
+      <part-name>x</part-name>
+    </score-part>
+    <part-group type="start">
+      <footnote>x</footnote>
+      <level>x</level>
+    </part-group>
+  </part-list>
+  <part id="id1">
+    <measure number="x">
+      <note>
+        <grace />
+        <pitch>
+          <step>A</step>
+          <octave>1</octave>
+        </pitch>
+        <footnote>x</footnote>
+        <level>x</level>
+        <voice>1</voice>
+        <staff>1</staff>
+        <notations>
+          <footnote>x</footnote>
+          <level>x</level>
+          <dynamics default-x="1" default-y="1" relative-x="1" relative-y="1" font-family="x" font-style="normal" font-size="1" font-weight="normal" color="#FF000000" halign="left" valign="top" placement="above" underline="1" overline="1" line-through="1" enclosure="rectangle" id="id3">
+            <p />
+          </dynamics>
+        </notations>
+      </note>
+    </measure>
+  </part>
+</score-partwise>

--- a/docs/ai/projects/gen/synthetic-files/3.1/elision.3.1.xml
+++ b/docs/ai/projects/gen/synthetic-files/3.1/elision.3.1.xml
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<score-partwise version="3.1">
+  <part-list>
+    <part-group type="start">
+      <footnote>x</footnote>
+      <level>x</level>
+    </part-group>
+    <score-part id="id1">
+      <part-name>x</part-name>
+    </score-part>
+    <part-group type="start">
+      <footnote>x</footnote>
+      <level>x</level>
+    </part-group>
+  </part-list>
+  <part id="id1">
+    <measure number="x">
+      <note>
+        <grace />
+        <pitch>
+          <step>A</step>
+          <octave>1</octave>
+        </pitch>
+        <footnote>x</footnote>
+        <level>x</level>
+        <voice>1</voice>
+        <staff>1</staff>
+        <lyric>
+          <text>x</text>
+          <elision font-family="x" font-style="normal" font-size="1" font-weight="normal" color="#FF000000" smufl="lyricsElision">x</elision>
+          <text>x</text>
+          <footnote>x</footnote>
+          <level>x</level>
+        </lyric>
+      </note>
+    </measure>
+  </part>
+</score-partwise>

--- a/docs/ai/projects/gen/synthetic-files/3.1/except-voice.3.1.xml
+++ b/docs/ai/projects/gen/synthetic-files/3.1/except-voice.3.1.xml
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<score-partwise version="3.1">
+  <part-list>
+    <part-group type="start">
+      <footnote>x</footnote>
+      <level>x</level>
+    </part-group>
+    <score-part id="id1">
+      <part-name>x</part-name>
+    </score-part>
+    <part-group type="start">
+      <footnote>x</footnote>
+      <level>x</level>
+    </part-group>
+  </part-list>
+  <part id="id1">
+    <measure number="x">
+      <attributes>
+        <footnote>x</footnote>
+        <level>x</level>
+        <measure-style>
+          <beat-repeat type="start">
+            <slash-type>1024th</slash-type>
+            <except-voice>1</except-voice>
+          </beat-repeat>
+        </measure-style>
+      </attributes>
+    </measure>
+  </part>
+</score-partwise>

--- a/docs/ai/projects/gen/synthetic-files/3.1/eyeglasses.3.1.xml
+++ b/docs/ai/projects/gen/synthetic-files/3.1/eyeglasses.3.1.xml
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<score-partwise version="3.1">
+  <part-list>
+    <part-group type="start">
+      <footnote>x</footnote>
+      <level>x</level>
+    </part-group>
+    <score-part id="id1">
+      <part-name>x</part-name>
+    </score-part>
+    <part-group type="start">
+      <footnote>x</footnote>
+      <level>x</level>
+    </part-group>
+  </part-list>
+  <part id="id1">
+    <measure number="x">
+      <direction>
+        <direction-type>
+          <eyeglasses default-x="1" default-y="1" relative-x="1" relative-y="1" font-family="x" font-style="normal" font-size="1" font-weight="normal" color="#FF000000" halign="left" valign="top" id="id3" />
+        </direction-type>
+        <footnote>x</footnote>
+        <level>x</level>
+        <voice>1</voice>
+        <staff>1</staff>
+      </direction>
+    </measure>
+  </part>
+</score-partwise>

--- a/docs/ai/projects/gen/synthetic-files/3.1/falloff.3.1.xml
+++ b/docs/ai/projects/gen/synthetic-files/3.1/falloff.3.1.xml
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<score-partwise version="3.1">
+  <part-list>
+    <part-group type="start">
+      <footnote>x</footnote>
+      <level>x</level>
+    </part-group>
+    <score-part id="id1">
+      <part-name>x</part-name>
+    </score-part>
+    <part-group type="start">
+      <footnote>x</footnote>
+      <level>x</level>
+    </part-group>
+  </part-list>
+  <part id="id1">
+    <measure number="x">
+      <note>
+        <grace />
+        <pitch>
+          <step>A</step>
+          <octave>1</octave>
+        </pitch>
+        <footnote>x</footnote>
+        <level>x</level>
+        <voice>1</voice>
+        <staff>1</staff>
+        <notations>
+          <footnote>x</footnote>
+          <level>x</level>
+          <articulations>
+            <falloff line-shape="straight" line-type="solid" line-length="short" dash-length="1" space-length="1" default-x="1" default-y="1" relative-x="1" relative-y="1" font-family="x" font-style="normal" font-size="1" font-weight="normal" color="#FF000000" placement="above" />
+          </articulations>
+        </notations>
+      </note>
+    </measure>
+  </part>
+</score-partwise>

--- a/docs/ai/projects/gen/synthetic-files/3.1/fermata.3.1.xml
+++ b/docs/ai/projects/gen/synthetic-files/3.1/fermata.3.1.xml
@@ -1,0 +1,36 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<score-partwise version="3.1">
+  <part-list>
+    <part-group type="start">
+      <footnote>x</footnote>
+      <level>x</level>
+    </part-group>
+    <score-part id="id1">
+      <part-name>x</part-name>
+    </score-part>
+    <part-group type="start">
+      <footnote>x</footnote>
+      <level>x</level>
+    </part-group>
+  </part-list>
+  <part id="id1">
+    <measure number="x">
+      <note>
+        <grace />
+        <pitch>
+          <step>A</step>
+          <octave>1</octave>
+        </pitch>
+        <footnote>x</footnote>
+        <level>x</level>
+        <voice>1</voice>
+        <staff>1</staff>
+        <notations>
+          <footnote>x</footnote>
+          <level>x</level>
+          <fermata type="upright" default-x="1" default-y="1" relative-x="1" relative-y="1" font-family="x" font-style="normal" font-size="1" font-weight="normal" color="#FF000000" id="id3">normal</fermata>
+        </notations>
+      </note>
+    </measure>
+  </part>
+</score-partwise>

--- a/docs/ai/projects/gen/synthetic-files/3.1/figured-bass.3.1.xml
+++ b/docs/ai/projects/gen/synthetic-files/3.1/figured-bass.3.1.xml
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<score-partwise version="3.1">
+  <part-list>
+    <part-group type="start">
+      <footnote>x</footnote>
+      <level>x</level>
+    </part-group>
+    <score-part id="id1">
+      <part-name>x</part-name>
+    </score-part>
+    <part-group type="start">
+      <footnote>x</footnote>
+      <level>x</level>
+    </part-group>
+  </part-list>
+  <part id="id1">
+    <measure number="x">
+      <figured-bass default-x="1" default-y="1" relative-x="1" relative-y="1" font-family="x" font-style="normal" font-size="1" font-weight="normal" color="#FF000000" print-object="yes" print-dot="yes" print-spacing="yes" print-lyric="yes" parentheses="yes" id="id3">
+        <figure>
+          <footnote>x</footnote>
+          <level>x</level>
+        </figure>
+        <duration>1</duration>
+        <footnote>x</footnote>
+        <level>x</level>
+      </figured-bass>
+    </measure>
+  </part>
+</score-partwise>

--- a/docs/ai/projects/gen/synthetic-files/3.1/flip.3.1.xml
+++ b/docs/ai/projects/gen/synthetic-files/3.1/flip.3.1.xml
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<score-partwise version="3.1">
+  <part-list>
+    <part-group type="start">
+      <footnote>x</footnote>
+      <level>x</level>
+    </part-group>
+    <score-part id="id1">
+      <part-name>x</part-name>
+    </score-part>
+    <part-group type="start">
+      <footnote>x</footnote>
+      <level>x</level>
+    </part-group>
+  </part-list>
+  <part id="id1">
+    <measure number="x">
+      <note>
+        <grace />
+        <pitch>
+          <step>A</step>
+          <octave>1</octave>
+        </pitch>
+        <footnote>x</footnote>
+        <level>x</level>
+        <voice>1</voice>
+        <staff>1</staff>
+        <notations>
+          <footnote>x</footnote>
+          <level>x</level>
+          <technical>
+            <flip default-x="1" default-y="1" relative-x="1" relative-y="1" font-family="x" font-style="normal" font-size="1" font-weight="normal" color="#FF000000" placement="above" />
+          </technical>
+        </notations>
+      </note>
+    </measure>
+  </part>
+</score-partwise>

--- a/docs/ai/projects/gen/synthetic-files/3.1/frame.3.1.xml
+++ b/docs/ai/projects/gen/synthetic-files/3.1/frame.3.1.xml
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<score-partwise version="3.1">
+  <part-list>
+    <part-group type="start">
+      <footnote>x</footnote>
+      <level>x</level>
+    </part-group>
+    <score-part id="id1">
+      <part-name>x</part-name>
+    </score-part>
+    <part-group type="start">
+      <footnote>x</footnote>
+      <level>x</level>
+    </part-group>
+  </part-list>
+  <part id="id1">
+    <measure number="x">
+      <harmony>
+        <root>
+          <root-step>A</root-step>
+        </root>
+        <kind>major</kind>
+        <frame default-x="1" default-y="1" relative-x="1" relative-y="1" color="#FF000000" halign="left" valign="top" height="1" width="1" unplayed="x" id="id3">
+          <frame-strings>1</frame-strings>
+          <frame-frets>1</frame-frets>
+          <frame-note>
+            <string>1</string>
+            <fret>1</fret>
+          </frame-note>
+        </frame>
+        <footnote>x</footnote>
+        <level>x</level>
+        <staff>1</staff>
+      </harmony>
+    </measure>
+  </part>
+</score-partwise>

--- a/docs/ai/projects/gen/synthetic-files/3.1/glass.3.1.xml
+++ b/docs/ai/projects/gen/synthetic-files/3.1/glass.3.1.xml
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<score-partwise version="3.1">
+  <part-list>
+    <part-group type="start">
+      <footnote>x</footnote>
+      <level>x</level>
+    </part-group>
+    <score-part id="id1">
+      <part-name>x</part-name>
+    </score-part>
+    <part-group type="start">
+      <footnote>x</footnote>
+      <level>x</level>
+    </part-group>
+  </part-list>
+  <part id="id1">
+    <measure number="x">
+      <direction>
+        <direction-type>
+          <percussion>
+            <glass smufl="pictGong">glass harmonica</glass>
+          </percussion>
+        </direction-type>
+        <footnote>x</footnote>
+        <level>x</level>
+        <voice>1</voice>
+        <staff>1</staff>
+      </direction>
+    </measure>
+  </part>
+</score-partwise>

--- a/docs/ai/projects/gen/synthetic-files/3.1/glissando.3.1.xml
+++ b/docs/ai/projects/gen/synthetic-files/3.1/glissando.3.1.xml
@@ -1,0 +1,36 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<score-partwise version="3.1">
+  <part-list>
+    <part-group type="start">
+      <footnote>x</footnote>
+      <level>x</level>
+    </part-group>
+    <score-part id="id1">
+      <part-name>x</part-name>
+    </score-part>
+    <part-group type="start">
+      <footnote>x</footnote>
+      <level>x</level>
+    </part-group>
+  </part-list>
+  <part id="id1">
+    <measure number="x">
+      <note>
+        <grace />
+        <pitch>
+          <step>A</step>
+          <octave>1</octave>
+        </pitch>
+        <footnote>x</footnote>
+        <level>x</level>
+        <voice>1</voice>
+        <staff>1</staff>
+        <notations>
+          <footnote>x</footnote>
+          <level>x</level>
+          <glissando default-x="1" default-y="1" relative-x="1" relative-y="1" font-family="x" font-style="normal" font-size="1" font-weight="normal" color="#FF000000" type="start" number="1" line-type="solid" dash-length="1" space-length="1" id="id3">x</glissando>
+        </notations>
+      </note>
+    </measure>
+  </part>
+</score-partwise>

--- a/docs/ai/projects/gen/synthetic-files/3.1/glyph.3.1.xml
+++ b/docs/ai/projects/gen/synthetic-files/3.1/glyph.3.1.xml
@@ -1,0 +1,36 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<score-partwise version="3.1">
+  <defaults>
+    <appearance>
+      <glyph type="x">noteheadBlack</glyph>
+    </appearance>
+  </defaults>
+  <part-list>
+    <part-group type="start">
+      <footnote>x</footnote>
+      <level>x</level>
+    </part-group>
+    <score-part id="id1">
+      <part-name>x</part-name>
+    </score-part>
+    <part-group type="start">
+      <footnote>x</footnote>
+      <level>x</level>
+    </part-group>
+  </part-list>
+  <part id="id1">
+    <measure number="x">
+      <note>
+        <grace />
+        <pitch>
+          <step>A</step>
+          <octave>1</octave>
+        </pitch>
+        <footnote>x</footnote>
+        <level>x</level>
+        <voice>1</voice>
+        <staff>1</staff>
+      </note>
+    </measure>
+  </part>
+</score-partwise>

--- a/docs/ai/projects/gen/synthetic-files/3.1/golpe.3.1.xml
+++ b/docs/ai/projects/gen/synthetic-files/3.1/golpe.3.1.xml
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<score-partwise version="3.1">
+  <part-list>
+    <part-group type="start">
+      <footnote>x</footnote>
+      <level>x</level>
+    </part-group>
+    <score-part id="id1">
+      <part-name>x</part-name>
+    </score-part>
+    <part-group type="start">
+      <footnote>x</footnote>
+      <level>x</level>
+    </part-group>
+  </part-list>
+  <part id="id1">
+    <measure number="x">
+      <note>
+        <grace />
+        <pitch>
+          <step>A</step>
+          <octave>1</octave>
+        </pitch>
+        <footnote>x</footnote>
+        <level>x</level>
+        <voice>1</voice>
+        <staff>1</staff>
+        <notations>
+          <footnote>x</footnote>
+          <level>x</level>
+          <technical>
+            <golpe default-x="1" default-y="1" relative-x="1" relative-y="1" font-family="x" font-style="normal" font-size="1" font-weight="normal" color="#FF000000" placement="above" />
+          </technical>
+        </notations>
+      </note>
+    </measure>
+  </part>
+</score-partwise>

--- a/docs/ai/projects/gen/synthetic-files/3.1/grouping.3.1.xml
+++ b/docs/ai/projects/gen/synthetic-files/3.1/grouping.3.1.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<score-partwise version="3.1">
+  <part-list>
+    <part-group type="start">
+      <footnote>x</footnote>
+      <level>x</level>
+    </part-group>
+    <score-part id="id1">
+      <part-name>x</part-name>
+    </score-part>
+    <part-group type="start">
+      <footnote>x</footnote>
+      <level>x</level>
+    </part-group>
+  </part-list>
+  <part id="id1">
+    <measure number="x">
+      <grouping type="start" number="x" member-of="x" id="id3" />
+    </measure>
+  </part>
+</score-partwise>

--- a/docs/ai/projects/gen/synthetic-files/3.1/half-muted.3.1.xml
+++ b/docs/ai/projects/gen/synthetic-files/3.1/half-muted.3.1.xml
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<score-partwise version="3.1">
+  <part-list>
+    <part-group type="start">
+      <footnote>x</footnote>
+      <level>x</level>
+    </part-group>
+    <score-part id="id1">
+      <part-name>x</part-name>
+    </score-part>
+    <part-group type="start">
+      <footnote>x</footnote>
+      <level>x</level>
+    </part-group>
+  </part-list>
+  <part id="id1">
+    <measure number="x">
+      <note>
+        <grace />
+        <pitch>
+          <step>A</step>
+          <octave>1</octave>
+        </pitch>
+        <footnote>x</footnote>
+        <level>x</level>
+        <voice>1</voice>
+        <staff>1</staff>
+        <notations>
+          <footnote>x</footnote>
+          <level>x</level>
+          <technical>
+            <half-muted default-x="1" default-y="1" relative-x="1" relative-y="1" font-family="x" font-style="normal" font-size="1" font-weight="normal" color="#FF000000" placement="above" smufl="noteheadBlack" />
+          </technical>
+        </notations>
+      </note>
+    </measure>
+  </part>
+</score-partwise>

--- a/docs/ai/projects/gen/synthetic-files/3.1/harmon-closed.3.1.xml
+++ b/docs/ai/projects/gen/synthetic-files/3.1/harmon-closed.3.1.xml
@@ -1,0 +1,40 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<score-partwise version="3.1">
+  <part-list>
+    <part-group type="start">
+      <footnote>x</footnote>
+      <level>x</level>
+    </part-group>
+    <score-part id="id1">
+      <part-name>x</part-name>
+    </score-part>
+    <part-group type="start">
+      <footnote>x</footnote>
+      <level>x</level>
+    </part-group>
+  </part-list>
+  <part id="id1">
+    <measure number="x">
+      <note>
+        <grace />
+        <pitch>
+          <step>A</step>
+          <octave>1</octave>
+        </pitch>
+        <footnote>x</footnote>
+        <level>x</level>
+        <voice>1</voice>
+        <staff>1</staff>
+        <notations>
+          <footnote>x</footnote>
+          <level>x</level>
+          <technical>
+            <harmon-mute>
+              <harmon-closed location="right">yes</harmon-closed>
+            </harmon-mute>
+          </technical>
+        </notations>
+      </note>
+    </measure>
+  </part>
+</score-partwise>

--- a/docs/ai/projects/gen/synthetic-files/3.1/harmon-mute.3.1.xml
+++ b/docs/ai/projects/gen/synthetic-files/3.1/harmon-mute.3.1.xml
@@ -1,0 +1,40 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<score-partwise version="3.1">
+  <part-list>
+    <part-group type="start">
+      <footnote>x</footnote>
+      <level>x</level>
+    </part-group>
+    <score-part id="id1">
+      <part-name>x</part-name>
+    </score-part>
+    <part-group type="start">
+      <footnote>x</footnote>
+      <level>x</level>
+    </part-group>
+  </part-list>
+  <part id="id1">
+    <measure number="x">
+      <note>
+        <grace />
+        <pitch>
+          <step>A</step>
+          <octave>1</octave>
+        </pitch>
+        <footnote>x</footnote>
+        <level>x</level>
+        <voice>1</voice>
+        <staff>1</staff>
+        <notations>
+          <footnote>x</footnote>
+          <level>x</level>
+          <technical>
+            <harmon-mute default-x="1" default-y="1" relative-x="1" relative-y="1" font-family="x" font-style="normal" font-size="1" font-weight="normal" color="#FF000000" placement="above">
+              <harmon-closed>yes</harmon-closed>
+            </harmon-mute>
+          </technical>
+        </notations>
+      </note>
+    </measure>
+  </part>
+</score-partwise>

--- a/docs/ai/projects/gen/synthetic-files/3.1/harmony.3.1.xml
+++ b/docs/ai/projects/gen/synthetic-files/3.1/harmony.3.1.xml
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<score-partwise version="3.1">
+  <part-list>
+    <part-group type="start">
+      <footnote>x</footnote>
+      <level>x</level>
+    </part-group>
+    <score-part id="id1">
+      <part-name>x</part-name>
+    </score-part>
+    <part-group type="start">
+      <footnote>x</footnote>
+      <level>x</level>
+    </part-group>
+  </part-list>
+  <part id="id1">
+    <measure number="x">
+      <harmony type="explicit" print-object="yes" print-frame="yes" default-x="1" default-y="1" relative-x="1" relative-y="1" font-family="x" font-style="normal" font-size="1" font-weight="normal" color="#FF000000" placement="above" id="id3">
+        <root>
+          <root-step>A</root-step>
+        </root>
+        <kind>major</kind>
+        <footnote>x</footnote>
+        <level>x</level>
+        <staff>1</staff>
+      </harmony>
+    </measure>
+  </part>
+</score-partwise>

--- a/docs/ai/projects/gen/synthetic-files/3.1/harp-pedals.3.1.xml
+++ b/docs/ai/projects/gen/synthetic-files/3.1/harp-pedals.3.1.xml
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<score-partwise version="3.1">
+  <part-list>
+    <part-group type="start">
+      <footnote>x</footnote>
+      <level>x</level>
+    </part-group>
+    <score-part id="id1">
+      <part-name>x</part-name>
+    </score-part>
+    <part-group type="start">
+      <footnote>x</footnote>
+      <level>x</level>
+    </part-group>
+  </part-list>
+  <part id="id1">
+    <measure number="x">
+      <direction>
+        <direction-type>
+          <harp-pedals default-x="1" default-y="1" relative-x="1" relative-y="1" font-family="x" font-style="normal" font-size="1" font-weight="normal" color="#FF000000" halign="left" valign="top" id="id3">
+            <pedal-tuning>
+              <pedal-step>A</pedal-step>
+              <pedal-alter>1</pedal-alter>
+            </pedal-tuning>
+          </harp-pedals>
+        </direction-type>
+        <footnote>x</footnote>
+        <level>x</level>
+        <voice>1</voice>
+        <staff>1</staff>
+      </direction>
+    </measure>
+  </part>
+</score-partwise>

--- a/docs/ai/projects/gen/synthetic-files/3.1/haydn.3.1.xml
+++ b/docs/ai/projects/gen/synthetic-files/3.1/haydn.3.1.xml
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<score-partwise version="3.1">
+  <part-list>
+    <part-group type="start">
+      <footnote>x</footnote>
+      <level>x</level>
+    </part-group>
+    <score-part id="id1">
+      <part-name>x</part-name>
+    </score-part>
+    <part-group type="start">
+      <footnote>x</footnote>
+      <level>x</level>
+    </part-group>
+  </part-list>
+  <part id="id1">
+    <measure number="x">
+      <note>
+        <grace />
+        <pitch>
+          <step>A</step>
+          <octave>1</octave>
+        </pitch>
+        <footnote>x</footnote>
+        <level>x</level>
+        <voice>1</voice>
+        <staff>1</staff>
+        <notations>
+          <footnote>x</footnote>
+          <level>x</level>
+          <ornaments>
+            <haydn default-x="1" default-y="1" relative-x="1" relative-y="1" font-family="x" font-style="normal" font-size="1" font-weight="normal" color="#FF000000" placement="above" start-note="upper" trill-step="whole" two-note-turn="whole" accelerate="yes" beats="2" second-beat="1" last-beat="1" />
+          </ornaments>
+        </notations>
+      </note>
+    </measure>
+  </part>
+</score-partwise>

--- a/docs/ai/projects/gen/synthetic-files/3.1/image.3.1.xml
+++ b/docs/ai/projects/gen/synthetic-files/3.1/image.3.1.xml
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<score-partwise version="3.1">
+  <part-list>
+    <part-group type="start">
+      <footnote>x</footnote>
+      <level>x</level>
+    </part-group>
+    <score-part id="id1">
+      <part-name>x</part-name>
+    </score-part>
+    <part-group type="start">
+      <footnote>x</footnote>
+      <level>x</level>
+    </part-group>
+  </part-list>
+  <part id="id1">
+    <measure number="x">
+      <direction>
+        <direction-type>
+          <image source="http://example.com" type="x" height="1" width="1" default-x="1" default-y="1" relative-x="1" relative-y="1" halign="left" valign="top" id="id3" />
+        </direction-type>
+        <footnote>x</footnote>
+        <level>x</level>
+        <voice>1</voice>
+        <staff>1</staff>
+      </direction>
+    </measure>
+  </part>
+</score-partwise>

--- a/docs/ai/projects/gen/synthetic-files/3.1/inverted-vertical-turn.3.1.xml
+++ b/docs/ai/projects/gen/synthetic-files/3.1/inverted-vertical-turn.3.1.xml
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<score-partwise version="3.1">
+  <part-list>
+    <part-group type="start">
+      <footnote>x</footnote>
+      <level>x</level>
+    </part-group>
+    <score-part id="id1">
+      <part-name>x</part-name>
+    </score-part>
+    <part-group type="start">
+      <footnote>x</footnote>
+      <level>x</level>
+    </part-group>
+  </part-list>
+  <part id="id1">
+    <measure number="x">
+      <note>
+        <grace />
+        <pitch>
+          <step>A</step>
+          <octave>1</octave>
+        </pitch>
+        <footnote>x</footnote>
+        <level>x</level>
+        <voice>1</voice>
+        <staff>1</staff>
+        <notations>
+          <footnote>x</footnote>
+          <level>x</level>
+          <ornaments>
+            <inverted-vertical-turn default-x="1" default-y="1" relative-x="1" relative-y="1" font-family="x" font-style="normal" font-size="1" font-weight="normal" color="#FF000000" placement="above" start-note="upper" trill-step="whole" two-note-turn="whole" accelerate="yes" beats="2" second-beat="1" last-beat="1" />
+          </ornaments>
+        </notations>
+      </note>
+    </measure>
+  </part>
+</score-partwise>

--- a/docs/ai/projects/gen/synthetic-files/3.1/key-accidental.smufl.3.1.xml
+++ b/docs/ai/projects/gen/synthetic-files/3.1/key-accidental.smufl.3.1.xml
@@ -1,0 +1,36 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<score-partwise version="3.1">
+  <part-list>
+    <score-part id="P1">
+      <part-name>P</part-name>
+    </score-part>
+  </part-list>
+  <part id="P1">
+    <measure number="1">
+      <attributes>
+        <divisions>1</divisions>
+        <key>
+          <key-step>C</key-step>
+          <key-alter>-1</key-alter>
+          <key-accidental smufl="accidentalFlat">flat</key-accidental>
+        </key>
+        <time>
+          <beats>4</beats>
+          <beat-type>4</beat-type>
+        </time>
+        <clef>
+          <sign>G</sign>
+          <line>2</line>
+        </clef>
+      </attributes>
+      <note>
+        <pitch>
+          <step>C</step>
+          <octave>4</octave>
+        </pitch>
+        <duration>1</duration>
+        <type>quarter</type>
+      </note>
+    </measure>
+  </part>
+</score-partwise>

--- a/docs/ai/projects/gen/synthetic-files/3.1/key.3.1.xml
+++ b/docs/ai/projects/gen/synthetic-files/3.1/key.3.1.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<score-partwise version="3.1">
+  <part-list>
+    <part-group type="start">
+      <footnote>x</footnote>
+      <level>x</level>
+    </part-group>
+    <score-part id="id1">
+      <part-name>x</part-name>
+    </score-part>
+    <part-group type="start">
+      <footnote>x</footnote>
+      <level>x</level>
+    </part-group>
+  </part-list>
+  <part id="id1">
+    <measure number="x">
+      <attributes>
+        <footnote>x</footnote>
+        <level>x</level>
+        <key number="1" default-x="1" default-y="1" relative-x="1" relative-y="1" font-family="x" font-style="normal" font-size="1" font-weight="normal" color="#FF000000" print-object="yes" id="id3">
+          <fifths>1</fifths>
+        </key>
+      </attributes>
+    </measure>
+  </part>
+</score-partwise>

--- a/docs/ai/projects/gen/synthetic-files/3.1/lyric.3.1.xml
+++ b/docs/ai/projects/gen/synthetic-files/3.1/lyric.3.1.xml
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<score-partwise version="3.1">
+  <part-list>
+    <part-group type="start">
+      <footnote>x</footnote>
+      <level>x</level>
+    </part-group>
+    <score-part id="id1">
+      <part-name>x</part-name>
+    </score-part>
+    <part-group type="start">
+      <footnote>x</footnote>
+      <level>x</level>
+    </part-group>
+  </part-list>
+  <part id="id1">
+    <measure number="x">
+      <note>
+        <grace />
+        <pitch>
+          <step>A</step>
+          <octave>1</octave>
+        </pitch>
+        <footnote>x</footnote>
+        <level>x</level>
+        <voice>1</voice>
+        <staff>1</staff>
+        <lyric number="x" name="x" justify="left" default-x="1" default-y="1" relative-x="1" relative-y="1" placement="above" color="#FF000000" print-object="yes" time-only="1" id="id3">
+          <text>x</text>
+          <elision>x</elision>
+          <text>x</text>
+          <footnote>x</footnote>
+          <level>x</level>
+        </lyric>
+      </note>
+    </measure>
+  </part>
+</score-partwise>

--- a/docs/ai/projects/gen/synthetic-files/3.1/measure-style.3.1.xml
+++ b/docs/ai/projects/gen/synthetic-files/3.1/measure-style.3.1.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<score-partwise version="3.1">
+  <part-list>
+    <part-group type="start">
+      <footnote>x</footnote>
+      <level>x</level>
+    </part-group>
+    <score-part id="id1">
+      <part-name>x</part-name>
+    </score-part>
+    <part-group type="start">
+      <footnote>x</footnote>
+      <level>x</level>
+    </part-group>
+  </part-list>
+  <part id="id1">
+    <measure number="x">
+      <attributes>
+        <footnote>x</footnote>
+        <level>x</level>
+        <measure-style number="1" font-family="x" font-style="normal" font-size="1" font-weight="normal" color="#FF000000" id="id3">
+          <multiple-rest>1</multiple-rest>
+        </measure-style>
+      </attributes>
+    </measure>
+  </part>
+</score-partwise>

--- a/docs/ai/projects/gen/synthetic-files/3.1/measure.3.1.xml
+++ b/docs/ai/projects/gen/synthetic-files/3.1/measure.3.1.xml
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<score-partwise version="3.1">
+  <part-list>
+    <part-group type="start">
+      <footnote>x</footnote>
+      <level>x</level>
+    </part-group>
+    <score-part id="id1">
+      <part-name>x</part-name>
+    </score-part>
+    <part-group type="start">
+      <footnote>x</footnote>
+      <level>x</level>
+    </part-group>
+  </part-list>
+  <part id="id1">
+    <measure number="x" text="x" implicit="yes" non-controlling="yes" width="1" id="id3">
+      <note>
+        <grace />
+        <pitch>
+          <step>A</step>
+          <octave>1</octave>
+        </pitch>
+        <footnote>x</footnote>
+        <level>x</level>
+        <voice>1</voice>
+        <staff>1</staff>
+      </note>
+    </measure>
+  </part>
+</score-partwise>

--- a/docs/ai/projects/gen/synthetic-files/3.1/metronome-arrows.3.1.xml
+++ b/docs/ai/projects/gen/synthetic-files/3.1/metronome-arrows.3.1.xml
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<score-partwise version="3.1">
+  <part-list>
+    <part-group type="start">
+      <footnote>x</footnote>
+      <level>x</level>
+    </part-group>
+    <score-part id="id1">
+      <part-name>x</part-name>
+    </score-part>
+    <part-group type="start">
+      <footnote>x</footnote>
+      <level>x</level>
+    </part-group>
+  </part-list>
+  <part id="id1">
+    <measure number="x">
+      <direction>
+        <direction-type>
+          <metronome>
+            <metronome-arrows />
+            <metronome-note>
+              <metronome-type>1024th</metronome-type>
+            </metronome-note>
+            <metronome-relation>1</metronome-relation>
+            <metronome-note>
+              <metronome-type>1024th</metronome-type>
+            </metronome-note>
+          </metronome>
+        </direction-type>
+        <footnote>x</footnote>
+        <level>x</level>
+        <voice>1</voice>
+        <staff>1</staff>
+      </direction>
+    </measure>
+  </part>
+</score-partwise>

--- a/docs/ai/projects/gen/synthetic-files/3.1/metronome-tied.3.1.xml
+++ b/docs/ai/projects/gen/synthetic-files/3.1/metronome-tied.3.1.xml
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<score-partwise version="3.1">
+  <part-list>
+    <part-group type="start">
+      <footnote>x</footnote>
+      <level>x</level>
+    </part-group>
+    <score-part id="id1">
+      <part-name>x</part-name>
+    </score-part>
+    <part-group type="start">
+      <footnote>x</footnote>
+      <level>x</level>
+    </part-group>
+  </part-list>
+  <part id="id1">
+    <measure number="x">
+      <direction>
+        <direction-type>
+          <metronome>
+            <metronome-note>
+              <metronome-type>1024th</metronome-type>
+              <metronome-tied type="start" />
+            </metronome-note>
+            <metronome-relation>1</metronome-relation>
+            <metronome-note>
+              <metronome-type>1024th</metronome-type>
+            </metronome-note>
+          </metronome>
+        </direction-type>
+        <footnote>x</footnote>
+        <level>x</level>
+        <voice>1</voice>
+        <staff>1</staff>
+      </direction>
+    </measure>
+  </part>
+</score-partwise>

--- a/docs/ai/projects/gen/synthetic-files/3.1/metronome.3.1.xml
+++ b/docs/ai/projects/gen/synthetic-files/3.1/metronome.3.1.xml
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<score-partwise version="3.1">
+  <part-list>
+    <part-group type="start">
+      <footnote>x</footnote>
+      <level>x</level>
+    </part-group>
+    <score-part id="id1">
+      <part-name>x</part-name>
+    </score-part>
+    <part-group type="start">
+      <footnote>x</footnote>
+      <level>x</level>
+    </part-group>
+  </part-list>
+  <part id="id1">
+    <measure number="x">
+      <direction>
+        <direction-type>
+          <metronome default-x="1" default-y="1" relative-x="1" relative-y="1" font-family="x" font-style="normal" font-size="1" font-weight="normal" color="#FF000000" halign="left" valign="top" justify="left" parentheses="yes" id="id3">
+            <beat-unit>1024th</beat-unit>
+            <per-minute>x</per-minute>
+          </metronome>
+        </direction-type>
+        <footnote>x</footnote>
+        <level>x</level>
+        <voice>1</voice>
+        <staff>1</staff>
+      </direction>
+    </measure>
+  </part>
+</score-partwise>

--- a/docs/ai/projects/gen/synthetic-files/3.1/n.3.1.xml
+++ b/docs/ai/projects/gen/synthetic-files/3.1/n.3.1.xml
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<score-partwise version="3.1">
+  <part-list>
+    <part-group type="start">
+      <footnote>x</footnote>
+      <level>x</level>
+    </part-group>
+    <score-part id="id1">
+      <part-name>x</part-name>
+    </score-part>
+    <part-group type="start">
+      <footnote>x</footnote>
+      <level>x</level>
+    </part-group>
+  </part-list>
+  <part id="id1">
+    <measure number="x">
+      <note>
+        <grace />
+        <pitch>
+          <step>A</step>
+          <octave>1</octave>
+        </pitch>
+        <footnote>x</footnote>
+        <level>x</level>
+        <voice>1</voice>
+        <staff>1</staff>
+        <notations>
+          <footnote>x</footnote>
+          <level>x</level>
+          <dynamics>
+            <n />
+          </dynamics>
+        </notations>
+      </note>
+    </measure>
+  </part>
+</score-partwise>

--- a/docs/ai/projects/gen/synthetic-files/3.1/non-arpeggiate.3.1.xml
+++ b/docs/ai/projects/gen/synthetic-files/3.1/non-arpeggiate.3.1.xml
@@ -1,0 +1,36 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<score-partwise version="3.1">
+  <part-list>
+    <part-group type="start">
+      <footnote>x</footnote>
+      <level>x</level>
+    </part-group>
+    <score-part id="id1">
+      <part-name>x</part-name>
+    </score-part>
+    <part-group type="start">
+      <footnote>x</footnote>
+      <level>x</level>
+    </part-group>
+  </part-list>
+  <part id="id1">
+    <measure number="x">
+      <note>
+        <grace />
+        <pitch>
+          <step>A</step>
+          <octave>1</octave>
+        </pitch>
+        <footnote>x</footnote>
+        <level>x</level>
+        <voice>1</voice>
+        <staff>1</staff>
+        <notations>
+          <footnote>x</footnote>
+          <level>x</level>
+          <non-arpeggiate type="top" number="1" default-x="1" default-y="1" relative-x="1" relative-y="1" placement="above" color="#FF000000" id="id3" />
+        </notations>
+      </note>
+    </measure>
+  </part>
+</score-partwise>

--- a/docs/ai/projects/gen/synthetic-files/3.1/notations.3.1.xml
+++ b/docs/ai/projects/gen/synthetic-files/3.1/notations.3.1.xml
@@ -1,0 +1,36 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<score-partwise version="3.1">
+  <part-list>
+    <part-group type="start">
+      <footnote>x</footnote>
+      <level>x</level>
+    </part-group>
+    <score-part id="id1">
+      <part-name>x</part-name>
+    </score-part>
+    <part-group type="start">
+      <footnote>x</footnote>
+      <level>x</level>
+    </part-group>
+  </part-list>
+  <part id="id1">
+    <measure number="x">
+      <note>
+        <grace />
+        <pitch>
+          <step>A</step>
+          <octave>1</octave>
+        </pitch>
+        <footnote>x</footnote>
+        <level>x</level>
+        <voice>1</voice>
+        <staff>1</staff>
+        <notations print-object="yes" id="id3">
+          <footnote>x</footnote>
+          <level>x</level>
+          <tied type="start" />
+        </notations>
+      </note>
+    </measure>
+  </part>
+</score-partwise>

--- a/docs/ai/projects/gen/synthetic-files/3.1/note.3.1.xml
+++ b/docs/ai/projects/gen/synthetic-files/3.1/note.3.1.xml
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<score-partwise version="3.1">
+  <part-list>
+    <part-group type="start">
+      <footnote>x</footnote>
+      <level>x</level>
+    </part-group>
+    <score-part id="id1">
+      <part-name>x</part-name>
+    </score-part>
+    <part-group type="start">
+      <footnote>x</footnote>
+      <level>x</level>
+    </part-group>
+  </part-list>
+  <part id="id1">
+    <measure number="x">
+      <note default-x="1" default-y="1" relative-x="1" relative-y="1" font-family="x" font-style="normal" font-size="1" font-weight="normal" color="#FF000000" print-object="yes" print-dot="yes" print-spacing="yes" print-lyric="yes" print-leger="yes" dynamics="1" end-dynamics="1" attack="1" release="1" time-only="1" pizzicato="yes" id="id3">
+        <grace />
+        <pitch>
+          <step>A</step>
+          <octave>1</octave>
+        </pitch>
+        <footnote>x</footnote>
+        <level>x</level>
+        <voice>1</voice>
+        <staff>1</staff>
+      </note>
+    </measure>
+  </part>
+</score-partwise>

--- a/docs/ai/projects/gen/synthetic-files/3.1/notehead.3.1.xml
+++ b/docs/ai/projects/gen/synthetic-files/3.1/notehead.3.1.xml
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<score-partwise version="3.1">
+  <part-list>
+    <part-group type="start">
+      <footnote>x</footnote>
+      <level>x</level>
+    </part-group>
+    <score-part id="id1">
+      <part-name>x</part-name>
+    </score-part>
+    <part-group type="start">
+      <footnote>x</footnote>
+      <level>x</level>
+    </part-group>
+  </part-list>
+  <part id="id1">
+    <measure number="x">
+      <note>
+        <grace />
+        <pitch>
+          <step>A</step>
+          <octave>1</octave>
+        </pitch>
+        <footnote>x</footnote>
+        <level>x</level>
+        <voice>1</voice>
+        <notehead filled="yes" parentheses="yes" font-family="x" font-style="normal" font-size="1" font-weight="normal" color="#FF000000" smufl="noteheadBlack">slash</notehead>
+        <staff>1</staff>
+      </note>
+    </measure>
+  </part>
+</score-partwise>

--- a/docs/ai/projects/gen/synthetic-files/3.1/octave-shift.3.1.xml
+++ b/docs/ai/projects/gen/synthetic-files/3.1/octave-shift.3.1.xml
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<score-partwise version="3.1">
+  <part-list>
+    <part-group type="start">
+      <footnote>x</footnote>
+      <level>x</level>
+    </part-group>
+    <score-part id="id1">
+      <part-name>x</part-name>
+    </score-part>
+    <part-group type="start">
+      <footnote>x</footnote>
+      <level>x</level>
+    </part-group>
+  </part-list>
+  <part id="id1">
+    <measure number="x">
+      <direction>
+        <direction-type>
+          <octave-shift type="up" number="1" size="1" dash-length="1" space-length="1" default-x="1" default-y="1" relative-x="1" relative-y="1" font-family="x" font-style="normal" font-size="1" font-weight="normal" color="#FF000000" id="id3" />
+        </direction-type>
+        <footnote>x</footnote>
+        <level>x</level>
+        <voice>1</voice>
+        <staff>1</staff>
+      </direction>
+    </measure>
+  </part>
+</score-partwise>

--- a/docs/ai/projects/gen/synthetic-files/3.1/open.3.1.xml
+++ b/docs/ai/projects/gen/synthetic-files/3.1/open.3.1.xml
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<score-partwise version="3.1">
+  <part-list>
+    <part-group type="start">
+      <footnote>x</footnote>
+      <level>x</level>
+    </part-group>
+    <score-part id="id1">
+      <part-name>x</part-name>
+    </score-part>
+    <part-group type="start">
+      <footnote>x</footnote>
+      <level>x</level>
+    </part-group>
+  </part-list>
+  <part id="id1">
+    <measure number="x">
+      <note>
+        <grace />
+        <pitch>
+          <step>A</step>
+          <octave>1</octave>
+        </pitch>
+        <footnote>x</footnote>
+        <level>x</level>
+        <voice>1</voice>
+        <staff>1</staff>
+        <notations>
+          <footnote>x</footnote>
+          <level>x</level>
+          <technical>
+            <open default-x="1" default-y="1" relative-x="1" relative-y="1" font-family="x" font-style="normal" font-size="1" font-weight="normal" color="#FF000000" placement="above" smufl="noteheadBlack" />
+          </technical>
+        </notations>
+      </note>
+    </measure>
+  </part>
+</score-partwise>

--- a/docs/ai/projects/gen/synthetic-files/3.1/ornaments.3.1.xml
+++ b/docs/ai/projects/gen/synthetic-files/3.1/ornaments.3.1.xml
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<score-partwise version="3.1">
+  <part-list>
+    <part-group type="start">
+      <footnote>x</footnote>
+      <level>x</level>
+    </part-group>
+    <score-part id="id1">
+      <part-name>x</part-name>
+    </score-part>
+    <part-group type="start">
+      <footnote>x</footnote>
+      <level>x</level>
+    </part-group>
+  </part-list>
+  <part id="id1">
+    <measure number="x">
+      <note>
+        <grace />
+        <pitch>
+          <step>A</step>
+          <octave>1</octave>
+        </pitch>
+        <footnote>x</footnote>
+        <level>x</level>
+        <voice>1</voice>
+        <staff>1</staff>
+        <notations>
+          <footnote>x</footnote>
+          <level>x</level>
+          <ornaments id="id3">
+            <trill-mark />
+          </ornaments>
+        </notations>
+      </note>
+    </measure>
+  </part>
+</score-partwise>

--- a/docs/ai/projects/gen/synthetic-files/3.1/other-articulation.3.1.xml
+++ b/docs/ai/projects/gen/synthetic-files/3.1/other-articulation.3.1.xml
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<score-partwise version="3.1">
+  <part-list>
+    <part-group type="start">
+      <footnote>x</footnote>
+      <level>x</level>
+    </part-group>
+    <score-part id="id1">
+      <part-name>x</part-name>
+    </score-part>
+    <part-group type="start">
+      <footnote>x</footnote>
+      <level>x</level>
+    </part-group>
+  </part-list>
+  <part id="id1">
+    <measure number="x">
+      <note>
+        <grace />
+        <pitch>
+          <step>A</step>
+          <octave>1</octave>
+        </pitch>
+        <footnote>x</footnote>
+        <level>x</level>
+        <voice>1</voice>
+        <staff>1</staff>
+        <notations>
+          <footnote>x</footnote>
+          <level>x</level>
+          <articulations>
+            <other-articulation default-x="1" default-y="1" relative-x="1" relative-y="1" font-family="x" font-style="normal" font-size="1" font-weight="normal" color="#FF000000" placement="above" smufl="noteheadBlack">x</other-articulation>
+          </articulations>
+        </notations>
+      </note>
+    </measure>
+  </part>
+</score-partwise>

--- a/docs/ai/projects/gen/synthetic-files/3.1/other-direction.3.1.xml
+++ b/docs/ai/projects/gen/synthetic-files/3.1/other-direction.3.1.xml
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<score-partwise version="3.1">
+  <part-list>
+    <part-group type="start">
+      <footnote>x</footnote>
+      <level>x</level>
+    </part-group>
+    <score-part id="id1">
+      <part-name>x</part-name>
+    </score-part>
+    <part-group type="start">
+      <footnote>x</footnote>
+      <level>x</level>
+    </part-group>
+  </part-list>
+  <part id="id1">
+    <measure number="x">
+      <direction>
+        <direction-type>
+          <other-direction default-x="1" default-y="1" relative-x="1" relative-y="1" font-family="x" font-style="normal" font-size="1" font-weight="normal" color="#FF000000" print-object="yes" halign="left" valign="top" smufl="noteheadBlack" id="id3">x</other-direction>
+        </direction-type>
+        <footnote>x</footnote>
+        <level>x</level>
+        <voice>1</voice>
+        <staff>1</staff>
+      </direction>
+    </measure>
+  </part>
+</score-partwise>

--- a/docs/ai/projects/gen/synthetic-files/3.1/other-dynamics.3.1.xml
+++ b/docs/ai/projects/gen/synthetic-files/3.1/other-dynamics.3.1.xml
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<score-partwise version="3.1">
+  <part-list>
+    <part-group type="start">
+      <footnote>x</footnote>
+      <level>x</level>
+    </part-group>
+    <score-part id="id1">
+      <part-name>x</part-name>
+    </score-part>
+    <part-group type="start">
+      <footnote>x</footnote>
+      <level>x</level>
+    </part-group>
+  </part-list>
+  <part id="id1">
+    <measure number="x">
+      <note>
+        <grace />
+        <pitch>
+          <step>A</step>
+          <octave>1</octave>
+        </pitch>
+        <footnote>x</footnote>
+        <level>x</level>
+        <voice>1</voice>
+        <staff>1</staff>
+        <notations>
+          <footnote>x</footnote>
+          <level>x</level>
+          <dynamics>
+            <other-dynamics smufl="noteheadBlack">x</other-dynamics>
+          </dynamics>
+        </notations>
+      </note>
+    </measure>
+  </part>
+</score-partwise>

--- a/docs/ai/projects/gen/synthetic-files/3.1/other-notation.3.1.xml
+++ b/docs/ai/projects/gen/synthetic-files/3.1/other-notation.3.1.xml
@@ -1,0 +1,36 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<score-partwise version="3.1">
+  <part-list>
+    <part-group type="start">
+      <footnote>x</footnote>
+      <level>x</level>
+    </part-group>
+    <score-part id="id1">
+      <part-name>x</part-name>
+    </score-part>
+    <part-group type="start">
+      <footnote>x</footnote>
+      <level>x</level>
+    </part-group>
+  </part-list>
+  <part id="id1">
+    <measure number="x">
+      <note>
+        <grace />
+        <pitch>
+          <step>A</step>
+          <octave>1</octave>
+        </pitch>
+        <footnote>x</footnote>
+        <level>x</level>
+        <voice>1</voice>
+        <staff>1</staff>
+        <notations>
+          <footnote>x</footnote>
+          <level>x</level>
+          <other-notation default-x="1" default-y="1" relative-x="1" relative-y="1" font-family="x" font-style="normal" font-size="1" font-weight="normal" color="#FF000000" placement="above" type="start" number="1" print-object="yes" smufl="noteheadBlack" id="id3">x</other-notation>
+        </notations>
+      </note>
+    </measure>
+  </part>
+</score-partwise>

--- a/docs/ai/projects/gen/synthetic-files/3.1/other-ornament.3.1.xml
+++ b/docs/ai/projects/gen/synthetic-files/3.1/other-ornament.3.1.xml
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<score-partwise version="3.1">
+  <part-list>
+    <part-group type="start">
+      <footnote>x</footnote>
+      <level>x</level>
+    </part-group>
+    <score-part id="id1">
+      <part-name>x</part-name>
+    </score-part>
+    <part-group type="start">
+      <footnote>x</footnote>
+      <level>x</level>
+    </part-group>
+  </part-list>
+  <part id="id1">
+    <measure number="x">
+      <note>
+        <grace />
+        <pitch>
+          <step>A</step>
+          <octave>1</octave>
+        </pitch>
+        <footnote>x</footnote>
+        <level>x</level>
+        <voice>1</voice>
+        <staff>1</staff>
+        <notations>
+          <footnote>x</footnote>
+          <level>x</level>
+          <ornaments>
+            <other-ornament default-x="1" default-y="1" relative-x="1" relative-y="1" font-family="x" font-style="normal" font-size="1" font-weight="normal" color="#FF000000" placement="above" smufl="noteheadBlack">x</other-ornament>
+          </ornaments>
+        </notations>
+      </note>
+    </measure>
+  </part>
+</score-partwise>

--- a/docs/ai/projects/gen/synthetic-files/3.1/other-percussion.3.1.xml
+++ b/docs/ai/projects/gen/synthetic-files/3.1/other-percussion.3.1.xml
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<score-partwise version="3.1">
+  <part-list>
+    <part-group type="start">
+      <footnote>x</footnote>
+      <level>x</level>
+    </part-group>
+    <score-part id="id1">
+      <part-name>x</part-name>
+    </score-part>
+    <part-group type="start">
+      <footnote>x</footnote>
+      <level>x</level>
+    </part-group>
+  </part-list>
+  <part id="id1">
+    <measure number="x">
+      <direction>
+        <direction-type>
+          <percussion>
+            <other-percussion smufl="noteheadBlack">x</other-percussion>
+          </percussion>
+        </direction-type>
+        <footnote>x</footnote>
+        <level>x</level>
+        <voice>1</voice>
+        <staff>1</staff>
+      </direction>
+    </measure>
+  </part>
+</score-partwise>

--- a/docs/ai/projects/gen/synthetic-files/3.1/other-technical.3.1.xml
+++ b/docs/ai/projects/gen/synthetic-files/3.1/other-technical.3.1.xml
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<score-partwise version="3.1">
+  <part-list>
+    <part-group type="start">
+      <footnote>x</footnote>
+      <level>x</level>
+    </part-group>
+    <score-part id="id1">
+      <part-name>x</part-name>
+    </score-part>
+    <part-group type="start">
+      <footnote>x</footnote>
+      <level>x</level>
+    </part-group>
+  </part-list>
+  <part id="id1">
+    <measure number="x">
+      <note>
+        <grace />
+        <pitch>
+          <step>A</step>
+          <octave>1</octave>
+        </pitch>
+        <footnote>x</footnote>
+        <level>x</level>
+        <voice>1</voice>
+        <staff>1</staff>
+        <notations>
+          <footnote>x</footnote>
+          <level>x</level>
+          <technical>
+            <other-technical default-x="1" default-y="1" relative-x="1" relative-y="1" font-family="x" font-style="normal" font-size="1" font-weight="normal" color="#FF000000" placement="above" smufl="noteheadBlack">x</other-technical>
+          </technical>
+        </notations>
+      </note>
+    </measure>
+  </part>
+</score-partwise>

--- a/docs/ai/projects/gen/synthetic-files/3.1/pedal.3.1.xml
+++ b/docs/ai/projects/gen/synthetic-files/3.1/pedal.3.1.xml
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<score-partwise version="3.1">
+  <part-list>
+    <part-group type="start">
+      <footnote>x</footnote>
+      <level>x</level>
+    </part-group>
+    <score-part id="id1">
+      <part-name>x</part-name>
+    </score-part>
+    <part-group type="start">
+      <footnote>x</footnote>
+      <level>x</level>
+    </part-group>
+  </part-list>
+  <part id="id1">
+    <measure number="x">
+      <direction>
+        <direction-type>
+          <pedal type="start" number="1" line="yes" sign="yes" abbreviated="yes" default-x="1" default-y="1" relative-x="1" relative-y="1" font-family="x" font-style="normal" font-size="1" font-weight="normal" color="#FF000000" halign="left" valign="top" id="id3" />
+        </direction-type>
+        <footnote>x</footnote>
+        <level>x</level>
+        <voice>1</voice>
+        <staff>1</staff>
+      </direction>
+    </measure>
+  </part>
+</score-partwise>

--- a/docs/ai/projects/gen/synthetic-files/3.1/percussion.3.1.xml
+++ b/docs/ai/projects/gen/synthetic-files/3.1/percussion.3.1.xml
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<score-partwise version="3.1">
+  <part-list>
+    <part-group type="start">
+      <footnote>x</footnote>
+      <level>x</level>
+    </part-group>
+    <score-part id="id1">
+      <part-name>x</part-name>
+    </score-part>
+    <part-group type="start">
+      <footnote>x</footnote>
+      <level>x</level>
+    </part-group>
+  </part-list>
+  <part id="id1">
+    <measure number="x">
+      <direction>
+        <direction-type>
+          <percussion default-x="1" default-y="1" relative-x="1" relative-y="1" font-family="x" font-style="normal" font-size="1" font-weight="normal" color="#FF000000" halign="left" valign="top" enclosure="rectangle" id="id3">
+            <glass>glass harmonica</glass>
+          </percussion>
+        </direction-type>
+        <footnote>x</footnote>
+        <level>x</level>
+        <voice>1</voice>
+        <staff>1</staff>
+      </direction>
+    </measure>
+  </part>
+</score-partwise>

--- a/docs/ai/projects/gen/synthetic-files/3.1/pf.3.1.xml
+++ b/docs/ai/projects/gen/synthetic-files/3.1/pf.3.1.xml
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<score-partwise version="3.1">
+  <part-list>
+    <part-group type="start">
+      <footnote>x</footnote>
+      <level>x</level>
+    </part-group>
+    <score-part id="id1">
+      <part-name>x</part-name>
+    </score-part>
+    <part-group type="start">
+      <footnote>x</footnote>
+      <level>x</level>
+    </part-group>
+  </part-list>
+  <part id="id1">
+    <measure number="x">
+      <note>
+        <grace />
+        <pitch>
+          <step>A</step>
+          <octave>1</octave>
+        </pitch>
+        <footnote>x</footnote>
+        <level>x</level>
+        <voice>1</voice>
+        <staff>1</staff>
+        <notations>
+          <footnote>x</footnote>
+          <level>x</level>
+          <dynamics>
+            <pf />
+          </dynamics>
+        </notations>
+      </note>
+    </measure>
+  </part>
+</score-partwise>

--- a/docs/ai/projects/gen/synthetic-files/3.1/pitched.3.1.xml
+++ b/docs/ai/projects/gen/synthetic-files/3.1/pitched.3.1.xml
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<score-partwise version="3.1">
+  <part-list>
+    <part-group type="start">
+      <footnote>x</footnote>
+      <level>x</level>
+    </part-group>
+    <score-part id="id1">
+      <part-name>x</part-name>
+    </score-part>
+    <part-group type="start">
+      <footnote>x</footnote>
+      <level>x</level>
+    </part-group>
+  </part-list>
+  <part id="id1">
+    <measure number="x">
+      <direction>
+        <direction-type>
+          <percussion>
+            <pitched smufl="pictGong">celesta</pitched>
+          </percussion>
+        </direction-type>
+        <footnote>x</footnote>
+        <level>x</level>
+        <voice>1</voice>
+        <staff>1</staff>
+      </direction>
+    </measure>
+  </part>
+</score-partwise>

--- a/docs/ai/projects/gen/synthetic-files/3.1/plop.3.1.xml
+++ b/docs/ai/projects/gen/synthetic-files/3.1/plop.3.1.xml
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<score-partwise version="3.1">
+  <part-list>
+    <part-group type="start">
+      <footnote>x</footnote>
+      <level>x</level>
+    </part-group>
+    <score-part id="id1">
+      <part-name>x</part-name>
+    </score-part>
+    <part-group type="start">
+      <footnote>x</footnote>
+      <level>x</level>
+    </part-group>
+  </part-list>
+  <part id="id1">
+    <measure number="x">
+      <note>
+        <grace />
+        <pitch>
+          <step>A</step>
+          <octave>1</octave>
+        </pitch>
+        <footnote>x</footnote>
+        <level>x</level>
+        <voice>1</voice>
+        <staff>1</staff>
+        <notations>
+          <footnote>x</footnote>
+          <level>x</level>
+          <articulations>
+            <plop line-shape="straight" line-type="solid" line-length="short" dash-length="1" space-length="1" default-x="1" default-y="1" relative-x="1" relative-y="1" font-family="x" font-style="normal" font-size="1" font-weight="normal" color="#FF000000" placement="above" />
+          </articulations>
+        </notations>
+      </note>
+    </measure>
+  </part>
+</score-partwise>

--- a/docs/ai/projects/gen/synthetic-files/3.1/principal-voice.3.1.xml
+++ b/docs/ai/projects/gen/synthetic-files/3.1/principal-voice.3.1.xml
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<score-partwise version="3.1">
+  <part-list>
+    <part-group type="start">
+      <footnote>x</footnote>
+      <level>x</level>
+    </part-group>
+    <score-part id="id1">
+      <part-name>x</part-name>
+    </score-part>
+    <part-group type="start">
+      <footnote>x</footnote>
+      <level>x</level>
+    </part-group>
+  </part-list>
+  <part id="id1">
+    <measure number="x">
+      <direction>
+        <direction-type>
+          <principal-voice default-x="1" default-y="1" relative-x="1" relative-y="1" font-family="x" font-style="normal" font-size="1" font-weight="normal" color="#FF000000" type="start" symbol="Hauptstimme" halign="left" valign="top" id="id3">x</principal-voice>
+        </direction-type>
+        <footnote>x</footnote>
+        <level>x</level>
+        <voice>1</voice>
+        <staff>1</staff>
+      </direction>
+    </measure>
+  </part>
+</score-partwise>

--- a/docs/ai/projects/gen/synthetic-files/3.1/print.3.1.xml
+++ b/docs/ai/projects/gen/synthetic-files/3.1/print.3.1.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<score-partwise version="3.1">
+  <part-list>
+    <part-group type="start">
+      <footnote>x</footnote>
+      <level>x</level>
+    </part-group>
+    <score-part id="id1">
+      <part-name>x</part-name>
+    </score-part>
+    <part-group type="start">
+      <footnote>x</footnote>
+      <level>x</level>
+    </part-group>
+  </part-list>
+  <part id="id1">
+    <measure number="x">
+      <print staff-spacing="1" new-system="yes" new-page="yes" blank-page="1" page-number="x" id="id3" />
+    </measure>
+  </part>
+</score-partwise>

--- a/docs/ai/projects/gen/synthetic-files/3.1/rehearsal.3.1.xml
+++ b/docs/ai/projects/gen/synthetic-files/3.1/rehearsal.3.1.xml
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<score-partwise version="3.1">
+  <part-list>
+    <part-group type="start">
+      <footnote>x</footnote>
+      <level>x</level>
+    </part-group>
+    <score-part id="id1">
+      <part-name>x</part-name>
+    </score-part>
+    <part-group type="start">
+      <footnote>x</footnote>
+      <level>x</level>
+    </part-group>
+  </part-list>
+  <part id="id1">
+    <measure number="x">
+      <direction>
+        <direction-type>
+          <rehearsal default-x="1" default-y="1" relative-x="1" relative-y="1" font-family="x" font-style="normal" font-size="1" font-weight="normal" color="#FF000000" justify="left" halign="left" valign="top" underline="1" overline="1" line-through="1" rotation="1" letter-spacing="1" line-height="1" xml:lang="en" xml:space="preserve" dir="ltr" enclosure="rectangle" id="id3">x</rehearsal>
+        </direction-type>
+        <footnote>x</footnote>
+        <level>x</level>
+        <voice>1</voice>
+        <staff>1</staff>
+      </direction>
+    </measure>
+  </part>
+</score-partwise>

--- a/docs/ai/projects/gen/synthetic-files/3.1/scoop.3.1.xml
+++ b/docs/ai/projects/gen/synthetic-files/3.1/scoop.3.1.xml
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<score-partwise version="3.1">
+  <part-list>
+    <part-group type="start">
+      <footnote>x</footnote>
+      <level>x</level>
+    </part-group>
+    <score-part id="id1">
+      <part-name>x</part-name>
+    </score-part>
+    <part-group type="start">
+      <footnote>x</footnote>
+      <level>x</level>
+    </part-group>
+  </part-list>
+  <part id="id1">
+    <measure number="x">
+      <note>
+        <grace />
+        <pitch>
+          <step>A</step>
+          <octave>1</octave>
+        </pitch>
+        <footnote>x</footnote>
+        <level>x</level>
+        <voice>1</voice>
+        <staff>1</staff>
+        <notations>
+          <footnote>x</footnote>
+          <level>x</level>
+          <articulations>
+            <scoop line-shape="straight" line-type="solid" line-length="short" dash-length="1" space-length="1" default-x="1" default-y="1" relative-x="1" relative-y="1" font-family="x" font-style="normal" font-size="1" font-weight="normal" color="#FF000000" placement="above" />
+          </articulations>
+        </notations>
+      </note>
+    </measure>
+  </part>
+</score-partwise>

--- a/docs/ai/projects/gen/synthetic-files/3.1/scordatura.3.1.xml
+++ b/docs/ai/projects/gen/synthetic-files/3.1/scordatura.3.1.xml
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<score-partwise version="3.1">
+  <part-list>
+    <part-group type="start">
+      <footnote>x</footnote>
+      <level>x</level>
+    </part-group>
+    <score-part id="id1">
+      <part-name>x</part-name>
+    </score-part>
+    <part-group type="start">
+      <footnote>x</footnote>
+      <level>x</level>
+    </part-group>
+  </part-list>
+  <part id="id1">
+    <measure number="x">
+      <direction>
+        <direction-type>
+          <scordatura id="id3">
+            <accord>
+              <tuning-step>A</tuning-step>
+              <tuning-octave>1</tuning-octave>
+            </accord>
+          </scordatura>
+        </direction-type>
+        <footnote>x</footnote>
+        <level>x</level>
+        <voice>1</voice>
+        <staff>1</staff>
+      </direction>
+    </measure>
+  </part>
+</score-partwise>

--- a/docs/ai/projects/gen/synthetic-files/3.1/segno.3.1.xml
+++ b/docs/ai/projects/gen/synthetic-files/3.1/segno.3.1.xml
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<score-partwise version="3.1">
+  <part-list>
+    <part-group type="start">
+      <footnote>x</footnote>
+      <level>x</level>
+    </part-group>
+    <score-part id="id1">
+      <part-name>x</part-name>
+    </score-part>
+    <part-group type="start">
+      <footnote>x</footnote>
+      <level>x</level>
+    </part-group>
+  </part-list>
+  <part id="id1">
+    <measure number="x">
+      <direction>
+        <direction-type>
+          <segno default-x="1" default-y="1" relative-x="1" relative-y="1" font-family="x" font-style="normal" font-size="1" font-weight="normal" color="#FF000000" halign="left" valign="top" id="id3" smufl="segno" />
+        </direction-type>
+        <footnote>x</footnote>
+        <level>x</level>
+        <voice>1</voice>
+        <staff>1</staff>
+      </direction>
+    </measure>
+  </part>
+</score-partwise>

--- a/docs/ai/projects/gen/synthetic-files/3.1/sfzp.3.1.xml
+++ b/docs/ai/projects/gen/synthetic-files/3.1/sfzp.3.1.xml
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<score-partwise version="3.1">
+  <part-list>
+    <part-group type="start">
+      <footnote>x</footnote>
+      <level>x</level>
+    </part-group>
+    <score-part id="id1">
+      <part-name>x</part-name>
+    </score-part>
+    <part-group type="start">
+      <footnote>x</footnote>
+      <level>x</level>
+    </part-group>
+  </part-list>
+  <part id="id1">
+    <measure number="x">
+      <note>
+        <grace />
+        <pitch>
+          <step>A</step>
+          <octave>1</octave>
+        </pitch>
+        <footnote>x</footnote>
+        <level>x</level>
+        <voice>1</voice>
+        <staff>1</staff>
+        <notations>
+          <footnote>x</footnote>
+          <level>x</level>
+          <dynamics>
+            <sfzp />
+          </dynamics>
+        </notations>
+      </note>
+    </measure>
+  </part>
+</score-partwise>

--- a/docs/ai/projects/gen/synthetic-files/3.1/slide.3.1.xml
+++ b/docs/ai/projects/gen/synthetic-files/3.1/slide.3.1.xml
@@ -1,0 +1,36 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<score-partwise version="3.1">
+  <part-list>
+    <part-group type="start">
+      <footnote>x</footnote>
+      <level>x</level>
+    </part-group>
+    <score-part id="id1">
+      <part-name>x</part-name>
+    </score-part>
+    <part-group type="start">
+      <footnote>x</footnote>
+      <level>x</level>
+    </part-group>
+  </part-list>
+  <part id="id1">
+    <measure number="x">
+      <note>
+        <grace />
+        <pitch>
+          <step>A</step>
+          <octave>1</octave>
+        </pitch>
+        <footnote>x</footnote>
+        <level>x</level>
+        <voice>1</voice>
+        <staff>1</staff>
+        <notations>
+          <footnote>x</footnote>
+          <level>x</level>
+          <slide default-x="1" default-y="1" relative-x="1" relative-y="1" font-family="x" font-style="normal" font-size="1" font-weight="normal" color="#FF000000" type="start" number="1" line-type="solid" dash-length="1" space-length="1" accelerate="yes" beats="2" first-beat="1" last-beat="1" id="id3">x</slide>
+        </notations>
+      </note>
+    </measure>
+  </part>
+</score-partwise>

--- a/docs/ai/projects/gen/synthetic-files/3.1/slur.3.1.xml
+++ b/docs/ai/projects/gen/synthetic-files/3.1/slur.3.1.xml
@@ -1,0 +1,36 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<score-partwise version="3.1">
+  <part-list>
+    <part-group type="start">
+      <footnote>x</footnote>
+      <level>x</level>
+    </part-group>
+    <score-part id="id1">
+      <part-name>x</part-name>
+    </score-part>
+    <part-group type="start">
+      <footnote>x</footnote>
+      <level>x</level>
+    </part-group>
+  </part-list>
+  <part id="id1">
+    <measure number="x">
+      <note>
+        <grace />
+        <pitch>
+          <step>A</step>
+          <octave>1</octave>
+        </pitch>
+        <footnote>x</footnote>
+        <level>x</level>
+        <voice>1</voice>
+        <staff>1</staff>
+        <notations>
+          <footnote>x</footnote>
+          <level>x</level>
+          <slur type="start" number="1" line-type="solid" dash-length="1" space-length="1" default-x="1" default-y="1" relative-x="1" relative-y="1" placement="above" orientation="over" bezier-x="1" bezier-y="1" bezier-x2="1" bezier-y2="1" bezier-offset="1" bezier-offset2="1" color="#FF000000" id="id3" />
+        </notations>
+      </note>
+    </measure>
+  </part>
+</score-partwise>

--- a/docs/ai/projects/gen/synthetic-files/3.1/smear.3.1.xml
+++ b/docs/ai/projects/gen/synthetic-files/3.1/smear.3.1.xml
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<score-partwise version="3.1">
+  <part-list>
+    <part-group type="start">
+      <footnote>x</footnote>
+      <level>x</level>
+    </part-group>
+    <score-part id="id1">
+      <part-name>x</part-name>
+    </score-part>
+    <part-group type="start">
+      <footnote>x</footnote>
+      <level>x</level>
+    </part-group>
+  </part-list>
+  <part id="id1">
+    <measure number="x">
+      <note>
+        <grace />
+        <pitch>
+          <step>A</step>
+          <octave>1</octave>
+        </pitch>
+        <footnote>x</footnote>
+        <level>x</level>
+        <voice>1</voice>
+        <staff>1</staff>
+        <notations>
+          <footnote>x</footnote>
+          <level>x</level>
+          <technical>
+            <smear default-x="1" default-y="1" relative-x="1" relative-y="1" font-family="x" font-style="normal" font-size="1" font-weight="normal" color="#FF000000" placement="above" />
+          </technical>
+        </notations>
+      </note>
+    </measure>
+  </part>
+</score-partwise>

--- a/docs/ai/projects/gen/synthetic-files/3.1/soft-accent.3.1.xml
+++ b/docs/ai/projects/gen/synthetic-files/3.1/soft-accent.3.1.xml
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<score-partwise version="3.1">
+  <part-list>
+    <part-group type="start">
+      <footnote>x</footnote>
+      <level>x</level>
+    </part-group>
+    <score-part id="id1">
+      <part-name>x</part-name>
+    </score-part>
+    <part-group type="start">
+      <footnote>x</footnote>
+      <level>x</level>
+    </part-group>
+  </part-list>
+  <part id="id1">
+    <measure number="x">
+      <note>
+        <grace />
+        <pitch>
+          <step>A</step>
+          <octave>1</octave>
+        </pitch>
+        <footnote>x</footnote>
+        <level>x</level>
+        <voice>1</voice>
+        <staff>1</staff>
+        <notations>
+          <footnote>x</footnote>
+          <level>x</level>
+          <articulations>
+            <soft-accent default-x="1" default-y="1" relative-x="1" relative-y="1" font-family="x" font-style="normal" font-size="1" font-weight="normal" color="#FF000000" placement="above" />
+          </articulations>
+        </notations>
+      </note>
+    </measure>
+  </part>
+</score-partwise>

--- a/docs/ai/projects/gen/synthetic-files/3.1/sound.3.1.xml
+++ b/docs/ai/projects/gen/synthetic-files/3.1/sound.3.1.xml
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<score-partwise version="3.1">
+  <part-list>
+    <part-group type="start">
+      <footnote>x</footnote>
+      <level>x</level>
+    </part-group>
+    <score-part id="id1">
+      <part-name>x</part-name>
+    </score-part>
+    <part-group type="start">
+      <footnote>x</footnote>
+      <level>x</level>
+    </part-group>
+  </part-list>
+  <part id="id1">
+    <measure number="x">
+      <direction>
+        <direction-type>
+          <rehearsal>x</rehearsal>
+        </direction-type>
+        <footnote>x</footnote>
+        <level>x</level>
+        <voice>1</voice>
+        <staff>1</staff>
+        <sound tempo="1" dynamics="1" dacapo="yes" segno="x" dalsegno="x" coda="x" tocoda="x" divisions="1" forward-repeat="yes" fine="x" time-only="1" pizzicato="yes" pan="1" elevation="1" damper-pedal="yes" soft-pedal="yes" sostenuto-pedal="yes" id="id3" />
+      </direction>
+    </measure>
+  </part>
+</score-partwise>

--- a/docs/ai/projects/gen/synthetic-files/3.1/staff-divide.3.1.xml
+++ b/docs/ai/projects/gen/synthetic-files/3.1/staff-divide.3.1.xml
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<score-partwise version="3.1">
+  <part-list>
+    <part-group type="start">
+      <footnote>x</footnote>
+      <level>x</level>
+    </part-group>
+    <score-part id="id1">
+      <part-name>x</part-name>
+    </score-part>
+    <part-group type="start">
+      <footnote>x</footnote>
+      <level>x</level>
+    </part-group>
+  </part-list>
+  <part id="id1">
+    <measure number="x">
+      <direction>
+        <direction-type>
+          <staff-divide type="down" default-x="1" default-y="1" relative-x="1" relative-y="1" font-family="x" font-style="normal" font-size="1" font-weight="normal" color="#FF000000" halign="left" valign="top" id="id3" />
+        </direction-type>
+        <footnote>x</footnote>
+        <level>x</level>
+        <voice>1</voice>
+        <staff>1</staff>
+      </direction>
+    </measure>
+  </part>
+</score-partwise>

--- a/docs/ai/projects/gen/synthetic-files/3.1/stick.3.1.xml
+++ b/docs/ai/projects/gen/synthetic-files/3.1/stick.3.1.xml
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<score-partwise version="3.1">
+  <part-list>
+    <part-group type="start">
+      <footnote>x</footnote>
+      <level>x</level>
+    </part-group>
+    <score-part id="id1">
+      <part-name>x</part-name>
+    </score-part>
+    <part-group type="start">
+      <footnote>x</footnote>
+      <level>x</level>
+    </part-group>
+  </part-list>
+  <part id="id1">
+    <measure number="x">
+      <direction>
+        <direction-type>
+          <percussion>
+            <stick tip="up" parentheses="yes" dashed-circle="yes">
+              <stick-type>bass drum</stick-type>
+              <stick-material>soft</stick-material>
+            </stick>
+          </percussion>
+        </direction-type>
+        <footnote>x</footnote>
+        <level>x</level>
+        <voice>1</voice>
+        <staff>1</staff>
+      </direction>
+    </measure>
+  </part>
+</score-partwise>

--- a/docs/ai/projects/gen/synthetic-files/3.1/stopped.3.1.xml
+++ b/docs/ai/projects/gen/synthetic-files/3.1/stopped.3.1.xml
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<score-partwise version="3.1">
+  <part-list>
+    <part-group type="start">
+      <footnote>x</footnote>
+      <level>x</level>
+    </part-group>
+    <score-part id="id1">
+      <part-name>x</part-name>
+    </score-part>
+    <part-group type="start">
+      <footnote>x</footnote>
+      <level>x</level>
+    </part-group>
+  </part-list>
+  <part id="id1">
+    <measure number="x">
+      <note>
+        <grace />
+        <pitch>
+          <step>A</step>
+          <octave>1</octave>
+        </pitch>
+        <footnote>x</footnote>
+        <level>x</level>
+        <voice>1</voice>
+        <staff>1</staff>
+        <notations>
+          <footnote>x</footnote>
+          <level>x</level>
+          <technical>
+            <stopped default-x="1" default-y="1" relative-x="1" relative-y="1" font-family="x" font-style="normal" font-size="1" font-weight="normal" color="#FF000000" placement="above" smufl="noteheadBlack" />
+          </technical>
+        </notations>
+      </note>
+    </measure>
+  </part>
+</score-partwise>

--- a/docs/ai/projects/gen/synthetic-files/3.1/string-mute.3.1.xml
+++ b/docs/ai/projects/gen/synthetic-files/3.1/string-mute.3.1.xml
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<score-partwise version="3.1">
+  <part-list>
+    <part-group type="start">
+      <footnote>x</footnote>
+      <level>x</level>
+    </part-group>
+    <score-part id="id1">
+      <part-name>x</part-name>
+    </score-part>
+    <part-group type="start">
+      <footnote>x</footnote>
+      <level>x</level>
+    </part-group>
+  </part-list>
+  <part id="id1">
+    <measure number="x">
+      <direction>
+        <direction-type>
+          <string-mute type="on" default-x="1" default-y="1" relative-x="1" relative-y="1" font-family="x" font-style="normal" font-size="1" font-weight="normal" color="#FF000000" halign="left" valign="top" id="id3" />
+        </direction-type>
+        <footnote>x</footnote>
+        <level>x</level>
+        <voice>1</voice>
+        <staff>1</staff>
+      </direction>
+    </measure>
+  </part>
+</score-partwise>

--- a/docs/ai/projects/gen/synthetic-files/3.1/symbol.3.1.xml
+++ b/docs/ai/projects/gen/synthetic-files/3.1/symbol.3.1.xml
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<score-partwise version="3.1">
+  <part-list>
+    <part-group type="start">
+      <footnote>x</footnote>
+      <level>x</level>
+    </part-group>
+    <score-part id="id1">
+      <part-name>x</part-name>
+    </score-part>
+    <part-group type="start">
+      <footnote>x</footnote>
+      <level>x</level>
+    </part-group>
+  </part-list>
+  <part id="id1">
+    <measure number="x">
+      <direction>
+        <direction-type>
+          <symbol justify="left" default-x="1" default-y="1" relative-x="1" relative-y="1" font-family="x" font-style="normal" font-size="1" font-weight="normal" color="#FF000000" halign="left" valign="top" underline="1" overline="1" line-through="1" rotation="1" letter-spacing="1" line-height="1" dir="ltr" enclosure="rectangle" id="id3">noteheadBlack</symbol>
+        </direction-type>
+        <footnote>x</footnote>
+        <level>x</level>
+        <voice>1</voice>
+        <staff>1</staff>
+      </direction>
+    </measure>
+  </part>
+</score-partwise>

--- a/docs/ai/projects/gen/synthetic-files/3.1/tap.3.1.xml
+++ b/docs/ai/projects/gen/synthetic-files/3.1/tap.3.1.xml
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<score-partwise version="3.1">
+  <part-list>
+    <part-group type="start">
+      <footnote>x</footnote>
+      <level>x</level>
+    </part-group>
+    <score-part id="id1">
+      <part-name>x</part-name>
+    </score-part>
+    <part-group type="start">
+      <footnote>x</footnote>
+      <level>x</level>
+    </part-group>
+  </part-list>
+  <part id="id1">
+    <measure number="x">
+      <note>
+        <grace />
+        <pitch>
+          <step>A</step>
+          <octave>1</octave>
+        </pitch>
+        <footnote>x</footnote>
+        <level>x</level>
+        <voice>1</voice>
+        <staff>1</staff>
+        <notations>
+          <footnote>x</footnote>
+          <level>x</level>
+          <technical>
+            <tap default-x="1" default-y="1" relative-x="1" relative-y="1" font-family="x" font-style="normal" font-size="1" font-weight="normal" color="#FF000000" placement="above" hand="left">x</tap>
+          </technical>
+        </notations>
+      </note>
+    </measure>
+  </part>
+</score-partwise>

--- a/docs/ai/projects/gen/synthetic-files/3.1/technical.3.1.xml
+++ b/docs/ai/projects/gen/synthetic-files/3.1/technical.3.1.xml
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<score-partwise version="3.1">
+  <part-list>
+    <part-group type="start">
+      <footnote>x</footnote>
+      <level>x</level>
+    </part-group>
+    <score-part id="id1">
+      <part-name>x</part-name>
+    </score-part>
+    <part-group type="start">
+      <footnote>x</footnote>
+      <level>x</level>
+    </part-group>
+  </part-list>
+  <part id="id1">
+    <measure number="x">
+      <note>
+        <grace />
+        <pitch>
+          <step>A</step>
+          <octave>1</octave>
+        </pitch>
+        <footnote>x</footnote>
+        <level>x</level>
+        <voice>1</voice>
+        <staff>1</staff>
+        <notations>
+          <footnote>x</footnote>
+          <level>x</level>
+          <technical id="id3">
+            <up-bow />
+          </technical>
+        </notations>
+      </note>
+    </measure>
+  </part>
+</score-partwise>

--- a/docs/ai/projects/gen/synthetic-files/3.1/tied.3.1.xml
+++ b/docs/ai/projects/gen/synthetic-files/3.1/tied.3.1.xml
@@ -1,0 +1,36 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<score-partwise version="3.1">
+  <part-list>
+    <part-group type="start">
+      <footnote>x</footnote>
+      <level>x</level>
+    </part-group>
+    <score-part id="id1">
+      <part-name>x</part-name>
+    </score-part>
+    <part-group type="start">
+      <footnote>x</footnote>
+      <level>x</level>
+    </part-group>
+  </part-list>
+  <part id="id1">
+    <measure number="x">
+      <note>
+        <grace />
+        <pitch>
+          <step>A</step>
+          <octave>1</octave>
+        </pitch>
+        <footnote>x</footnote>
+        <level>x</level>
+        <voice>1</voice>
+        <staff>1</staff>
+        <notations>
+          <footnote>x</footnote>
+          <level>x</level>
+          <tied type="start" number="1" line-type="solid" dash-length="1" space-length="1" default-x="1" default-y="1" relative-x="1" relative-y="1" placement="above" orientation="over" bezier-x="1" bezier-y="1" bezier-x2="1" bezier-y2="1" bezier-offset="1" bezier-offset2="1" color="#FF000000" id="id3" />
+        </notations>
+      </note>
+    </measure>
+  </part>
+</score-partwise>

--- a/docs/ai/projects/gen/synthetic-files/3.1/time.3.1.xml
+++ b/docs/ai/projects/gen/synthetic-files/3.1/time.3.1.xml
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<score-partwise version="3.1">
+  <part-list>
+    <part-group type="start">
+      <footnote>x</footnote>
+      <level>x</level>
+    </part-group>
+    <score-part id="id1">
+      <part-name>x</part-name>
+    </score-part>
+    <part-group type="start">
+      <footnote>x</footnote>
+      <level>x</level>
+    </part-group>
+  </part-list>
+  <part id="id1">
+    <measure number="x">
+      <attributes>
+        <footnote>x</footnote>
+        <level>x</level>
+        <time number="1" symbol="common" separator="none" default-x="1" default-y="1" relative-x="1" relative-y="1" font-family="x" font-style="normal" font-size="1" font-weight="normal" color="#FF000000" halign="left" valign="top" print-object="yes" id="id3">
+          <beats>1</beats>
+          <beat-type>1</beat-type>
+        </time>
+      </attributes>
+    </measure>
+  </part>
+</score-partwise>

--- a/docs/ai/projects/gen/synthetic-files/3.1/transpose.3.1.xml
+++ b/docs/ai/projects/gen/synthetic-files/3.1/transpose.3.1.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<score-partwise version="3.1">
+  <part-list>
+    <part-group type="start">
+      <footnote>x</footnote>
+      <level>x</level>
+    </part-group>
+    <score-part id="id1">
+      <part-name>x</part-name>
+    </score-part>
+    <part-group type="start">
+      <footnote>x</footnote>
+      <level>x</level>
+    </part-group>
+  </part-list>
+  <part id="id1">
+    <measure number="x">
+      <attributes>
+        <footnote>x</footnote>
+        <level>x</level>
+        <transpose number="1" id="id3">
+          <chromatic>1</chromatic>
+        </transpose>
+      </attributes>
+    </measure>
+  </part>
+</score-partwise>

--- a/docs/ai/projects/gen/synthetic-files/3.1/tremolo.3.1.xml
+++ b/docs/ai/projects/gen/synthetic-files/3.1/tremolo.3.1.xml
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<score-partwise version="3.1">
+  <part-list>
+    <part-group type="start">
+      <footnote>x</footnote>
+      <level>x</level>
+    </part-group>
+    <score-part id="id1">
+      <part-name>x</part-name>
+    </score-part>
+    <part-group type="start">
+      <footnote>x</footnote>
+      <level>x</level>
+    </part-group>
+  </part-list>
+  <part id="id1">
+    <measure number="x">
+      <note>
+        <grace />
+        <pitch>
+          <step>A</step>
+          <octave>1</octave>
+        </pitch>
+        <footnote>x</footnote>
+        <level>x</level>
+        <voice>1</voice>
+        <staff>1</staff>
+        <notations>
+          <footnote>x</footnote>
+          <level>x</level>
+          <ornaments>
+            <tremolo type="start" default-x="1" default-y="1" relative-x="1" relative-y="1" font-family="x" font-style="normal" font-size="1" font-weight="normal" color="#FF000000" placement="above" smufl="noteheadBlack">1</tremolo>
+          </ornaments>
+        </notations>
+      </note>
+    </measure>
+  </part>
+</score-partwise>

--- a/docs/ai/projects/gen/synthetic-files/3.1/tuplet.3.1.xml
+++ b/docs/ai/projects/gen/synthetic-files/3.1/tuplet.3.1.xml
@@ -1,0 +1,36 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<score-partwise version="3.1">
+  <part-list>
+    <part-group type="start">
+      <footnote>x</footnote>
+      <level>x</level>
+    </part-group>
+    <score-part id="id1">
+      <part-name>x</part-name>
+    </score-part>
+    <part-group type="start">
+      <footnote>x</footnote>
+      <level>x</level>
+    </part-group>
+  </part-list>
+  <part id="id1">
+    <measure number="x">
+      <note>
+        <grace />
+        <pitch>
+          <step>A</step>
+          <octave>1</octave>
+        </pitch>
+        <footnote>x</footnote>
+        <level>x</level>
+        <voice>1</voice>
+        <staff>1</staff>
+        <notations>
+          <footnote>x</footnote>
+          <level>x</level>
+          <tuplet type="start" number="1" bracket="yes" show-number="actual" show-type="actual" line-shape="straight" default-x="1" default-y="1" relative-x="1" relative-y="1" placement="above" id="id3" />
+        </notations>
+      </note>
+    </measure>
+  </part>
+</score-partwise>

--- a/docs/ai/projects/gen/synthetic-files/3.1/wedge.3.1.xml
+++ b/docs/ai/projects/gen/synthetic-files/3.1/wedge.3.1.xml
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<score-partwise version="3.1">
+  <part-list>
+    <part-group type="start">
+      <footnote>x</footnote>
+      <level>x</level>
+    </part-group>
+    <score-part id="id1">
+      <part-name>x</part-name>
+    </score-part>
+    <part-group type="start">
+      <footnote>x</footnote>
+      <level>x</level>
+    </part-group>
+  </part-list>
+  <part id="id1">
+    <measure number="x">
+      <direction>
+        <direction-type>
+          <wedge type="crescendo" number="1" spread="1" niente="yes" line-type="solid" dash-length="1" space-length="1" default-x="1" default-y="1" relative-x="1" relative-y="1" color="#FF000000" id="id3" />
+        </direction-type>
+        <footnote>x</footnote>
+        <level>x</level>
+        <voice>1</voice>
+        <staff>1</staff>
+      </direction>
+    </measure>
+  </part>
+</score-partwise>

--- a/docs/ai/projects/gen/synthetic-files/3.1/words.3.1.xml
+++ b/docs/ai/projects/gen/synthetic-files/3.1/words.3.1.xml
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<score-partwise version="3.1">
+  <part-list>
+    <part-group type="start">
+      <footnote>x</footnote>
+      <level>x</level>
+    </part-group>
+    <score-part id="id1">
+      <part-name>x</part-name>
+    </score-part>
+    <part-group type="start">
+      <footnote>x</footnote>
+      <level>x</level>
+    </part-group>
+  </part-list>
+  <part id="id1">
+    <measure number="x">
+      <direction>
+        <direction-type>
+          <words default-x="1" default-y="1" relative-x="1" relative-y="1" font-family="x" font-style="normal" font-size="1" font-weight="normal" color="#FF000000" justify="left" halign="left" valign="top" underline="1" overline="1" line-through="1" rotation="1" letter-spacing="1" line-height="1" xml:lang="en" xml:space="preserve" dir="ltr" enclosure="rectangle" id="id3">x</words>
+        </direction-type>
+        <footnote>x</footnote>
+        <level>x</level>
+        <voice>1</voice>
+        <staff>1</staff>
+      </direction>
+    </measure>
+  </part>
+</score-partwise>

--- a/docs/ai/projects/gen/synthetic-files/4.0/arpeggiate.4.0.xml
+++ b/docs/ai/projects/gen/synthetic-files/4.0/arpeggiate.4.0.xml
@@ -1,0 +1,36 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<score-partwise version="4.0">
+  <part-list>
+    <part-group type="start">
+      <footnote>x</footnote>
+      <level>x</level>
+    </part-group>
+    <score-part id="id1">
+      <part-name>x</part-name>
+    </score-part>
+    <part-group type="start">
+      <footnote>x</footnote>
+      <level>x</level>
+    </part-group>
+  </part-list>
+  <part id="id1">
+    <measure number="x">
+      <note>
+        <grace />
+        <pitch>
+          <step>A</step>
+          <octave>1</octave>
+        </pitch>
+        <footnote>x</footnote>
+        <level>x</level>
+        <voice>1</voice>
+        <staff>1</staff>
+        <notations>
+          <footnote>x</footnote>
+          <level>x</level>
+          <arpeggiate number="1" direction="up" unbroken="yes" default-x="1" default-y="1" relative-x="1" relative-y="1" placement="above" color="#FF000000" id="id3" />
+        </notations>
+      </note>
+    </measure>
+  </part>
+</score-partwise>

--- a/docs/ai/projects/gen/synthetic-files/4.0/assess.4.0.xml
+++ b/docs/ai/projects/gen/synthetic-files/4.0/assess.4.0.xml
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<score-partwise version="4.0">
+  <part-list>
+    <part-group type="start">
+      <footnote>x</footnote>
+      <level>x</level>
+    </part-group>
+    <score-part id="id1">
+      <part-name>x</part-name>
+    </score-part>
+    <part-group type="start">
+      <footnote>x</footnote>
+      <level>x</level>
+    </part-group>
+  </part-list>
+  <part id="id1">
+    <measure number="x">
+      <note>
+        <grace />
+        <pitch>
+          <step>A</step>
+          <octave>1</octave>
+        </pitch>
+        <footnote>x</footnote>
+        <level>x</level>
+        <voice>1</voice>
+        <staff>1</staff>
+        <listen>
+          <assess type="yes" player="id3" time-only="1" />
+        </listen>
+      </note>
+    </measure>
+  </part>
+</score-partwise>

--- a/docs/ai/projects/gen/synthetic-files/4.0/bass-separator.4.0.xml
+++ b/docs/ai/projects/gen/synthetic-files/4.0/bass-separator.4.0.xml
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<score-partwise version="4.0">
+  <part-list>
+    <part-group type="start">
+      <footnote>x</footnote>
+      <level>x</level>
+    </part-group>
+    <score-part id="id1">
+      <part-name>x</part-name>
+    </score-part>
+    <part-group type="start">
+      <footnote>x</footnote>
+      <level>x</level>
+    </part-group>
+  </part-list>
+  <part id="id1">
+    <measure number="x">
+      <harmony>
+        <root>
+          <root-step>A</root-step>
+        </root>
+        <kind>major</kind>
+        <bass>
+          <bass-separator default-x="1" default-y="1" relative-x="1" relative-y="1" font-family="x" font-style="normal" font-size="1" font-weight="normal" color="#FF000000">x</bass-separator>
+          <bass-step>A</bass-step>
+        </bass>
+        <footnote>x</footnote>
+        <level>x</level>
+        <staff>1</staff>
+      </harmony>
+    </measure>
+  </part>
+</score-partwise>

--- a/docs/ai/projects/gen/synthetic-files/4.0/bass.4.0.xml
+++ b/docs/ai/projects/gen/synthetic-files/4.0/bass.4.0.xml
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<score-partwise version="4.0">
+  <part-list>
+    <part-group type="start">
+      <footnote>x</footnote>
+      <level>x</level>
+    </part-group>
+    <score-part id="id1">
+      <part-name>x</part-name>
+    </score-part>
+    <part-group type="start">
+      <footnote>x</footnote>
+      <level>x</level>
+    </part-group>
+  </part-list>
+  <part id="id1">
+    <measure number="x">
+      <harmony>
+        <root>
+          <root-step>A</root-step>
+        </root>
+        <kind>major</kind>
+        <bass arrangement="vertical">
+          <bass-step>A</bass-step>
+        </bass>
+        <footnote>x</footnote>
+        <level>x</level>
+        <staff>1</staff>
+      </harmony>
+    </measure>
+  </part>
+</score-partwise>

--- a/docs/ai/projects/gen/synthetic-files/4.0/bend.4.0.xml
+++ b/docs/ai/projects/gen/synthetic-files/4.0/bend.4.0.xml
@@ -1,0 +1,41 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<score-partwise version="4.0">
+  <part-list>
+    <part-group type="start">
+      <footnote>x</footnote>
+      <level>x</level>
+    </part-group>
+    <score-part id="id1">
+      <part-name>x</part-name>
+    </score-part>
+    <part-group type="start">
+      <footnote>x</footnote>
+      <level>x</level>
+    </part-group>
+  </part-list>
+  <part id="id1">
+    <measure number="x">
+      <note>
+        <grace />
+        <pitch>
+          <step>A</step>
+          <octave>1</octave>
+        </pitch>
+        <footnote>x</footnote>
+        <level>x</level>
+        <voice>1</voice>
+        <staff>1</staff>
+        <notations>
+          <footnote>x</footnote>
+          <level>x</level>
+          <technical>
+            <bend shape="angled" default-x="1" default-y="1" relative-x="1" relative-y="1" font-family="x" font-style="normal" font-size="1" font-weight="normal" color="#FF000000" accelerate="yes" beats="2" first-beat="1" last-beat="1">
+              <bend-alter>1</bend-alter>
+              <pre-bend />
+            </bend>
+          </technical>
+        </notations>
+      </note>
+    </measure>
+  </part>
+</score-partwise>

--- a/docs/ai/projects/gen/synthetic-files/4.0/concert-score.4.0.xml
+++ b/docs/ai/projects/gen/synthetic-files/4.0/concert-score.4.0.xml
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<score-partwise version="4.0">
+  <defaults>
+    <concert-score />
+  </defaults>
+  <part-list>
+    <part-group type="start">
+      <footnote>x</footnote>
+      <level>x</level>
+    </part-group>
+    <score-part id="id1">
+      <part-name>x</part-name>
+    </score-part>
+    <part-group type="start">
+      <footnote>x</footnote>
+      <level>x</level>
+    </part-group>
+  </part-list>
+  <part id="id1">
+    <measure number="x">
+      <note>
+        <grace />
+        <pitch>
+          <step>A</step>
+          <octave>1</octave>
+        </pitch>
+        <footnote>x</footnote>
+        <level>x</level>
+        <voice>1</voice>
+        <staff>1</staff>
+      </note>
+    </measure>
+  </part>
+</score-partwise>

--- a/docs/ai/projects/gen/synthetic-files/4.0/direction.4.0.xml
+++ b/docs/ai/projects/gen/synthetic-files/4.0/direction.4.0.xml
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<score-partwise version="4.0">
+  <part-list>
+    <part-group type="start">
+      <footnote>x</footnote>
+      <level>x</level>
+    </part-group>
+    <score-part id="id1">
+      <part-name>x</part-name>
+    </score-part>
+    <part-group type="start">
+      <footnote>x</footnote>
+      <level>x</level>
+    </part-group>
+  </part-list>
+  <part id="id1">
+    <measure number="x">
+      <direction placement="above" directive="yes" system="only-top" id="id3">
+        <direction-type>
+          <rehearsal>x</rehearsal>
+        </direction-type>
+        <footnote>x</footnote>
+        <level>x</level>
+        <voice>1</voice>
+        <staff>1</staff>
+      </direction>
+    </measure>
+  </part>
+</score-partwise>

--- a/docs/ai/projects/gen/synthetic-files/4.0/double.4.0.xml
+++ b/docs/ai/projects/gen/synthetic-files/4.0/double.4.0.xml
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<score-partwise version="4.0">
+  <part-list>
+    <part-group type="start">
+      <footnote>x</footnote>
+      <level>x</level>
+    </part-group>
+    <score-part id="id1">
+      <part-name>x</part-name>
+    </score-part>
+    <part-group type="start">
+      <footnote>x</footnote>
+      <level>x</level>
+    </part-group>
+  </part-list>
+  <part id="id1">
+    <measure number="x">
+      <attributes>
+        <footnote>x</footnote>
+        <level>x</level>
+        <transpose>
+          <chromatic>1</chromatic>
+          <double above="yes" />
+        </transpose>
+      </attributes>
+    </measure>
+  </part>
+</score-partwise>

--- a/docs/ai/projects/gen/synthetic-files/4.0/effect.4.0.xml
+++ b/docs/ai/projects/gen/synthetic-files/4.0/effect.4.0.xml
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<score-partwise version="4.0">
+  <part-list>
+    <part-group type="start">
+      <footnote>x</footnote>
+      <level>x</level>
+    </part-group>
+    <score-part id="id1">
+      <part-name>x</part-name>
+    </score-part>
+    <part-group type="start">
+      <footnote>x</footnote>
+      <level>x</level>
+    </part-group>
+  </part-list>
+  <part id="id1">
+    <measure number="x">
+      <direction>
+        <direction-type>
+          <percussion>
+            <effect smufl="pictGong">anvil</effect>
+          </percussion>
+        </direction-type>
+        <footnote>x</footnote>
+        <level>x</level>
+        <voice>1</voice>
+        <staff>1</staff>
+      </direction>
+    </measure>
+  </part>
+</score-partwise>

--- a/docs/ai/projects/gen/synthetic-files/4.0/ending.4.0.xml
+++ b/docs/ai/projects/gen/synthetic-files/4.0/ending.4.0.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<score-partwise version="4.0">
+  <part-list>
+    <part-group type="start">
+      <footnote>x</footnote>
+      <level>x</level>
+    </part-group>
+    <score-part id="id1">
+      <part-name>x</part-name>
+    </score-part>
+    <part-group type="start">
+      <footnote>x</footnote>
+      <level>x</level>
+    </part-group>
+  </part-list>
+  <part id="id1">
+    <measure number="x">
+      <barline>
+        <footnote>x</footnote>
+        <level>x</level>
+        <ending default-x="1" default-y="1" relative-x="1" relative-y="1" font-family="x" font-style="normal" font-size="1" font-weight="normal" color="#FF000000" number="1" type="start" print-object="yes" system="only-top" end-length="1" text-x="1" text-y="1">x</ending>
+      </barline>
+    </measure>
+  </part>
+</score-partwise>

--- a/docs/ai/projects/gen/synthetic-files/4.0/figured-bass.4.0.xml
+++ b/docs/ai/projects/gen/synthetic-files/4.0/figured-bass.4.0.xml
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<score-partwise version="4.0">
+  <part-list>
+    <part-group type="start">
+      <footnote>x</footnote>
+      <level>x</level>
+    </part-group>
+    <score-part id="id1">
+      <part-name>x</part-name>
+    </score-part>
+    <part-group type="start">
+      <footnote>x</footnote>
+      <level>x</level>
+    </part-group>
+  </part-list>
+  <part id="id1">
+    <measure number="x">
+      <figured-bass default-x="1" default-y="1" relative-x="1" relative-y="1" font-family="x" font-style="normal" font-size="1" font-weight="normal" color="#FF000000" halign="left" valign="top" placement="above" print-object="yes" print-dot="yes" print-spacing="yes" print-lyric="yes" parentheses="yes" id="id3">
+        <figure>
+          <footnote>x</footnote>
+          <level>x</level>
+        </figure>
+        <duration>1</duration>
+        <footnote>x</footnote>
+        <level>x</level>
+      </figured-bass>
+    </measure>
+  </part>
+</score-partwise>

--- a/docs/ai/projects/gen/synthetic-files/4.0/first.4.0.xml
+++ b/docs/ai/projects/gen/synthetic-files/4.0/first.4.0.xml
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<score-partwise version="4.0">
+  <part-list>
+    <part-group type="start">
+      <footnote>x</footnote>
+      <level>x</level>
+    </part-group>
+    <score-part id="id1">
+      <part-name>x</part-name>
+    </score-part>
+    <part-group type="start">
+      <footnote>x</footnote>
+      <level>x</level>
+    </part-group>
+  </part-list>
+  <part id="id1">
+    <measure number="x">
+      <direction>
+        <direction-type>
+          <rehearsal>x</rehearsal>
+        </direction-type>
+        <footnote>x</footnote>
+        <level>x</level>
+        <voice>1</voice>
+        <staff>1</staff>
+        <sound>
+          <swing>
+            <first>1</first>
+            <second>1</second>
+          </swing>
+        </sound>
+      </direction>
+    </measure>
+  </part>
+</score-partwise>

--- a/docs/ai/projects/gen/synthetic-files/4.0/for-part.4.0.xml
+++ b/docs/ai/projects/gen/synthetic-files/4.0/for-part.4.0.xml
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<score-partwise version="4.0">
+  <part-list>
+    <part-group type="start">
+      <footnote>x</footnote>
+      <level>x</level>
+    </part-group>
+    <score-part id="id1">
+      <part-name>x</part-name>
+    </score-part>
+    <part-group type="start">
+      <footnote>x</footnote>
+      <level>x</level>
+    </part-group>
+  </part-list>
+  <part id="id1">
+    <measure number="x">
+      <attributes>
+        <footnote>x</footnote>
+        <level>x</level>
+        <for-part number="1" id="id3">
+          <part-transpose>
+            <chromatic>1</chromatic>
+          </part-transpose>
+        </for-part>
+      </attributes>
+    </measure>
+  </part>
+</score-partwise>

--- a/docs/ai/projects/gen/synthetic-files/4.0/group-link.4.0.xml
+++ b/docs/ai/projects/gen/synthetic-files/4.0/group-link.4.0.xml
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<score-partwise xmlns:xlink="http://www.w3.org/1999/xlink" version="4.0">
+  <part-list>
+    <part-group type="start">
+      <footnote>x</footnote>
+      <level>x</level>
+    </part-group>
+    <score-part id="id1">
+      <part-link xlink:href="http://example.com">
+        <group-link>1</group-link>
+      </part-link>
+      <part-name>x</part-name>
+    </score-part>
+    <part-group type="start">
+      <footnote>x</footnote>
+      <level>x</level>
+    </part-group>
+  </part-list>
+  <part id="id1">
+    <measure number="x">
+      <note>
+        <grace />
+        <pitch>
+          <step>A</step>
+          <octave>1</octave>
+        </pitch>
+        <footnote>x</footnote>
+        <level>x</level>
+        <voice>1</voice>
+        <staff>1</staff>
+      </note>
+    </measure>
+  </part>
+</score-partwise>

--- a/docs/ai/projects/gen/synthetic-files/4.0/harmony.4.0.xml
+++ b/docs/ai/projects/gen/synthetic-files/4.0/harmony.4.0.xml
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<score-partwise version="4.0">
+  <part-list>
+    <part-group type="start">
+      <footnote>x</footnote>
+      <level>x</level>
+    </part-group>
+    <score-part id="id1">
+      <part-name>x</part-name>
+    </score-part>
+    <part-group type="start">
+      <footnote>x</footnote>
+      <level>x</level>
+    </part-group>
+  </part-list>
+  <part id="id1">
+    <measure number="x">
+      <harmony type="explicit" print-object="yes" print-frame="yes" arrangement="vertical" default-x="1" default-y="1" relative-x="1" relative-y="1" font-family="x" font-style="normal" font-size="1" font-weight="normal" color="#FF000000" placement="above" system="only-top" id="id3">
+        <root>
+          <root-step>A</root-step>
+        </root>
+        <kind>major</kind>
+        <footnote>x</footnote>
+        <level>x</level>
+        <staff>1</staff>
+      </harmony>
+    </measure>
+  </part>
+</score-partwise>

--- a/docs/ai/projects/gen/synthetic-files/4.0/instrument-change.4.0.xml
+++ b/docs/ai/projects/gen/synthetic-files/4.0/instrument-change.4.0.xml
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<score-partwise version="4.0">
+  <part-list>
+    <part-group type="start">
+      <footnote>x</footnote>
+      <level>x</level>
+    </part-group>
+    <score-part id="id1">
+      <part-name>x</part-name>
+    </score-part>
+    <part-group type="start">
+      <footnote>x</footnote>
+      <level>x</level>
+    </part-group>
+  </part-list>
+  <part id="id1">
+    <measure number="x">
+      <direction>
+        <direction-type>
+          <rehearsal>x</rehearsal>
+        </direction-type>
+        <footnote>x</footnote>
+        <level>x</level>
+        <voice>1</voice>
+        <staff>1</staff>
+        <sound>
+          <instrument-change id="id3">
+            <solo />
+          </instrument-change>
+        </sound>
+      </direction>
+    </measure>
+  </part>
+</score-partwise>

--- a/docs/ai/projects/gen/synthetic-files/4.0/instrument-link.4.0.xml
+++ b/docs/ai/projects/gen/synthetic-files/4.0/instrument-link.4.0.xml
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<score-partwise xmlns:xlink="http://www.w3.org/1999/xlink" version="4.0">
+  <part-list>
+    <part-group type="start">
+      <footnote>x</footnote>
+      <level>x</level>
+    </part-group>
+    <score-part id="id1">
+      <part-link xlink:href="http://example.com">
+        <instrument-link id="id2" />
+      </part-link>
+      <part-name>x</part-name>
+    </score-part>
+    <part-group type="start">
+      <footnote>x</footnote>
+      <level>x</level>
+    </part-group>
+  </part-list>
+  <part id="id1">
+    <measure number="x">
+      <note>
+        <grace />
+        <pitch>
+          <step>A</step>
+          <octave>1</octave>
+        </pitch>
+        <footnote>x</footnote>
+        <level>x</level>
+        <voice>1</voice>
+        <staff>1</staff>
+      </note>
+    </measure>
+  </part>
+</score-partwise>

--- a/docs/ai/projects/gen/synthetic-files/4.0/inversion.4.0.xml
+++ b/docs/ai/projects/gen/synthetic-files/4.0/inversion.4.0.xml
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<score-partwise version="4.0">
+  <part-list>
+    <part-group type="start">
+      <footnote>x</footnote>
+      <level>x</level>
+    </part-group>
+    <score-part id="id1">
+      <part-name>x</part-name>
+    </score-part>
+    <part-group type="start">
+      <footnote>x</footnote>
+      <level>x</level>
+    </part-group>
+  </part-list>
+  <part id="id1">
+    <measure number="x">
+      <harmony>
+        <root>
+          <root-step>A</root-step>
+        </root>
+        <kind>major</kind>
+        <inversion text="x" default-x="1" default-y="1" relative-x="1" relative-y="1" font-family="x" font-style="normal" font-size="1" font-weight="normal" color="#FF000000">1</inversion>
+        <footnote>x</footnote>
+        <level>x</level>
+        <staff>1</staff>
+      </harmony>
+    </measure>
+  </part>
+</score-partwise>

--- a/docs/ai/projects/gen/synthetic-files/4.0/level.4.0.xml
+++ b/docs/ai/projects/gen/synthetic-files/4.0/level.4.0.xml
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<score-partwise version="4.0">
+  <part-list>
+    <part-group type="start">
+      <footnote>x</footnote>
+      <level reference="yes" type="start" parentheses="yes" bracket="yes" size="full">x</level>
+    </part-group>
+    <score-part id="id1">
+      <part-name>x</part-name>
+    </score-part>
+    <part-group type="start">
+      <footnote>x</footnote>
+      <level>x</level>
+    </part-group>
+  </part-list>
+  <part id="id1">
+    <measure number="x">
+      <note>
+        <grace />
+        <pitch>
+          <step>A</step>
+          <octave>1</octave>
+        </pitch>
+        <footnote>x</footnote>
+        <level>x</level>
+        <voice>1</voice>
+        <staff>1</staff>
+      </note>
+    </measure>
+  </part>
+</score-partwise>

--- a/docs/ai/projects/gen/synthetic-files/4.0/line-detail.4.0.xml
+++ b/docs/ai/projects/gen/synthetic-files/4.0/line-detail.4.0.xml
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<score-partwise version="4.0">
+  <part-list>
+    <part-group type="start">
+      <footnote>x</footnote>
+      <level>x</level>
+    </part-group>
+    <score-part id="id1">
+      <part-name>x</part-name>
+    </score-part>
+    <part-group type="start">
+      <footnote>x</footnote>
+      <level>x</level>
+    </part-group>
+  </part-list>
+  <part id="id1">
+    <measure number="x">
+      <attributes>
+        <footnote>x</footnote>
+        <level>x</level>
+        <staff-details>
+          <staff-lines>1</staff-lines>
+          <line-detail line="1" width="1" color="#FF000000" line-type="solid" print-object="yes" />
+        </staff-details>
+      </attributes>
+    </measure>
+  </part>
+</score-partwise>

--- a/docs/ai/projects/gen/synthetic-files/4.0/listen.4.0.xml
+++ b/docs/ai/projects/gen/synthetic-files/4.0/listen.4.0.xml
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<score-partwise version="4.0">
+  <part-list>
+    <part-group type="start">
+      <footnote>x</footnote>
+      <level>x</level>
+    </part-group>
+    <score-part id="id1">
+      <part-name>x</part-name>
+    </score-part>
+    <part-group type="start">
+      <footnote>x</footnote>
+      <level>x</level>
+    </part-group>
+  </part-list>
+  <part id="id1">
+    <measure number="x">
+      <note>
+        <grace />
+        <pitch>
+          <step>A</step>
+          <octave>1</octave>
+        </pitch>
+        <footnote>x</footnote>
+        <level>x</level>
+        <voice>1</voice>
+        <staff>1</staff>
+        <listen>
+          <assess type="yes" />
+        </listen>
+      </note>
+    </measure>
+  </part>
+</score-partwise>

--- a/docs/ai/projects/gen/synthetic-files/4.0/listening.4.0.xml
+++ b/docs/ai/projects/gen/synthetic-files/4.0/listening.4.0.xml
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<score-partwise version="4.0">
+  <part-list>
+    <part-group type="start">
+      <footnote>x</footnote>
+      <level>x</level>
+    </part-group>
+    <score-part id="id1">
+      <part-name>x</part-name>
+    </score-part>
+    <part-group type="start">
+      <footnote>x</footnote>
+      <level>x</level>
+    </part-group>
+  </part-list>
+  <part id="id1">
+    <measure number="x">
+      <direction>
+        <direction-type>
+          <rehearsal>x</rehearsal>
+        </direction-type>
+        <footnote>x</footnote>
+        <level>x</level>
+        <voice>1</voice>
+        <staff>1</staff>
+        <listening>
+          <sync type="none" />
+        </listening>
+      </direction>
+    </measure>
+  </part>
+</score-partwise>

--- a/docs/ai/projects/gen/synthetic-files/4.0/measure-numbering.4.0.xml
+++ b/docs/ai/projects/gen/synthetic-files/4.0/measure-numbering.4.0.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<score-partwise version="4.0">
+  <part-list>
+    <part-group type="start">
+      <footnote>x</footnote>
+      <level>x</level>
+    </part-group>
+    <score-part id="id1">
+      <part-name>x</part-name>
+    </score-part>
+    <part-group type="start">
+      <footnote>x</footnote>
+      <level>x</level>
+    </part-group>
+  </part-list>
+  <part id="id1">
+    <measure number="x">
+      <print>
+        <measure-numbering system="only-top" staff="1" multiple-rest-always="yes" multiple-rest-range="yes" default-x="1" default-y="1" relative-x="1" relative-y="1" font-family="x" font-style="normal" font-size="1" font-weight="normal" color="#FF000000" halign="left" valign="top">none</measure-numbering>
+      </print>
+    </measure>
+  </part>
+</score-partwise>

--- a/docs/ai/projects/gen/synthetic-files/4.0/membrane.4.0.xml
+++ b/docs/ai/projects/gen/synthetic-files/4.0/membrane.4.0.xml
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<score-partwise version="4.0">
+  <part-list>
+    <part-group type="start">
+      <footnote>x</footnote>
+      <level>x</level>
+    </part-group>
+    <score-part id="id1">
+      <part-name>x</part-name>
+    </score-part>
+    <part-group type="start">
+      <footnote>x</footnote>
+      <level>x</level>
+    </part-group>
+  </part-list>
+  <part id="id1">
+    <measure number="x">
+      <direction>
+        <direction-type>
+          <percussion>
+            <membrane smufl="pictGong">bass drum</membrane>
+          </percussion>
+        </direction-type>
+        <footnote>x</footnote>
+        <level>x</level>
+        <voice>1</voice>
+        <staff>1</staff>
+      </direction>
+    </measure>
+  </part>
+</score-partwise>

--- a/docs/ai/projects/gen/synthetic-files/4.0/metal.4.0.xml
+++ b/docs/ai/projects/gen/synthetic-files/4.0/metal.4.0.xml
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<score-partwise version="4.0">
+  <part-list>
+    <part-group type="start">
+      <footnote>x</footnote>
+      <level>x</level>
+    </part-group>
+    <score-part id="id1">
+      <part-name>x</part-name>
+    </score-part>
+    <part-group type="start">
+      <footnote>x</footnote>
+      <level>x</level>
+    </part-group>
+  </part-list>
+  <part id="id1">
+    <measure number="x">
+      <direction>
+        <direction-type>
+          <percussion>
+            <metal smufl="pictGong">agogo</metal>
+          </percussion>
+        </direction-type>
+        <footnote>x</footnote>
+        <level>x</level>
+        <voice>1</voice>
+        <staff>1</staff>
+      </direction>
+    </measure>
+  </part>
+</score-partwise>

--- a/docs/ai/projects/gen/synthetic-files/4.0/metronome.4.0.xml
+++ b/docs/ai/projects/gen/synthetic-files/4.0/metronome.4.0.xml
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<score-partwise version="4.0">
+  <part-list>
+    <part-group type="start">
+      <footnote>x</footnote>
+      <level>x</level>
+    </part-group>
+    <score-part id="id1">
+      <part-name>x</part-name>
+    </score-part>
+    <part-group type="start">
+      <footnote>x</footnote>
+      <level>x</level>
+    </part-group>
+  </part-list>
+  <part id="id1">
+    <measure number="x">
+      <direction>
+        <direction-type>
+          <metronome default-x="1" default-y="1" relative-x="1" relative-y="1" font-family="x" font-style="normal" font-size="1" font-weight="normal" color="#FF000000" halign="left" valign="top" print-object="yes" justify="left" parentheses="yes" id="id3">
+            <beat-unit>1024th</beat-unit>
+            <per-minute>x</per-minute>
+          </metronome>
+        </direction-type>
+        <footnote>x</footnote>
+        <level>x</level>
+        <voice>1</voice>
+        <staff>1</staff>
+      </direction>
+    </measure>
+  </part>
+</score-partwise>

--- a/docs/ai/projects/gen/synthetic-files/4.0/numeral-alter.4.0.xml
+++ b/docs/ai/projects/gen/synthetic-files/4.0/numeral-alter.4.0.xml
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<score-partwise version="4.0">
+  <part-list>
+    <part-group type="start">
+      <footnote>x</footnote>
+      <level>x</level>
+    </part-group>
+    <score-part id="id1">
+      <part-name>x</part-name>
+    </score-part>
+    <part-group type="start">
+      <footnote>x</footnote>
+      <level>x</level>
+    </part-group>
+  </part-list>
+  <part id="id1">
+    <measure number="x">
+      <harmony>
+        <numeral>
+          <numeral-root>1</numeral-root>
+          <numeral-alter print-object="yes" default-x="1" default-y="1" relative-x="1" relative-y="1" font-family="x" font-style="normal" font-size="1" font-weight="normal" color="#FF000000" location="left">1</numeral-alter>
+        </numeral>
+        <kind>major</kind>
+        <footnote>x</footnote>
+        <level>x</level>
+        <staff>1</staff>
+      </harmony>
+    </measure>
+  </part>
+</score-partwise>

--- a/docs/ai/projects/gen/synthetic-files/4.0/numeral-fifths.4.0.xml
+++ b/docs/ai/projects/gen/synthetic-files/4.0/numeral-fifths.4.0.xml
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<score-partwise version="4.0">
+  <part-list>
+    <part-group type="start">
+      <footnote>x</footnote>
+      <level>x</level>
+    </part-group>
+    <score-part id="id1">
+      <part-name>x</part-name>
+    </score-part>
+    <part-group type="start">
+      <footnote>x</footnote>
+      <level>x</level>
+    </part-group>
+  </part-list>
+  <part id="id1">
+    <measure number="x">
+      <harmony>
+        <numeral>
+          <numeral-root>1</numeral-root>
+          <numeral-key>
+            <numeral-fifths>1</numeral-fifths>
+            <numeral-mode>major</numeral-mode>
+          </numeral-key>
+        </numeral>
+        <kind>major</kind>
+        <footnote>x</footnote>
+        <level>x</level>
+        <staff>1</staff>
+      </harmony>
+    </measure>
+  </part>
+</score-partwise>

--- a/docs/ai/projects/gen/synthetic-files/4.0/numeral-key.4.0.xml
+++ b/docs/ai/projects/gen/synthetic-files/4.0/numeral-key.4.0.xml
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<score-partwise version="4.0">
+  <part-list>
+    <part-group type="start">
+      <footnote>x</footnote>
+      <level>x</level>
+    </part-group>
+    <score-part id="id1">
+      <part-name>x</part-name>
+    </score-part>
+    <part-group type="start">
+      <footnote>x</footnote>
+      <level>x</level>
+    </part-group>
+  </part-list>
+  <part id="id1">
+    <measure number="x">
+      <harmony>
+        <numeral>
+          <numeral-root>1</numeral-root>
+          <numeral-key print-object="yes">
+            <numeral-fifths>1</numeral-fifths>
+            <numeral-mode>major</numeral-mode>
+          </numeral-key>
+        </numeral>
+        <kind>major</kind>
+        <footnote>x</footnote>
+        <level>x</level>
+        <staff>1</staff>
+      </harmony>
+    </measure>
+  </part>
+</score-partwise>

--- a/docs/ai/projects/gen/synthetic-files/4.0/numeral-mode.4.0.xml
+++ b/docs/ai/projects/gen/synthetic-files/4.0/numeral-mode.4.0.xml
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<score-partwise version="4.0">
+  <part-list>
+    <part-group type="start">
+      <footnote>x</footnote>
+      <level>x</level>
+    </part-group>
+    <score-part id="id1">
+      <part-name>x</part-name>
+    </score-part>
+    <part-group type="start">
+      <footnote>x</footnote>
+      <level>x</level>
+    </part-group>
+  </part-list>
+  <part id="id1">
+    <measure number="x">
+      <harmony>
+        <numeral>
+          <numeral-root>1</numeral-root>
+          <numeral-key>
+            <numeral-fifths>1</numeral-fifths>
+            <numeral-mode>major</numeral-mode>
+          </numeral-key>
+        </numeral>
+        <kind>major</kind>
+        <footnote>x</footnote>
+        <level>x</level>
+        <staff>1</staff>
+      </harmony>
+    </measure>
+  </part>
+</score-partwise>

--- a/docs/ai/projects/gen/synthetic-files/4.0/numeral-root.4.0.xml
+++ b/docs/ai/projects/gen/synthetic-files/4.0/numeral-root.4.0.xml
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<score-partwise version="4.0">
+  <part-list>
+    <part-group type="start">
+      <footnote>x</footnote>
+      <level>x</level>
+    </part-group>
+    <score-part id="id1">
+      <part-name>x</part-name>
+    </score-part>
+    <part-group type="start">
+      <footnote>x</footnote>
+      <level>x</level>
+    </part-group>
+  </part-list>
+  <part id="id1">
+    <measure number="x">
+      <harmony>
+        <numeral>
+          <numeral-root text="x" default-x="1" default-y="1" relative-x="1" relative-y="1" font-family="x" font-style="normal" font-size="1" font-weight="normal" color="#FF000000">1</numeral-root>
+        </numeral>
+        <kind>major</kind>
+        <footnote>x</footnote>
+        <level>x</level>
+        <staff>1</staff>
+      </harmony>
+    </measure>
+  </part>
+</score-partwise>

--- a/docs/ai/projects/gen/synthetic-files/4.0/numeral.4.0.xml
+++ b/docs/ai/projects/gen/synthetic-files/4.0/numeral.4.0.xml
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<score-partwise version="4.0">
+  <part-list>
+    <part-group type="start">
+      <footnote>x</footnote>
+      <level>x</level>
+    </part-group>
+    <score-part id="id1">
+      <part-name>x</part-name>
+    </score-part>
+    <part-group type="start">
+      <footnote>x</footnote>
+      <level>x</level>
+    </part-group>
+  </part-list>
+  <part id="id1">
+    <measure number="x">
+      <harmony>
+        <numeral>
+          <numeral-root>1</numeral-root>
+        </numeral>
+        <kind>major</kind>
+        <footnote>x</footnote>
+        <level>x</level>
+        <staff>1</staff>
+      </harmony>
+    </measure>
+  </part>
+</score-partwise>

--- a/docs/ai/projects/gen/synthetic-files/4.0/other-listen.4.0.xml
+++ b/docs/ai/projects/gen/synthetic-files/4.0/other-listen.4.0.xml
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<score-partwise version="4.0">
+  <part-list>
+    <part-group type="start">
+      <footnote>x</footnote>
+      <level>x</level>
+    </part-group>
+    <score-part id="id1">
+      <part-name>x</part-name>
+    </score-part>
+    <part-group type="start">
+      <footnote>x</footnote>
+      <level>x</level>
+    </part-group>
+  </part-list>
+  <part id="id1">
+    <measure number="x">
+      <note>
+        <grace />
+        <pitch>
+          <step>A</step>
+          <octave>1</octave>
+        </pitch>
+        <footnote>x</footnote>
+        <level>x</level>
+        <voice>1</voice>
+        <staff>1</staff>
+        <listen>
+          <other-listen type="x" player="id3" time-only="1">x</other-listen>
+        </listen>
+      </note>
+    </measure>
+  </part>
+</score-partwise>

--- a/docs/ai/projects/gen/synthetic-files/4.0/other-listening.4.0.xml
+++ b/docs/ai/projects/gen/synthetic-files/4.0/other-listening.4.0.xml
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<score-partwise version="4.0">
+  <part-list>
+    <part-group type="start">
+      <footnote>x</footnote>
+      <level>x</level>
+    </part-group>
+    <score-part id="id1">
+      <part-name>x</part-name>
+    </score-part>
+    <part-group type="start">
+      <footnote>x</footnote>
+      <level>x</level>
+    </part-group>
+  </part-list>
+  <part id="id1">
+    <measure number="x">
+      <direction>
+        <direction-type>
+          <rehearsal>x</rehearsal>
+        </direction-type>
+        <footnote>x</footnote>
+        <level>x</level>
+        <voice>1</voice>
+        <staff>1</staff>
+        <listening>
+          <other-listening type="x" player="id3" time-only="1">x</other-listening>
+        </listening>
+      </direction>
+    </measure>
+  </part>
+</score-partwise>

--- a/docs/ai/projects/gen/synthetic-files/4.0/part-clef.4.0.xml
+++ b/docs/ai/projects/gen/synthetic-files/4.0/part-clef.4.0.xml
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<score-partwise version="4.0">
+  <part-list>
+    <part-group type="start">
+      <footnote>x</footnote>
+      <level>x</level>
+    </part-group>
+    <score-part id="id1">
+      <part-name>x</part-name>
+    </score-part>
+    <part-group type="start">
+      <footnote>x</footnote>
+      <level>x</level>
+    </part-group>
+  </part-list>
+  <part id="id1">
+    <measure number="x">
+      <attributes>
+        <footnote>x</footnote>
+        <level>x</level>
+        <for-part>
+          <part-clef>
+            <sign>G</sign>
+          </part-clef>
+          <part-transpose>
+            <chromatic>1</chromatic>
+          </part-transpose>
+        </for-part>
+      </attributes>
+    </measure>
+  </part>
+</score-partwise>

--- a/docs/ai/projects/gen/synthetic-files/4.0/part-link.4.0.xml
+++ b/docs/ai/projects/gen/synthetic-files/4.0/part-link.4.0.xml
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<score-partwise xmlns:xlink="http://www.w3.org/1999/xlink" version="4.0">
+  <part-list>
+    <part-group type="start">
+      <footnote>x</footnote>
+      <level>x</level>
+    </part-group>
+    <score-part id="id1">
+      <part-link xlink:href="http://example.com" xlink:type="simple" xlink:role="http://example.com/role" xlink:title="x" xlink:show="new" xlink:actuate="onRequest" />
+      <part-name>x</part-name>
+    </score-part>
+    <part-group type="start">
+      <footnote>x</footnote>
+      <level>x</level>
+    </part-group>
+  </part-list>
+  <part id="id1">
+    <measure number="x">
+      <note>
+        <grace />
+        <pitch>
+          <step>A</step>
+          <octave>1</octave>
+        </pitch>
+        <footnote>x</footnote>
+        <level>x</level>
+        <voice>1</voice>
+        <staff>1</staff>
+      </note>
+    </measure>
+  </part>
+</score-partwise>

--- a/docs/ai/projects/gen/synthetic-files/4.0/part-transpose.4.0.xml
+++ b/docs/ai/projects/gen/synthetic-files/4.0/part-transpose.4.0.xml
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<score-partwise version="4.0">
+  <part-list>
+    <part-group type="start">
+      <footnote>x</footnote>
+      <level>x</level>
+    </part-group>
+    <score-part id="id1">
+      <part-name>x</part-name>
+    </score-part>
+    <part-group type="start">
+      <footnote>x</footnote>
+      <level>x</level>
+    </part-group>
+  </part-list>
+  <part id="id1">
+    <measure number="x">
+      <attributes>
+        <footnote>x</footnote>
+        <level>x</level>
+        <for-part>
+          <part-transpose>
+            <chromatic>1</chromatic>
+          </part-transpose>
+        </for-part>
+      </attributes>
+    </measure>
+  </part>
+</score-partwise>

--- a/docs/ai/projects/gen/synthetic-files/4.0/player-name.4.0.xml
+++ b/docs/ai/projects/gen/synthetic-files/4.0/player-name.4.0.xml
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<score-partwise version="4.0">
+  <part-list>
+    <part-group type="start">
+      <footnote>x</footnote>
+      <level>x</level>
+    </part-group>
+    <score-part id="id1">
+      <part-name>x</part-name>
+      <player id="id2">
+        <player-name>1</player-name>
+      </player>
+    </score-part>
+    <part-group type="start">
+      <footnote>x</footnote>
+      <level>x</level>
+    </part-group>
+  </part-list>
+  <part id="id1">
+    <measure number="x">
+      <note>
+        <grace />
+        <pitch>
+          <step>A</step>
+          <octave>1</octave>
+        </pitch>
+        <footnote>x</footnote>
+        <level>x</level>
+        <voice>1</voice>
+        <staff>1</staff>
+      </note>
+    </measure>
+  </part>
+</score-partwise>

--- a/docs/ai/projects/gen/synthetic-files/4.0/player.4.0.xml
+++ b/docs/ai/projects/gen/synthetic-files/4.0/player.4.0.xml
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<score-partwise version="4.0">
+  <part-list>
+    <part-group type="start">
+      <footnote>x</footnote>
+      <level>x</level>
+    </part-group>
+    <score-part id="id1">
+      <part-name>x</part-name>
+      <player id="id2">
+        <player-name>1</player-name>
+      </player>
+    </score-part>
+    <part-group type="start">
+      <footnote>x</footnote>
+      <level>x</level>
+    </part-group>
+  </part-list>
+  <part id="id1">
+    <measure number="x">
+      <note>
+        <grace />
+        <pitch>
+          <step>A</step>
+          <octave>1</octave>
+        </pitch>
+        <footnote>x</footnote>
+        <level>x</level>
+        <voice>1</voice>
+        <staff>1</staff>
+      </note>
+    </measure>
+  </part>
+</score-partwise>

--- a/docs/ai/projects/gen/synthetic-files/4.0/release.4.0.xml
+++ b/docs/ai/projects/gen/synthetic-files/4.0/release.4.0.xml
@@ -1,0 +1,41 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<score-partwise version="4.0">
+  <part-list>
+    <part-group type="start">
+      <footnote>x</footnote>
+      <level>x</level>
+    </part-group>
+    <score-part id="id1">
+      <part-name>x</part-name>
+    </score-part>
+    <part-group type="start">
+      <footnote>x</footnote>
+      <level>x</level>
+    </part-group>
+  </part-list>
+  <part id="id1">
+    <measure number="x">
+      <note>
+        <grace />
+        <pitch>
+          <step>A</step>
+          <octave>1</octave>
+        </pitch>
+        <footnote>x</footnote>
+        <level>x</level>
+        <voice>1</voice>
+        <staff>1</staff>
+        <notations>
+          <footnote>x</footnote>
+          <level>x</level>
+          <technical>
+            <bend>
+              <bend-alter>1</bend-alter>
+              <release offset="1" />
+            </bend>
+          </technical>
+        </notations>
+      </note>
+    </measure>
+  </part>
+</score-partwise>

--- a/docs/ai/projects/gen/synthetic-files/4.0/repeat.4.0.xml
+++ b/docs/ai/projects/gen/synthetic-files/4.0/repeat.4.0.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<score-partwise version="4.0">
+  <part-list>
+    <part-group type="start">
+      <footnote>x</footnote>
+      <level>x</level>
+    </part-group>
+    <score-part id="id1">
+      <part-name>x</part-name>
+    </score-part>
+    <part-group type="start">
+      <footnote>x</footnote>
+      <level>x</level>
+    </part-group>
+  </part-list>
+  <part id="id1">
+    <measure number="x">
+      <barline>
+        <footnote>x</footnote>
+        <level>x</level>
+        <repeat direction="backward" times="1" after-jump="yes" winged="none" />
+      </barline>
+    </measure>
+  </part>
+</score-partwise>

--- a/docs/ai/projects/gen/synthetic-files/4.0/second.4.0.xml
+++ b/docs/ai/projects/gen/synthetic-files/4.0/second.4.0.xml
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<score-partwise version="4.0">
+  <part-list>
+    <part-group type="start">
+      <footnote>x</footnote>
+      <level>x</level>
+    </part-group>
+    <score-part id="id1">
+      <part-name>x</part-name>
+    </score-part>
+    <part-group type="start">
+      <footnote>x</footnote>
+      <level>x</level>
+    </part-group>
+  </part-list>
+  <part id="id1">
+    <measure number="x">
+      <direction>
+        <direction-type>
+          <rehearsal>x</rehearsal>
+        </direction-type>
+        <footnote>x</footnote>
+        <level>x</level>
+        <voice>1</voice>
+        <staff>1</staff>
+        <sound>
+          <swing>
+            <first>1</first>
+            <second>1</second>
+          </swing>
+        </sound>
+      </direction>
+    </measure>
+  </part>
+</score-partwise>

--- a/docs/ai/projects/gen/synthetic-files/4.0/staff-size.4.0.xml
+++ b/docs/ai/projects/gen/synthetic-files/4.0/staff-size.4.0.xml
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<score-partwise version="4.0">
+  <part-list>
+    <part-group type="start">
+      <footnote>x</footnote>
+      <level>x</level>
+    </part-group>
+    <score-part id="id1">
+      <part-name>x</part-name>
+    </score-part>
+    <part-group type="start">
+      <footnote>x</footnote>
+      <level>x</level>
+    </part-group>
+  </part-list>
+  <part id="id1">
+    <measure number="x">
+      <attributes>
+        <footnote>x</footnote>
+        <level>x</level>
+        <staff-details>
+          <staff-lines>1</staff-lines>
+          <staff-size scaling="1">1</staff-size>
+        </staff-details>
+      </attributes>
+    </measure>
+  </part>
+</score-partwise>

--- a/docs/ai/projects/gen/synthetic-files/4.0/straight.4.0.xml
+++ b/docs/ai/projects/gen/synthetic-files/4.0/straight.4.0.xml
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<score-partwise version="4.0">
+  <part-list>
+    <part-group type="start">
+      <footnote>x</footnote>
+      <level>x</level>
+    </part-group>
+    <score-part id="id1">
+      <part-name>x</part-name>
+    </score-part>
+    <part-group type="start">
+      <footnote>x</footnote>
+      <level>x</level>
+    </part-group>
+  </part-list>
+  <part id="id1">
+    <measure number="x">
+      <direction>
+        <direction-type>
+          <rehearsal>x</rehearsal>
+        </direction-type>
+        <footnote>x</footnote>
+        <level>x</level>
+        <voice>1</voice>
+        <staff>1</staff>
+        <sound>
+          <swing>
+            <straight />
+          </swing>
+        </sound>
+      </direction>
+    </measure>
+  </part>
+</score-partwise>

--- a/docs/ai/projects/gen/synthetic-files/4.0/swing-style.4.0.xml
+++ b/docs/ai/projects/gen/synthetic-files/4.0/swing-style.4.0.xml
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<score-partwise version="4.0">
+  <part-list>
+    <part-group type="start">
+      <footnote>x</footnote>
+      <level>x</level>
+    </part-group>
+    <score-part id="id1">
+      <part-name>x</part-name>
+    </score-part>
+    <part-group type="start">
+      <footnote>x</footnote>
+      <level>x</level>
+    </part-group>
+  </part-list>
+  <part id="id1">
+    <measure number="x">
+      <direction>
+        <direction-type>
+          <rehearsal>x</rehearsal>
+        </direction-type>
+        <footnote>x</footnote>
+        <level>x</level>
+        <voice>1</voice>
+        <staff>1</staff>
+        <sound>
+          <swing>
+            <straight />
+            <swing-style>1</swing-style>
+          </swing>
+        </sound>
+      </direction>
+    </measure>
+  </part>
+</score-partwise>

--- a/docs/ai/projects/gen/synthetic-files/4.0/swing-type.4.0.xml
+++ b/docs/ai/projects/gen/synthetic-files/4.0/swing-type.4.0.xml
@@ -1,0 +1,36 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<score-partwise version="4.0">
+  <part-list>
+    <part-group type="start">
+      <footnote>x</footnote>
+      <level>x</level>
+    </part-group>
+    <score-part id="id1">
+      <part-name>x</part-name>
+    </score-part>
+    <part-group type="start">
+      <footnote>x</footnote>
+      <level>x</level>
+    </part-group>
+  </part-list>
+  <part id="id1">
+    <measure number="x">
+      <direction>
+        <direction-type>
+          <rehearsal>x</rehearsal>
+        </direction-type>
+        <footnote>x</footnote>
+        <level>x</level>
+        <voice>1</voice>
+        <staff>1</staff>
+        <sound>
+          <swing>
+            <first>1</first>
+            <second>1</second>
+            <swing-type>16th</swing-type>
+          </swing>
+        </sound>
+      </direction>
+    </measure>
+  </part>
+</score-partwise>

--- a/docs/ai/projects/gen/synthetic-files/4.0/swing.4.0.xml
+++ b/docs/ai/projects/gen/synthetic-files/4.0/swing.4.0.xml
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<score-partwise version="4.0">
+  <part-list>
+    <part-group type="start">
+      <footnote>x</footnote>
+      <level>x</level>
+    </part-group>
+    <score-part id="id1">
+      <part-name>x</part-name>
+    </score-part>
+    <part-group type="start">
+      <footnote>x</footnote>
+      <level>x</level>
+    </part-group>
+  </part-list>
+  <part id="id1">
+    <measure number="x">
+      <direction>
+        <direction-type>
+          <rehearsal>x</rehearsal>
+        </direction-type>
+        <footnote>x</footnote>
+        <level>x</level>
+        <voice>1</voice>
+        <staff>1</staff>
+        <sound>
+          <swing>
+            <straight />
+          </swing>
+        </sound>
+      </direction>
+    </measure>
+  </part>
+</score-partwise>

--- a/docs/ai/projects/gen/synthetic-files/4.0/sync.4.0.xml
+++ b/docs/ai/projects/gen/synthetic-files/4.0/sync.4.0.xml
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<score-partwise version="4.0">
+  <part-list>
+    <part-group type="start">
+      <footnote>x</footnote>
+      <level>x</level>
+    </part-group>
+    <score-part id="id1">
+      <part-name>x</part-name>
+    </score-part>
+    <part-group type="start">
+      <footnote>x</footnote>
+      <level>x</level>
+    </part-group>
+  </part-list>
+  <part id="id1">
+    <measure number="x">
+      <direction>
+        <direction-type>
+          <rehearsal>x</rehearsal>
+        </direction-type>
+        <footnote>x</footnote>
+        <level>x</level>
+        <voice>1</voice>
+        <staff>1</staff>
+        <listening>
+          <sync type="none" latency="1" player="id3" time-only="1" />
+        </listening>
+      </direction>
+    </measure>
+  </part>
+</score-partwise>

--- a/docs/ai/projects/gen/synthetic-files/4.0/timpani.4.0.xml
+++ b/docs/ai/projects/gen/synthetic-files/4.0/timpani.4.0.xml
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<score-partwise version="4.0">
+  <part-list>
+    <part-group type="start">
+      <footnote>x</footnote>
+      <level>x</level>
+    </part-group>
+    <score-part id="id1">
+      <part-name>x</part-name>
+    </score-part>
+    <part-group type="start">
+      <footnote>x</footnote>
+      <level>x</level>
+    </part-group>
+  </part-list>
+  <part id="id1">
+    <measure number="x">
+      <direction>
+        <direction-type>
+          <percussion>
+            <timpani smufl="pictGong" />
+          </percussion>
+        </direction-type>
+        <footnote>x</footnote>
+        <level>x</level>
+        <voice>1</voice>
+        <staff>1</staff>
+      </direction>
+    </measure>
+  </part>
+</score-partwise>

--- a/docs/ai/projects/gen/synthetic-files/4.0/wait.4.0.xml
+++ b/docs/ai/projects/gen/synthetic-files/4.0/wait.4.0.xml
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<score-partwise version="4.0">
+  <part-list>
+    <part-group type="start">
+      <footnote>x</footnote>
+      <level>x</level>
+    </part-group>
+    <score-part id="id1">
+      <part-name>x</part-name>
+    </score-part>
+    <part-group type="start">
+      <footnote>x</footnote>
+      <level>x</level>
+    </part-group>
+  </part-list>
+  <part id="id1">
+    <measure number="x">
+      <note>
+        <grace />
+        <pitch>
+          <step>A</step>
+          <octave>1</octave>
+        </pitch>
+        <footnote>x</footnote>
+        <level>x</level>
+        <voice>1</voice>
+        <staff>1</staff>
+        <listen>
+          <wait player="id3" time-only="1" />
+        </listen>
+      </note>
+    </measure>
+  </part>
+</score-partwise>

--- a/docs/ai/projects/gen/synthetic-files/4.0/wavy-line.4.0.xml
+++ b/docs/ai/projects/gen/synthetic-files/4.0/wavy-line.4.0.xml
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<score-partwise version="4.0">
+  <part-list>
+    <part-group type="start">
+      <footnote>x</footnote>
+      <level>x</level>
+    </part-group>
+    <score-part id="id1">
+      <part-name>x</part-name>
+    </score-part>
+    <part-group type="start">
+      <footnote>x</footnote>
+      <level>x</level>
+    </part-group>
+  </part-list>
+  <part id="id1">
+    <measure number="x">
+      <note>
+        <grace />
+        <pitch>
+          <step>A</step>
+          <octave>1</octave>
+        </pitch>
+        <footnote>x</footnote>
+        <level>x</level>
+        <voice>1</voice>
+        <staff>1</staff>
+        <notations>
+          <footnote>x</footnote>
+          <level>x</level>
+          <ornaments>
+            <wavy-line type="start" number="1" smufl="wiggleTrill" default-x="1" default-y="1" relative-x="1" relative-y="1" placement="above" color="#FF000000" start-note="upper" trill-step="whole" two-note-turn="whole" accelerate="yes" beats="2" second-beat="1" last-beat="1" />
+          </ornaments>
+        </notations>
+      </note>
+    </measure>
+  </part>
+</score-partwise>

--- a/docs/ai/projects/gen/synthetic-files/4.0/wood.4.0.xml
+++ b/docs/ai/projects/gen/synthetic-files/4.0/wood.4.0.xml
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<score-partwise version="4.0">
+  <part-list>
+    <part-group type="start">
+      <footnote>x</footnote>
+      <level>x</level>
+    </part-group>
+    <score-part id="id1">
+      <part-name>x</part-name>
+    </score-part>
+    <part-group type="start">
+      <footnote>x</footnote>
+      <level>x</level>
+    </part-group>
+  </part-list>
+  <part id="id1">
+    <measure number="x">
+      <direction>
+        <direction-type>
+          <percussion>
+            <wood smufl="pictGong">bamboo scraper</wood>
+          </percussion>
+        </direction-type>
+        <footnote>x</footnote>
+        <level>x</level>
+        <voice>1</voice>
+        <staff>1</staff>
+      </direction>
+    </measure>
+  </part>
+</score-partwise>


### PR DESCRIPTION
## Summary

The 3.1 and 4.0 synthetic coverage batches were generated alongside the 3.0
batch but never landed. This restores them.

## Details

#162 committed the 235 3.0 files but only 3 of the 3.1 files (one an empty
stub) and none of the 4.0 files. Restored here:

- `docs/ai/projects/gen/synthetic-files/3.1/` - 101 files (98 new, 1 empty
  stub filled in, 2 already correct)
- `docs/ai/projects/gen/synthetic-files/4.0/` - 52 files (all new)

Recovered from an unreachable commit left after pruning; the 4.0 subtree was
byte-identical to a sibling copy, so the content is unambiguous.

## Verification

- No 0-byte files among the 153 restored (smallest is 542 bytes).
- Counts match the batch table in `synthetic-plan.md` (101 and 52).

## References

- Progress on #156
- Restores files omitted by #162
- Tracked by #58