### PR TITLE
pia: fix sound id clarinet piccolo silently missing

### DIFF
--- a/src/include/mx/api/SoundID.h
+++ b/src/include/mx/api/SoundID.h
@@ -797,6 +797,7 @@ enum class SoundID
     windReedClarinetContraAlto,
     windReedClarinetContrabass,
     windReedClarinetEflat,
+    windReedClarinetPiccolo,
     windReedClarinetPiccoloAflat,
     windReedClarinetteDamour,
     windReedContrabass,

--- a/src/private/mx/impl/Converter.cpp
+++ b/src/private/mx/impl/Converter.cpp
@@ -1134,6 +1134,7 @@ const Converter::EnumMap<core::SoundID, api::SoundID> Converter::instrumentMap =
     {core::SoundID::windReedClarinetContraAlto(), api::SoundID::windReedClarinetContraAlto},
     {core::SoundID::windReedClarinetContrabass(), api::SoundID::windReedClarinetContrabass},
     {core::SoundID::windReedClarinetEflat(), api::SoundID::windReedClarinetEflat},
+    {core::SoundID::windReedClarinetPiccolo(), api::SoundID::windReedClarinetPiccolo},
     {core::SoundID::windReedClarinetPiccoloAflat(), api::SoundID::windReedClarinetPiccoloAflat},
     {core::SoundID::windReedClarinetteDamour(), api::SoundID::windReedClarinetteDamour},
     {core::SoundID::windReedContrabass(), api::SoundID::windReedContrabass},

--- a/src/private/mxtest/impl/ConverterSoundIDTest.cpp
+++ b/src/private/mxtest/impl/ConverterSoundIDTest.cpp
@@ -1,0 +1,31 @@
+// MusicXML Class Library
+// Copyright (c) by Matthew James Briggs
+// Distributed under the MIT License
+
+#include "mxtest/control/CompileControl.h"
+#ifdef MX_COMPILE_IMPL_TESTS
+
+#include "cpul/cpulTestHarness.h"
+#include "mx/api/SoundID.h"
+#include "mx/core/generated/SoundID.h"
+#include "mx/impl/Converter.h"
+
+using namespace mx;
+
+TEST(windReedClarinetPiccolo_coreToApi, ConverterSoundID)
+{
+    const impl::Converter converter;
+    const auto result = converter.convert(core::SoundID::windReedClarinetPiccolo());
+    CHECK(api::SoundID::windReedClarinetPiccolo == result);
+}
+
+TEST(windReedClarinetPiccolo_apiToCore, ConverterSoundID)
+{
+    const impl::Converter converter;
+    const auto result = converter.convert(api::SoundID::windReedClarinetPiccolo);
+    CHECK(core::SoundID::windReedClarinetPiccolo() == result);
+}
+
+T_END
+
+#endif


### PR DESCRIPTION
$(cat <<'EOF'
## Summary

- `api::SoundID::windReedClarinetPiccolo` was missing from the enum in `src/include/mx/api/SoundID.h`
- The corresponding row `{core::SoundID::windReedClarinetPiccolo(), api::SoundID::windReedClarinetPiccolo}` was absent from `Converter::instrumentMap` in `Converter.cpp`
- As a result, any MusicXML file carrying `instrument-sound wind.reed.clarinet.piccolo` was silently read back as `api::SoundID::unspecified` (data loss on round-trip)

This is the "one-line table fix" for `windReedClarinetPiccolo` described in `docs/ai/api-feature-audit.md` §1a.

## Changes

- `src/include/mx/api/SoundID.h`: add `windReedClarinetPiccolo` between `windReedClarinetEflat` and `windReedClarinetPiccoloAflat`
- `src/private/mx/impl/Converter.cpp`: add the matching row to `instrumentMap`
- `src/private/mxtest/impl/ConverterSoundIDTest.cpp`: new test file with two cases (core→api and api→core) that were RED before the fix and GREEN after

## Test plan

- [x] `make fmt` passes (clang-format clean)
- [x] `make check` passes
- [x] New tests `windReedClarinetPiccolo_coreToApi_ConverterSoundID` and `windReedClarinetPiccolo_apiToCore_ConverterSoundID` confirmed RED before fix, GREEN after
- [x] Full suite: `./build/api/mxtest` — all 3914 assertions in 220 test cases pass
