### PR TITLE
build: add swift package for local builds

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -349,3 +349,24 @@ jobs:
 
       - name: Build and run examples
         run: make examples-run
+
+  swift-local:
+    name: macOS (Swift package, local checkout)
+    runs-on: macos-latest
+
+    # The local-checkout consumption mode (MX_LOCAL_CHECKOUT) builds `Mx` as a
+    # source library straight from this checkout -- the path komp takes when it
+    # depends on a sibling mx via `.package(path:)`. Building it here proves mx
+    # compiles as a Swift package under AppleClang/SPM on every PR. The binary
+    # xcframework release arm is follow-up work.
+    env:
+      MX_LOCAL_CHECKOUT: "1"
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Swift toolchain
+        run: swift --version
+
+      - name: Build the Mx Swift package (local-checkout source mode)
+        run: swift build --product Mx

--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,7 @@ __pycache__/
 # Gen test build artifacts
 gen/test/c/build/
 gen/test/go/build/
+
+# Swift package build artifacts
+.build/
+Package.resolved

--- a/Package.swift
+++ b/Package.swift
@@ -1,0 +1,52 @@
+// swift-tools-version: 5.9
+import PackageDescription
+
+// mx is consumed as a Swift package in one of two modes, selected by the
+// MX_LOCAL_CHECKOUT environment variable. The name mirrors the repo's existing
+// local-vs-Docker build switch (MX_RUNNING_IN_DOCKER) and reads as "consume mx
+// from a local checkout":
+//
+//   set   -> `Mx` is a source library compiled from this checkout, for
+//            sibling-checkout development (a consumer using `.package(path:)`).
+//   unset -> `Mx` is the published xcframework binary release. That pipeline is
+//            follow-up work and is not wired up yet, so this arm fails loudly
+//            rather than silently resolving to a nonexistent artifact.
+let useLocalCheckout = Context.environment["MX_LOCAL_CHECKOUT"] != nil
+
+let mxTarget: Target
+if useLocalCheckout {
+    // SPM globs every C++ translation unit under `src` (all of which live in
+    // `src/private`), minus the Catch2 runner, the test suites, and the example
+    // programs -- the only files carrying their own main(). The public surface
+    // is the mx::api headers under `src/include`; `src/private` is added to the
+    // internal header search path so the model can include `mx/core/...` and
+    // `pugixml/...`.
+    mxTarget = .target(
+        name: "Mx",
+        path: "src",
+        exclude: [
+            "private/cpul",
+            "private/mxtest",
+            "private/mx/examples",
+        ],
+        publicHeadersPath: "include",
+        cxxSettings: [
+            .headerSearchPath("private"),
+        ]
+    )
+} else {
+    fatalError(
+        "The Mx binary release is not published yet. Build with "
+            + "MX_LOCAL_CHECKOUT=1 against a sibling mx checkout; the "
+            + "binary-release arm is follow-up work."
+    )
+}
+
+let package = Package(
+    name: "mx",
+    products: [
+        .library(name: "Mx", targets: ["Mx"]),
+    ],
+    targets: [mxTarget],
+    cxxLanguageStandard: .cxx20
+)

--- a/src/include/mx/api/ApiCommon.h
+++ b/src/include/mx/api/ApiCommon.h
@@ -12,7 +12,7 @@ namespace mx
 {
 namespace api
 {
-using Double = long double;
+using Double = double;
 using OptionalDouble = std::optional<Double>;
 constexpr const Double MX_API_EQUALITY_EPSILON = 0.00000001;
 

--- a/src/include/mx/api/ApiEquality.h
+++ b/src/include/mx/api/ApiEquality.h
@@ -58,7 +58,7 @@ template <typename T> inline bool areEqual(const T &lhs, const T &rhs)
     return lhs == rhs;
 }
 
-template <> inline bool areEqual<long double>(const long double &lhs, const long double &rhs)
+template <> inline bool areEqual<double>(const double &lhs, const double &rhs)
 {
     return areSame(lhs, rhs);
 }

--- a/src/include/mx/api/AppearanceData.h
+++ b/src/include/mx/api/AppearanceData.h
@@ -48,7 +48,7 @@ class AppearanceData
   public:
     AppearanceType appearanceType;
     std::string appearanceSubType;
-    long double value;
+    double value;
 };
 
 MXAPI_EQUALS_BEGIN(AppearanceData)

--- a/src/include/mx/api/CurveData.h
+++ b/src/include/mx/api/CurveData.h
@@ -65,10 +65,10 @@ struct CurvePoints
     PositionData positionData;
 
     bool isBezierXSpecified;
-    long double bezierX;
+    double bezierX;
 
     bool isBezierYSpecified;
-    long double bezierY;
+    double bezierY;
 
     bool isBezierOffsetSpecified;
     int bezierOffset;
@@ -112,11 +112,11 @@ struct CurveContinue
     int numberLevel;
     CurvePoints curvePoints;
     bool isBezierX2Specified;
-    long double bezierX2;
+    double bezierX2;
     bool isBezierY2Specified;
-    long double bezierY2;
+    double bezierY2;
     bool isBezierOffset2Specified;
-    long double bezierOffset2;
+    double bezierOffset2;
 
     CurveContinue(CurveType inCurveType)
         : curveType{inCurveType}, numberLevel{-1}, curvePoints{}, isBezierX2Specified{false}, bezierX2{0.0},

--- a/src/include/mx/api/DurationData.h
+++ b/src/include/mx/api/DurationData.h
@@ -32,25 +32,25 @@ enum class DurationName
     dur1024th
 };
 
-constexpr long double DUR_QUARTERS_VALUE_MAXIMA = 32.0L;
-constexpr long double DUR_QUARTERS_VALUE_LONGA = 16.0L;
-constexpr long double DUR_QUARTERS_VALUE_BREVE = 8.0L;
-constexpr long double DUR_QUARTERS_VALUE_WHOLE = 4.0L;
-constexpr long double DUR_QUARTERS_VALUE_HALF = 2.0L;
-constexpr long double DUR_QUARTERS_VALUE_QUARTER = 1.0L;
-constexpr long double DUR_QUARTERS_VALUE_EIGHTH = 1.0L / 2.0L;
-constexpr long double DUR_QUARTERS_VALUE_16TH = 1.0L / 4.0L;
-constexpr long double DUR_QUARTERS_VALUE_32ND = 1.0L / 8.0L;
-constexpr long double DUR_QUARTERS_VALUE_64TH = 1.0L / 16.0L;
-constexpr long double DUR_QUARTERS_VALUE_128TH = 1.0L / 32.0L;
-constexpr long double DUR_QUARTERS_VALUE_256TH = 1.0L / 64.0L;
-constexpr long double DUR_QUARTERS_VALUE_512TH = 1.0L / 128.0L;
-constexpr long double DUR_QUARTERS_VALUE_1024TH = 1.0L / 256.0L;
+constexpr double DUR_QUARTERS_VALUE_MAXIMA = 32.0;
+constexpr double DUR_QUARTERS_VALUE_LONGA = 16.0;
+constexpr double DUR_QUARTERS_VALUE_BREVE = 8.0;
+constexpr double DUR_QUARTERS_VALUE_WHOLE = 4.0;
+constexpr double DUR_QUARTERS_VALUE_HALF = 2.0;
+constexpr double DUR_QUARTERS_VALUE_QUARTER = 1.0;
+constexpr double DUR_QUARTERS_VALUE_EIGHTH = 1.0 / 2.0;
+constexpr double DUR_QUARTERS_VALUE_16TH = 1.0 / 4.0;
+constexpr double DUR_QUARTERS_VALUE_32ND = 1.0 / 8.0;
+constexpr double DUR_QUARTERS_VALUE_64TH = 1.0 / 16.0;
+constexpr double DUR_QUARTERS_VALUE_128TH = 1.0 / 32.0;
+constexpr double DUR_QUARTERS_VALUE_256TH = 1.0 / 64.0;
+constexpr double DUR_QUARTERS_VALUE_512TH = 1.0 / 128.0;
+constexpr double DUR_QUARTERS_VALUE_1024TH = 1.0 / 256.0;
 
-inline long double applyDots(long double inUnDottedValue, int inNumDots)
+inline double applyDots(double inUnDottedValue, int inNumDots)
 {
-    long double outValue = inUnDottedValue;
-    long double valueToAdd = inUnDottedValue / 0.5;
+    double outValue = inUnDottedValue;
+    double valueToAdd = inUnDottedValue / 0.5;
 
     for (int i = 0; i < inNumDots; ++i)
     {

--- a/src/include/mx/api/FontData.h
+++ b/src/include/mx/api/FontData.h
@@ -56,7 +56,7 @@ struct FontData
     // is in use. if css, then use the fontSizeCss
     // field, if point then use fontSizePoint
     FontSizeType sizeType;
-    long double sizePoint;
+    double sizePoint;
     CssSize sizeCss;
 
     FontStyle style;
@@ -69,7 +69,7 @@ struct FontData
     int lineThrough;
 
     FontData()
-        : sizeType{FontSizeType::unspecified}, sizePoint{-1.0L}, sizeCss{CssSize::unspecified},
+        : sizeType{FontSizeType::unspecified}, sizePoint{-1.0}, sizeCss{CssSize::unspecified},
           style{FontStyle::unspecified}, weight{FontWeight::unspecified}, fontFamily{}, underline{0}, overline{0},
           lineThrough{0}
     {

--- a/src/include/mx/api/LineData.h
+++ b/src/include/mx/api/LineData.h
@@ -34,11 +34,11 @@ struct LineData
     LineType lineType;
     LineHook lineHook;
     bool isStopLengthSpecified;
-    long double endLength;
+    double endLength;
     bool isDashLengthSpecified;
-    long double dashLength;
+    double dashLength;
     bool isSpaceLengthSpecified;
-    long double spaceLength;
+    double spaceLength;
 
     inline bool isSpecified() const
     {

--- a/src/include/mx/api/MeasureData.h
+++ b/src/include/mx/api/MeasureData.h
@@ -84,7 +84,7 @@ class MeasureData
     Bool nonControlling;
 
     // a width value less than 0 means 'unspecified'
-    long double width;
+    double width;
     std::vector<KeyData> keys;
     std::vector<BarlineData> barlines;
 

--- a/src/include/mx/api/PartData.h
+++ b/src/include/mx/api/PartData.h
@@ -43,15 +43,15 @@ struct MidiData
     int unpitched;
 
     // percent, valid range 0.0 to 100.0
-    long double volume;
+    double volume;
     bool isVolumeSpecified;
 
     // rotation degrees, valid range -180.0 to +180.0
-    long double pan;
+    double pan;
     bool isPanSpecified;
 
     // rotation degrees, valid range -180.0 to +180.0
-    long double elevation;
+    double elevation;
     bool isElevationSpecified;
 
     MidiData()

--- a/src/include/mx/api/PositionData.h
+++ b/src/include/mx/api/PositionData.h
@@ -96,13 +96,13 @@ class PositionData
   public:
     // decimal values are in 'tenths'
 
-    long double defaultX;
+    double defaultX;
     bool isDefaultXSpecified;
-    long double defaultY;
+    double defaultY;
     bool isDefaultYSpecified;
-    long double relativeX;
+    double relativeX;
     bool isRelativeXSpecified;
-    long double relativeY;
+    double relativeY;
     bool isRelativeYSpecified;
     Placement placement;
     VerticalAlignment verticalAlignment;

--- a/src/include/mx/api/WedgeData.h
+++ b/src/include/mx/api/WedgeData.h
@@ -25,7 +25,7 @@ struct WedgeStart
     int numberLevel;
     WedgeType wedgeType;
     bool isSpreadSpecified;
-    long double spread;
+    double spread;
     LineData lineData;
     PositionData positionData;
     ColorData colorData;
@@ -42,7 +42,7 @@ struct WedgeStop
     int numberLevel;
     PositionData positionData;
     bool isSpreadSpecified;
-    long double spread;
+    double spread;
 
     WedgeStop() : numberLevel{-1}, positionData{}, isSpreadSpecified{false}, spread{0.0}
     {

--- a/src/private/mx/impl/Cursor.cpp
+++ b/src/private/mx/impl/Cursor.cpp
@@ -39,25 +39,25 @@ void Cursor::reset()
 
 int Cursor::convertDurationToGlobalTickScale(const core::PositiveDivisions &duration) const
 {
-    return convertDurationToGlobalTickScale(static_cast<long double>(duration.value().value()));
+    return convertDurationToGlobalTickScale(static_cast<double>(duration.value().value()));
 }
 
-int Cursor::convertDurationToGlobalTickScale(long double durationValue) const
+int Cursor::convertDurationToGlobalTickScale(double durationValue) const
 {
     if (this->ticksPerQuarter == this->getGlobalTicksPerQuarter())
     {
-        return static_cast<int>(std::ceil(durationValue - 0.5L));
+        return static_cast<int>(std::ceil(durationValue - 0.5));
     }
 
-    const long double currentTicksPerQuarter = static_cast<long double>(this->ticksPerQuarter);
-    const long double globalTicksPerQuarter = static_cast<long double>(this->getGlobalTicksPerQuarter());
-    const long double convertedVal = durationValue * (globalTicksPerQuarter / currentTicksPerQuarter);
-    return static_cast<int>(std::ceil(convertedVal - 0.5L));
+    const double currentTicksPerQuarter = static_cast<double>(this->ticksPerQuarter);
+    const double globalTicksPerQuarter = static_cast<double>(this->getGlobalTicksPerQuarter());
+    const double convertedVal = durationValue * (globalTicksPerQuarter / currentTicksPerQuarter);
+    return static_cast<int>(std::ceil(convertedVal - 0.5));
 }
 
 int Cursor::convertDurationToGlobalTickScale(int durationValue) const
 {
-    return convertDurationToGlobalTickScale(static_cast<long double>(durationValue));
+    return convertDurationToGlobalTickScale(static_cast<double>(durationValue));
 }
 } // namespace impl
 } // namespace mx

--- a/src/private/mx/impl/Cursor.h
+++ b/src/private/mx/impl/Cursor.h
@@ -44,7 +44,7 @@ class Cursor
     void reset();
 
     int convertDurationToGlobalTickScale(const core::PositiveDivisions &duration) const;
-    int convertDurationToGlobalTickScale(long double durationValue) const;
+    int convertDurationToGlobalTickScale(double durationValue) const;
     int convertDurationToGlobalTickScale(int duration) const;
 
   private:

--- a/src/private/mx/impl/DirectionReader.cpp
+++ b/src/private/mx/impl/DirectionReader.cpp
@@ -428,7 +428,7 @@ void DirectionReader::parseWedge(const core::DirectionType &directionType)
     const auto &wedge = directionType.choice().asWedge();
     const auto wedgeType = myConverter.convert(wedge.type());
     const bool isSpreadSpecified = wedge.spread().has_value();
-    const long double spread = isSpreadSpecified ? static_cast<long double>(wedge.spread()->value().value()) : 0.0L;
+    const double spread = isSpreadSpecified ? static_cast<double>(wedge.spread()->value().value()) : 0.0;
     auto positionData = getPositionData(wedge);
     auto lineData = getLineData(wedge);
     auto colorData = getColor(wedge);
@@ -569,17 +569,17 @@ void DirectionReader::parseBracket(const core::DirectionType &directionType)
         if (bracket.endLength().has_value())
         {
             lineData.isStopLengthSpecified = true;
-            lineData.endLength = static_cast<long double>(bracket.endLength()->value().value());
+            lineData.endLength = static_cast<double>(bracket.endLength()->value().value());
         }
         if (bracket.dashLength().has_value())
         {
             lineData.isDashLengthSpecified = true;
-            lineData.dashLength = static_cast<long double>(bracket.dashLength()->value().value());
+            lineData.dashLength = static_cast<double>(bracket.dashLength()->value().value());
         }
         if (bracket.spaceLength().has_value())
         {
             lineData.isSpaceLengthSpecified = true;
-            lineData.spaceLength = static_cast<long double>(bracket.spaceLength()->value().value());
+            lineData.spaceLength = static_cast<double>(bracket.spaceLength()->value().value());
         }
         return lineData;
     };

--- a/src/private/mx/impl/FontFunctions.h
+++ b/src/private/mx/impl/FontFunctions.h
@@ -79,11 +79,11 @@ template <typename ATTRIBUTES_TYPE> api::FontWeight getFontWeight(const ATTRIBUT
 }
 
 template <typename ATTRIBUTES_TYPE>
-api::FontSizeType getFontSize(const ATTRIBUTES_TYPE &inAttributes, long double &outPointSize, api::CssSize &outCssSize)
+api::FontSizeType getFontSize(const ATTRIBUTES_TYPE &inAttributes, double &outPointSize, api::CssSize &outCssSize)
 {
     if (!checkHasFontSize<ATTRIBUTES_TYPE>(&inAttributes))
     {
-        outPointSize = -1.0L;
+        outPointSize = -1.0;
         outCssSize = api::CssSize::unspecified;
         return api::FontSizeType::unspecified;
     }
@@ -93,7 +93,7 @@ api::FontSizeType getFontSize(const ATTRIBUTES_TYPE &inAttributes, long double &
 
     if (coreFontSize.isCSSFontSize())
     {
-        outPointSize = -1.0L;
+        outPointSize = -1.0;
         outCssSize = converter.convert(coreFontSize.asCSSFontSize());
         return api::FontSizeType::css;
     }

--- a/src/private/mx/impl/LineFunctions.h
+++ b/src/private/mx/impl/LineFunctions.h
@@ -23,13 +23,13 @@ MX_OPTIONAL_HAS_FUNC(lineStop, LineStop);
 MX_OPTIONAL_GET_VALUE_FUNC(lineStop, LineStop, core::LineEnd, core::LineEnd::none());
 
 MX_OPTIONAL_HAS_FUNC(dashLength, DashLength);
-MX_OPTIONAL_GET_DECIMAL_FUNC(dashLength, DashLength, 0.0L);
+MX_OPTIONAL_GET_DECIMAL_FUNC(dashLength, DashLength, 0.0);
 
 MX_OPTIONAL_HAS_FUNC(spaceLength, SpaceLength);
-MX_OPTIONAL_GET_DECIMAL_FUNC(spaceLength, SpaceLength, 0.0L);
+MX_OPTIONAL_GET_DECIMAL_FUNC(spaceLength, SpaceLength, 0.0);
 
 MX_OPTIONAL_HAS_FUNC(endLength, StopLength);
-MX_OPTIONAL_GET_DECIMAL_FUNC(endLength, StopLength, 0.0L);
+MX_OPTIONAL_GET_DECIMAL_FUNC(endLength, StopLength, 0.0);
 
 template <typename ATTRIBUTES_TYPE> api::LineData getLineData(const ATTRIBUTES_TYPE &inAttributes)
 {

--- a/src/private/mx/impl/MeasureReader.cpp
+++ b/src/private/mx/impl/MeasureReader.cpp
@@ -171,7 +171,7 @@ std::pair<api::MeasureData, std::optional<api::TransposeData>> MeasureReader::ge
 
     if (myPartwiseMeasure.width().has_value())
     {
-        myOutMeasureData.width = static_cast<long double>(myPartwiseMeasure.width()->value().value());
+        myOutMeasureData.width = static_cast<double>(myPartwiseMeasure.width()->value().value());
     }
 
     if (myPartwiseMeasure.implicit().has_value())

--- a/src/private/mx/impl/NoteFunctions.cpp
+++ b/src/private/mx/impl/NoteFunctions.cpp
@@ -147,8 +147,8 @@ api::NoteData NoteFunctions::parseNote() const
 // TODO - make this work even if notes are dotted and if they are tupleted
 api::DurationName NoteFunctions::deriveNoteTypeFromDurationValue(const NoteReader &reader) const
 {
-    const long double durationValue = reader.getDurationValue();
-    const long double ticksPerQuarter = static_cast<long double>(myCursor.getGlobalTicksPerQuarter());
+    const double durationValue = reader.getDurationValue();
+    const double ticksPerQuarter = static_cast<double>(myCursor.getGlobalTicksPerQuarter());
 
     if (api::areSame(durationValue, api::DUR_QUARTERS_VALUE_QUARTER * ticksPerQuarter))
     {

--- a/src/private/mx/impl/NoteReader.cpp
+++ b/src/private/mx/impl/NoteReader.cpp
@@ -139,7 +139,7 @@ std::string getLyricDisplayText(const core::LyricTextGroup &inGroup)
 NoteReader::NoteReader(const core::Note &mxNote)
     : myNote(mxNote), myNoteChoice(myNote.choice()), myFullNoteGroup(findFullNoteGroup(myNoteChoice)),
       myIsNormal(false), myIsGrace(false), myIsCue(false), myIsRest(false), myIsChord(false), myIsMeasureRest(false),
-      myIsUnpitched(false), myIsPitch(false), myIsDisplayStepOctaveSpecified(false), myDurationValue(0.0L),
+      myIsUnpitched(false), myIsPitch(false), myIsDisplayStepOctaveSpecified(false), myDurationValue(0.0),
       myStep(core::Step::c()), myAlter(0), myCents(0.0), myOctave(4), myStaffNumber(0), myVoiceNumber(0),
       myNoteheadValue(core::NoteheadValue::normal()), myDurationType(core::NoteTypeValue::maxima()),
       myIsDurationTypeSpecified(false), myNumDots(0), myBeams(), myTimeModificationActualNotes(-1),

--- a/src/private/mx/impl/NoteReader.h
+++ b/src/private/mx/impl/NoteReader.h
@@ -87,7 +87,7 @@ class NoteReader
         return myIsDisplayStepOctaveSpecified;
     }
 
-    inline long double getDurationValue() const
+    inline double getDurationValue() const
     {
         return myDurationValue;
     }
@@ -235,7 +235,7 @@ class NoteReader
     bool myIsUnpitched;
     bool myIsPitch;
     bool myIsDisplayStepOctaveSpecified;
-    long double myDurationValue;
+    double myDurationValue;
     core::Step myStep;
     int myAlter;
     double myCents;

--- a/src/private/mx/impl/NoteWriter.cpp
+++ b/src/private/mx/impl/NoteWriter.cpp
@@ -168,8 +168,8 @@ core::Note NoteWriter::getNote(bool isStartOfChord) const
             if (tickTimeDistance > 0 && tupletStart.normalNumber != 0 && tupletStart.actualNumber != 0)
             {
                 // calculate the tuplet normal type and dots based on the distance between start and stop and the ratio
-                const long double normalLength =
-                    static_cast<long double>(tickTimeDistance) / static_cast<long double>(tupletStart.normalNumber);
+                const double normalLength =
+                    static_cast<double>(tickTimeDistance) / static_cast<double>(tupletStart.normalNumber);
 
                 mx::api::DurationName normalName = mx::api::DurationName::unspecified;
                 int normalDots = 0;
@@ -461,12 +461,12 @@ void NoteWriter::setMiscData() const
     myOutNote.setEditorialVoice(std::move(editorialVoice));
 }
 
-bool NoteWriter::findNormalNameAndDots(mx::api::DurationName &ioName, int &ioDots, long double inTickLength) const
+bool NoteWriter::findNormalNameAndDots(mx::api::DurationName &ioName, int &ioDots, double inTickLength) const
 {
-    const auto equals = [&](long double a, long double b) { return std::abs(a - b) < 0.0001; };
+    const auto equals = [&](double a, double b) { return std::abs(a - b) < 0.0001; };
 
-    const auto isMatch = [&](long double durQuarters, int numDots, mx::api::DurationName name) {
-        if (equals(mx::api::applyDots(durQuarters * static_cast<long double>(myCursor.ticksPerQuarter), numDots),
+    const auto isMatch = [&](double durQuarters, int numDots, mx::api::DurationName name) {
+        if (equals(mx::api::applyDots(durQuarters * static_cast<double>(myCursor.ticksPerQuarter), numDots),
                    inTickLength))
         {
             ioName = name;

--- a/src/private/mx/impl/NoteWriter.h
+++ b/src/private/mx/impl/NoteWriter.h
@@ -51,7 +51,7 @@ class NoteWriter
     void setNotehead() const;
     void setStemDirection() const;
     void setMiscData() const;
-    bool findNormalNameAndDots(mx::api::DurationName &ioName, int &ioDots, long double inTickLength) const;
+    bool findNormalNameAndDots(mx::api::DurationName &ioName, int &ioDots, double inTickLength) const;
 };
 } // namespace impl
 } // namespace mx

--- a/src/private/mx/impl/PositionFunctions.h
+++ b/src/private/mx/impl/PositionFunctions.h
@@ -13,16 +13,16 @@ namespace mx
 namespace impl
 {
 MX_OPTIONAL_HAS_FUNC(defaultX, DefaultX);
-MX_OPTIONAL_GET_DECIMAL_FUNC(defaultX, DefaultX, 1.0L);
+MX_OPTIONAL_GET_DECIMAL_FUNC(defaultX, DefaultX, 1.0);
 
 MX_OPTIONAL_HAS_FUNC(defaultY, DefaultY);
-MX_OPTIONAL_GET_DECIMAL_FUNC(defaultY, DefaultY, 1.0L);
+MX_OPTIONAL_GET_DECIMAL_FUNC(defaultY, DefaultY, 1.0);
 
 MX_OPTIONAL_HAS_FUNC(relativeX, RelativeX);
-MX_OPTIONAL_GET_DECIMAL_FUNC(relativeX, RelativeX, 1.0L);
+MX_OPTIONAL_GET_DECIMAL_FUNC(relativeX, RelativeX, 1.0);
 
 MX_OPTIONAL_HAS_FUNC(relativeY, RelativeY);
-MX_OPTIONAL_GET_DECIMAL_FUNC(relativeY, RelativeY, 1.0L);
+MX_OPTIONAL_GET_DECIMAL_FUNC(relativeY, RelativeY, 1.0);
 
 MX_OPTIONAL_HAS_FUNC(halign, Halign);
 MX_OPTIONAL_GET_VALUE_FUNC(halign, Halign, core::LeftCenterRight, core::LeftCenterRight::left());

--- a/src/private/mx/impl/ScoreReader.cpp
+++ b/src/private/mx/impl/ScoreReader.cpp
@@ -490,8 +490,8 @@ void ScoreReader::scanForPageInfo() const
                 if (pageLayout.group().has_value())
                 {
                     outPageData.pageLayoutData.size =
-                        api::SizeData{static_cast<long double>(pageLayout.group()->pageHeight().value().value()),
-                                      static_cast<long double>(pageLayout.group()->pageWidth().value().value())};
+                        api::SizeData{static_cast<double>(pageLayout.group()->pageHeight().value().value()),
+                                      static_cast<double>(pageLayout.group()->pageWidth().value().value())};
                 }
                 for (const auto &pageMargins : pageLayout.pageMargins())
                 {
@@ -509,10 +509,10 @@ void ScoreReader::scanForPageInfo() const
                         t = *pageMargins.type();
                     }
                     const auto &allMargins = pageMargins.allMargins();
-                    const long double left = allMargins.leftRightMargins().leftMargin().value().value();
-                    const long double right = allMargins.leftRightMargins().rightMargin().value().value();
-                    const long double top = allMargins.topMargin().value().value();
-                    const long double bottom = allMargins.bottomMargin().value().value();
+                    const double left = allMargins.leftRightMargins().leftMargin().value().value();
+                    const double right = allMargins.leftRightMargins().rightMargin().value().value();
+                    const double top = allMargins.topMargin().value().value();
+                    const double bottom = allMargins.bottomMargin().value().value();
                     const api::MarginsData margins{left, right, top, bottom};
                     const bool writeOdd =
                         t.tag() == core::MarginType::Tag::both || t.tag() == core::MarginType::Tag::odd;

--- a/src/private/mx/utility/OptionalMembers.h
+++ b/src/private/mx/utility/OptionalMembers.h
@@ -51,13 +51,13 @@
 // Value getter for a clamped-decimal wrapper field (e.g. Tenths).
 #define MX_OPTIONAL_GET_DECIMAL_FUNC(fieldName, fieldNameCapitalized, defaultReturnValue)                              \
                                                                                                                        \
-    template <class T> long double check##fieldNameCapitalized(const T *const el)                                      \
+    template <class T> double check##fieldNameCapitalized(const T *const el)                                           \
     {                                                                                                                  \
         if constexpr (requires { el->fieldName()->value().value(); })                                                  \
         {                                                                                                              \
             if (el->fieldName().has_value())                                                                           \
             {                                                                                                          \
-                return static_cast<long double>(el->fieldName()->value().value());                                     \
+                return static_cast<double>(el->fieldName()->value().value());                                          \
             }                                                                                                          \
         }                                                                                                              \
         return defaultReturnValue;                                                                                     \


### PR DESCRIPTION
## Summary

Compile `mx` as a Swift package so a sibling consumer can depend on it via
`.package(path:)` for local-checkout development.

- `Package.swift` vends the `Mx` library.
- `MX_LOCAL_CHECKOUT` selects the mode:
  - When set, mx is a local sibling checkout and being compiled from local source.
  - Unset is reserved for a future binary release mechanism.
- `swift-local` ci job builds the package in local mode

Also fixes the AppleClang charconv error on `from_chars` / `to_chars`

Base: `musicxml-4.0` (feeds #169).
