### PR TITLE
build: default to swift local build

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -354,13 +354,10 @@ jobs:
     name: macOS (Swift package, local checkout)
     runs-on: macos-latest
 
-    # The local-checkout consumption mode (MX_LOCAL_CHECKOUT) builds `Mx` as a
-    # source library straight from this checkout -- the path komp takes when it
-    # depends on a sibling mx via `.package(path:)`. Building it here proves mx
-    # compiles as a Swift package under AppleClang/SPM on every PR. The binary
-    # xcframework release arm is follow-up work.
-    env:
-      MX_LOCAL_CHECKOUT: "1"
+    # By default mx builds `Mx` as a source library straight from this checkout --
+    # the path komp takes when it depends on a sibling mx via `.package(path:)`.
+    # Building it here proves mx compiles as a Swift package under AppleClang/SPM on
+    # every PR. The binary xcframework release arm (MX_BINARY_RELEASE) is follow-up work.
 
     steps:
       - uses: actions/checkout@v4

--- a/Package.swift
+++ b/Package.swift
@@ -1,20 +1,25 @@
 // swift-tools-version: 5.9
 import PackageDescription
 
-// mx is consumed as a Swift package in one of two modes, selected by the
-// MX_LOCAL_CHECKOUT environment variable. The name mirrors the repo's existing
-// local-vs-Docker build switch (MX_RUNNING_IN_DOCKER) and reads as "consume mx
-// from a local checkout":
+// mx is consumed as a Swift package in one of two modes:
 //
-//   set   -> `Mx` is a source library compiled from this checkout, for
-//            sibling-checkout development (a consumer using `.package(path:)`).
-//   unset -> `Mx` is the published xcframework binary release. That pipeline is
-//            follow-up work and is not wired up yet, so this arm fails loudly
-//            rather than silently resolving to a nonexistent artifact.
-let useLocalCheckout = Context.environment["MX_LOCAL_CHECKOUT"] != nil
+//   default            -> `Mx` is a source library compiled from this checkout,
+//                         for sibling-checkout development (a consumer using
+//                         `.package(path:)`). This is the default, so consumers
+//                         need no environment setup -- just a checkout.
+//   MX_BINARY_RELEASE  -> `Mx` is the published xcframework binary release. That
+//                         pipeline is follow-up work and is not wired up yet, so
+//                         this arm fails loudly rather than silently resolving to
+//                         a nonexistent artifact.
+let useBinaryRelease = Context.environment["MX_BINARY_RELEASE"] != nil
 
 let mxTarget: Target
-if useLocalCheckout {
+if useBinaryRelease {
+    fatalError(
+        "The Mx binary release is not published yet. Build from a source "
+            + "checkout (the default); the binary-release arm is follow-up work."
+    )
+} else {
     // SPM globs every C++ translation unit under `src` (all of which live in
     // `src/private`), minus the Catch2 runner, the test suites, and the example
     // programs -- the only files carrying their own main(). The public surface
@@ -33,12 +38,6 @@ if useLocalCheckout {
         cxxSettings: [
             .headerSearchPath("private"),
         ]
-    )
-} else {
-    fatalError(
-        "The Mx binary release is not published yet. Build with "
-            + "MX_LOCAL_CHECKOUT=1 against a sibling mx checkout; the "
-            + "binary-release arm is follow-up work."
     )
 }
 


### PR DESCRIPTION
Instead of using an annoying environment variable to build a local Swift package, use the environment variable for the future binary release path instead.