### PR TITLE
impl: fix accidental sharp sharp silently missing

### DIFF
--- a/src/private/mx/impl/Converter.cpp
+++ b/src/private/mx/impl/Converter.cpp
@@ -80,6 +80,7 @@ const Converter::EnumMap<core::AccidentalValue, api::Accidental> Converter::acci
     {core::AccidentalValue::natural(), api::Accidental::natural},
     {core::AccidentalValue::flat(), api::Accidental::flat},
     {core::AccidentalValue::doubleSharp(), api::Accidental::doubleSharp},
+    {core::AccidentalValue::sharpSharp(), api::Accidental::sharpSharp},
     {core::AccidentalValue::flatFlat(), api::Accidental::flatFlat},
     {core::AccidentalValue::naturalSharp(), api::Accidental::naturalSharp},
     {core::AccidentalValue::naturalFlat(), api::Accidental::naturalFlat},

--- a/src/private/mxtest/api/PitchDataTest.cpp
+++ b/src/private/mxtest/api/PitchDataTest.cpp
@@ -222,6 +222,29 @@ TEST(AlmostDoubleFlat, PitchData)
 
 T_END;
 
+TEST(SharpSharp, PitchData)
+{
+    // Regression: accidentalMap was missing sharpSharp, so it round-tripped as Accidental::none.
+    auto input = Input{};
+    input.step = Step::c;
+    input.alter = 2;
+    input.cents = 0.0;
+    input.accidental = Accidental::sharpSharp;
+    const std::string expectedAlterString = "2";
+    const int expectedAlter = 2;
+    const double expectedCents = 0.0;
+    const Accidental expectedAccidental = Accidental::sharpSharp;
+    const auto output = pitchDataTest(input);
+
+    CHECK_EQUAL(expectedAlterString, output.alterString);
+    CHECK_EQUAL(expectedAlterString, output.secondAlterString);
+    CHECK_EQUAL(expectedAlter, output.alter);
+    CHECK_DOUBLES_EQUAL(expectedCents, output.cents, MX_API_EQUALITY_EPSILON);
+    CHECK(expectedAccidental == output.accidental);
+}
+
+T_END;
+
 TEST(CrazyEdgeCase1, PitchData)
 {
     auto input = Input{};


### PR DESCRIPTION
## Summary

- `accidentalMap` in `Converter.cpp` was missing the entry for `core::AccidentalValue::sharpSharp()` / `api::Accidental::sharpSharp`.
- A MusicXML file containing `<accidental>sharp-sharp</accidental>` would silently lose the accidental on read (falling back to `Accidental::none`), and write it back as `natural` on round-trip — visible data loss.
- The fix is a single row added to the map, matching the pattern of every other entry.
- A regression test (`SharpSharp_PitchData`) round-trips a note with `Accidental::sharpSharp` through the full serialize→deserialize path and asserts the value is preserved.

## Test plan

- [x] `SharpSharp_PitchData` fails before the fix, passes after
- [x] All PitchData tests pass (`*_PitchData`: 37 assertions in 8 test cases)
- [x] Full test suite passes (3917 assertions in 219 test cases)
- [x] `make check` (fmt-check) passes
