### PR TITLE
ci: fix Go cache perms in mx-sdk container

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -45,4 +45,14 @@ ENV MX_RUNNING_IN_DOCKER=1 \
     CCACHE_DIR=/workspace/build/.ccache \
     CCACHE_MAXSIZE=2G
 
+# The container runs as the caller's uid:gid (DOCKER_USER), which has no passwd
+# entry, so HOME defaults to "/". Go would then place GOPATH at /go and GOCACHE
+# at /.cache/go-build -- both unwritable -- and `make test-go` dies with
+# "could not create module cache: mkdir /go: permission denied". Pin the Go
+# caches under the writable build volume, exactly as CCACHE_DIR above. The Go
+# module is vendored, so no network fetch is needed.
+ENV GOPATH=/workspace/build/go \
+    GOCACHE=/workspace/build/go/cache \
+    GOMODCACHE=/workspace/build/go/pkg/mod
+
 WORKDIR /workspace


### PR DESCRIPTION
## Problem

The `Linux (Go + C targets)` CI job fails at the **Go corert suite** step
([run](https://github.com/webern/mx/actions/runs/27506189030/job/81297724980)):

```
cd gen/test/go && MX_REPO_ROOT=/workspace go test -count=1 -v ./corert/
go: go: could not create module cache: mkdir /go: permission denied
make: *** [Makefile:355: test-go] Error 1
```

The `DOCKER_RUN` recipe runs the `mx-sdk` container as the caller's `uid:gid`
(`--user 1001:1001` on the runner). That UID has no `/etc/passwd` entry, so
`HOME` defaults to `/`. Go then derives `GOPATH=/go` and
`GOCACHE=/.cache/go-build`, neither of which the unprivileged user can create.

The C++ jobs don't hit this because the Dockerfile already pins `CCACHE_DIR`
to the writable `/workspace/build` volume; Go had no equivalent override.

## Fix

Pin `GOPATH`, `GOCACHE`, and `GOMODCACHE` under the writable `/workspace/build`
volume in the Dockerfile, exactly mirroring `CCACHE_DIR`. The Go module is
vendored (`gen/test/go/vendor/`), so no network fetch is needed.

## Base

Targets `musicxml-4.0` so that merging this folds the fix into PR #169.