### PR TITLE
api: fix notehead value fa up silently missing

### DIFF
--- a/src/private/mx/impl/Converter.cpp
+++ b/src/private/mx/impl/Converter.cpp
@@ -62,6 +62,7 @@ const Converter::EnumMap<core::NoteheadValue, api::Notehead> Converter::notehead
     {core::NoteheadValue::re(), api::Notehead::re},
     {core::NoteheadValue::mi(), api::Notehead::mi},
     {core::NoteheadValue::fa(), api::Notehead::fa},
+    {core::NoteheadValue::faUp(), api::Notehead::faUp},
     {core::NoteheadValue::la(), api::Notehead::la},
     {core::NoteheadValue::so(), api::Notehead::so},
     {core::NoteheadValue::ti(), api::Notehead::ti},

--- a/src/private/mxtest/api/NoteDataTest.cpp
+++ b/src/private/mxtest/api/NoteDataTest.cpp
@@ -1172,4 +1172,48 @@ TEST(notePositionRoundTrip, NoteData)
 
 T_END;
 
+TEST(noteheadFaUpRoundtrip, NoteData)
+{
+    ScoreData score;
+    score.parts.emplace_back();
+    score.ticksPerQuarter = 96;
+    auto &part = score.parts.back();
+    part.measures.emplace_back();
+    auto &measure = part.measures.back();
+    measure.staves.emplace_back();
+    auto &staff = measure.staves.back();
+    auto &voice = staff.voices[0];
+
+    NoteData note;
+    note.durationData.durationName = DurationName::quarter;
+    note.durationData.durationTimeTicks = 96;
+    note.notehead = Notehead::faUp;
+    voice.notes.push_back(note);
+
+    auto &mgr = DocumentManager::getInstance();
+    const auto r1 = mgr.createFromScore(score);
+    REQUIRE(r1.ok());
+    auto docId = r1.value();
+    std::stringstream ss;
+    mgr.writeToStream(docId, ss);
+    mgr.destroyDocument(docId);
+    const std::string xml = ss.str();
+
+    CHECK(xml.find("fa up") != std::string::npos);
+
+    std::istringstream iss{xml};
+    const auto r2 = mgr.createFromStream(iss);
+    REQUIRE(r2.ok());
+    docId = r2.value();
+    const auto rd = mgr.getData(docId);
+    REQUIRE(rd.ok());
+    const auto outScore = rd.value();
+    mgr.destroyDocument(docId);
+
+    const auto &outNote = outScore.parts.back().measures.back().staves.back().voices.at(0).notes.back();
+    CHECK(outNote.notehead == Notehead::faUp);
+}
+
+T_END;
+
 #endif


### PR DESCRIPTION
## Summary

- `noteheadMap` in `Converter.cpp` was missing the `faUp` entry, so any MusicXML note with `<notehead>fa up</notehead>` was silently read back as `Notehead::none` (data loss)
- Add the single missing row: `{core::NoteheadValue::faUp(), api::Notehead::faUp}`
- Add a round-trip test (`noteheadFaUpRoundtrip`) that verifies both the write path (serialized XML contains `"fa up"`) and the read path (notehead survives deserialization as `faUp`)

## Test plan

- [x] `make test` passes (219 test cases, 3917 assertions — all green)
- [x] `make fmt` / `make check` passes (no format diff)
- [x] New test `noteheadFaUpRoundtrip_NoteData` confirmed RED before fix, GREEN after
