### PR TITLE
api: header and layout round-trip: midi-name, defaults fonts, credit gaps, per-measure print

### DIFF
--- a/docs/ai/api-feature-audit.md
+++ b/docs/ai/api-feature-audit.md
@@ -176,7 +176,7 @@ so these boxes are status markers, not clickable; the live checklist is the pare
 | [ ] | notehead `circled` and `other` | 1b(7) | #183 |
 | [ ] | instrument-sound 4.0 sound ids | 1b(8) | #184 |
 | [ ] | technical marks with payloads (`fingering`, `pluck`, `bend`, ...) | 1c | #185 |
-| [ ] | read `<print>` per-measure layout | 2(1) | #186 |
+| [x] | read `<print>` per-measure layout | 2(1) | #186 |
 | [x] | `<credit>` gaps (credit-image, no-words credits, multiple credit-type) | 2(2) | #187 |
 | [ ] | read and write `<sound>` | 2(3) | #188 |
 | [x] | defaults fonts (`word-font`, `lyric-font`, `music-font`) | 2(4) | #189 |

--- a/docs/ai/api-feature-audit.md
+++ b/docs/ai/api-feature-audit.md
@@ -177,7 +177,7 @@ so these boxes are status markers, not clickable; the live checklist is the pare
 | [ ] | instrument-sound 4.0 sound ids | 1b(8) | #184 |
 | [ ] | technical marks with payloads (`fingering`, `pluck`, `bend`, ...) | 1c | #185 |
 | [ ] | read `<print>` per-measure layout | 2(1) | #186 |
-| [ ] | `<credit>` gaps (credit-image, no-words credits, multiple credit-type) | 2(2) | #187 |
+| [x] | `<credit>` gaps (credit-image, no-words credits, multiple credit-type) | 2(2) | #187 |
 | [ ] | read and write `<sound>` | 2(3) | #188 |
 | [x] | defaults fonts (`word-font`, `lyric-font`, `music-font`) | 2(4) | #189 |
 | [ ] | round-trip `<figured-bass>` | 2(5) | #190 |

--- a/docs/ai/api-feature-audit.md
+++ b/docs/ai/api-feature-audit.md
@@ -182,6 +182,6 @@ so these boxes are status markers, not clickable; the live checklist is the pare
 | [ ] | defaults fonts (`word-font`, `lyric-font`, `music-font`) | 2(4) | #189 |
 | [ ] | round-trip `<figured-bass>` | 2(5) | #190 |
 | [ ] | harmony `inversion`, `function`, `numeral` | 2(6) | #191 |
-| [ ] | write `midi-name` on output | 3 | #192 |
+| [x] | write `midi-name` on output | 3 | #192 |
 
 Parent tracker: #159. The section-2 lower-use gaps are intentionally not tracked yet.

--- a/docs/ai/api-feature-audit.md
+++ b/docs/ai/api-feature-audit.md
@@ -179,7 +179,7 @@ so these boxes are status markers, not clickable; the live checklist is the pare
 | [ ] | read `<print>` per-measure layout | 2(1) | #186 |
 | [ ] | `<credit>` gaps (credit-image, no-words credits, multiple credit-type) | 2(2) | #187 |
 | [ ] | read and write `<sound>` | 2(3) | #188 |
-| [ ] | defaults fonts (`word-font`, `lyric-font`, `music-font`) | 2(4) | #189 |
+| [x] | defaults fonts (`word-font`, `lyric-font`, `music-font`) | 2(4) | #189 |
 | [ ] | round-trip `<figured-bass>` | 2(5) | #190 |
 | [ ] | harmony `inversion`, `function`, `numeral` | 2(6) | #191 |
 | [x] | write `midi-name` on output | 3 | #192 |

--- a/src/include/mx/api/DefaultsData.h
+++ b/src/include/mx/api/DefaultsData.h
@@ -6,9 +6,11 @@
 
 #include "mx/api/ApiCommon.h"
 #include "mx/api/AppearanceData.h"
+#include "mx/api/FontData.h"
 #include "mx/api/PageLayoutData.h"
 #include "mx/api/SystemLayoutData.h"
 
+#include <optional>
 #include <string>
 #include <vector>
 
@@ -16,6 +18,23 @@ namespace mx
 {
 namespace api
 {
+/// Corresponds to a `<lyric-font>` default. It is a `FontData` plus the
+/// optional `number` and `name` attributes that identify which lyric
+/// line/verse the font applies to.
+struct LyricFontData
+{
+    std::string number;
+    std::string name;
+    FontData font;
+};
+
+MXAPI_EQUALS_BEGIN(LyricFontData)
+MXAPI_EQUALS_MEMBER(number)
+MXAPI_EQUALS_MEMBER(name)
+MXAPI_EQUALS_MEMBER(font)
+MXAPI_EQUALS_END;
+MXAPI_NOT_EQUALS_AND_VECTORS(LyricFontData);
+
 /// Corresponds to the `<defaults>` element which is part of the
 /// `ScoreHeaderGroup`. Sets the global defaults for the score such as
 /// page size, system spacing, and the all-important `<tenths>` and
@@ -103,6 +122,17 @@ class DefaultsData
 
     std::vector<AppearanceData> appearance;
 
+    /// The `<music-font>` default. Engaged when the score declares a default
+    /// font for musical symbols.
+    std::optional<FontData> musicFont;
+
+    /// The `<word-font>` default. Engaged when the score declares a default
+    /// font for text directions and words.
+    std::optional<FontData> wordFont;
+
+    /// The `<lyric-font>` defaults (one per lyric line/verse).
+    std::vector<LyricFontData> lyricFonts;
+
     // TODO - this appears not to be used anywhere, please do not use
     /// Measure numbering setting, at the global level, will be stated
     /// in first measure's <print> tag. This can can be overridden by a
@@ -110,8 +140,8 @@ class DefaultsData
     MeasureNumbering measureNumbering;
 
     DefaultsData()
-        : scalingMillimeters{-1.0}, scalingTenths{-1.0}, pageLayout{}, systemLayout{}, appearance{},
-          measureNumbering{MeasureNumbering::unspecified}
+        : scalingMillimeters{-1.0}, scalingTenths{-1.0}, pageLayout{}, systemLayout{}, appearance{}, musicFont{},
+          wordFont{}, lyricFonts{}, measureNumbering{MeasureNumbering::unspecified}
     {
     }
 };
@@ -120,6 +150,13 @@ MXAPI_EQUALS_BEGIN(DefaultsData)
 MXAPI_EQUALS_MEMBER(pageLayout)
 MXAPI_EQUALS_MEMBER(systemLayout)
 MXAPI_EQUALS_MEMBER(appearance)
+MXAPI_EQUALS_MEMBER(musicFont)
+MXAPI_EQUALS_MEMBER(wordFont)
+if (!areVectorsEqual(lhs.lyricFonts, rhs.lyricFonts))
+{
+    MX_SHOW_UNEQUAL("DefaultsData", "lyricFonts");
+    return false;
+}
 MXAPI_EQUALS_MEMBER(measureNumbering)
 MXAPI_EQUALS_END;
 MXAPI_NOT_EQUALS_AND_VECTORS(DefaultsData);

--- a/src/include/mx/api/PageImageData.h
+++ b/src/include/mx/api/PageImageData.h
@@ -1,0 +1,62 @@
+// MusicXML Class Library
+// Copyright (c) by Matthew James Briggs
+// Distributed under the MIT License
+
+#pragma once
+
+#include "mx/api/ApiCommon.h"
+#include "mx/api/PositionData.h"
+
+#include <string>
+#include <vector>
+
+namespace mx
+{
+namespace api
+{
+
+// distance values are in 'tenths' governed by the 'scaling' values
+
+/// Corresponds to a `<credit-image>` element. Models a graphical image
+/// placed on a page of the score (e.g. a logo or a scanned title page).
+class PageImageData
+{
+  public:
+    /// The image file location (the required `source` attribute).
+    std::string source;
+
+    /// The MIME type of the image (the required `type` attribute), e.g.
+    /// "image/png".
+    std::string type;
+
+    /// Image height in tenths. Negative means unspecified.
+    double height;
+
+    /// Image width in tenths. Negative means unspecified.
+    double width;
+
+    /// The page this credit-image appears on (the credit's `page`
+    /// attribute). Values <= 0 mean unspecified.
+    int pageNumber;
+
+    /// default-x/default-y/relative-x/relative-y and horizontal alignment.
+    /// (Vertical alignment uses a credit-image specific type and is not
+    /// modeled here.)
+    PositionData positionData;
+
+    PageImageData() : source{}, type{}, height{-1.0}, width{-1.0}, pageNumber{0}, positionData{}
+    {
+    }
+};
+
+MXAPI_EQUALS_BEGIN(PageImageData)
+MXAPI_EQUALS_MEMBER(source)
+MXAPI_EQUALS_MEMBER(type)
+MXAPI_EQUALS_MEMBER(height)
+MXAPI_EQUALS_MEMBER(width)
+MXAPI_EQUALS_MEMBER(pageNumber)
+MXAPI_EQUALS_MEMBER(positionData)
+MXAPI_EQUALS_END;
+MXAPI_NOT_EQUALS_AND_VECTORS(PageImageData);
+} // namespace api
+} // namespace mx

--- a/src/include/mx/api/PageTextData.h
+++ b/src/include/mx/api/PageTextData.h
@@ -27,6 +27,13 @@ class PageTextData
     FontData fontData;
     std::string description; // e.g. 'composer', 'page number', 'title', etc., this is metadata which does not appear on
                              // the printed page
+
+    // All `<credit-type>` values for this credit, in document order. A
+    // `<credit>` may carry more than one credit-type; `description` mirrors
+    // the first for source compatibility. When `text` is empty and
+    // `creditTypes` is non-empty, this represents a metadata-only credit
+    // (a `<credit>` with no `<credit-words>`).
+    std::vector<std::string> creditTypes;
 };
 
 MXAPI_EQUALS_BEGIN(PageTextData)
@@ -35,6 +42,11 @@ MXAPI_EQUALS_MEMBER(pageNumber)
 MXAPI_EQUALS_MEMBER(positionData)
 MXAPI_EQUALS_MEMBER(fontData)
 MXAPI_EQUALS_MEMBER(description)
+if (!areVectorsEqual(lhs.creditTypes, rhs.creditTypes))
+{
+    MX_SHOW_UNEQUAL("PageTextData", "creditTypes");
+    return false;
+}
 MXAPI_EQUALS_END;
 MXAPI_NOT_EQUALS_AND_VECTORS(PageTextData);
 } // namespace api

--- a/src/include/mx/api/ScoreData.h
+++ b/src/include/mx/api/ScoreData.h
@@ -9,6 +9,7 @@
 #include "mx/api/EncodingData.h"
 #include "mx/api/LayoutData.h"
 #include "mx/api/PageData.h"
+#include "mx/api/PageImageData.h"
 #include "mx/api/PageTextData.h"
 #include "mx/api/PartData.h"
 #include "mx/api/PartGroupData.h"
@@ -53,6 +54,10 @@ class ScoreData
     EncodingData encoding;
     std::vector<PageTextData> pageTextItems;
 
+    /// `<credit-image>` items. Each corresponds to a `<credit>` whose
+    /// content is an image rather than text.
+    std::vector<PageImageData> pageImageItems;
+
     /// Specifies the scaling factor (`tenths` and `millimeters`), the default page sizes and margins, and the
     /// default system spacing and margins. Corresponds to the `<defaults>` MusicXML element. (Note this field
     /// used to be named `layout` and was renamed to `defaults` in v0.5.0.)
@@ -93,6 +98,7 @@ MXAPI_EQUALS_MEMBER(publisher)
 MXAPI_EQUALS_MEMBER(copyright)
 MXAPI_EQUALS_MEMBER(encoding)
 MXAPI_EQUALS_MEMBER(pageTextItems)
+MXAPI_EQUALS_MEMBER(pageImageItems)
 MXAPI_EQUALS_MEMBER(defaults)
 MXAPI_EQUALS_MEMBER(parts)
 MXAPI_EQUALS_MEMBER(partGroups)

--- a/src/private/mx/impl/LayoutFunctions.cpp
+++ b/src/private/mx/impl/LayoutFunctions.cpp
@@ -5,15 +5,18 @@
 #include "mx/impl/LayoutFunctions.h"
 #include "mx/api/ScoreData.h"
 #include "mx/core/Decimal.h"
+#include "mx/core/NameToken.h"
 #include "mx/core/generated/AllMarginsGroup.h"
 #include "mx/core/generated/Appearance.h"
 #include "mx/core/generated/Defaults.h"
 #include "mx/core/generated/Distance.h"
 #include "mx/core/generated/DistanceType.h"
+#include "mx/core/generated/EmptyFont.h"
 #include "mx/core/generated/LayoutGroup.h"
 #include "mx/core/generated/LeftRightMarginsGroup.h"
 #include "mx/core/generated/LineWidth.h"
 #include "mx/core/generated/LineWidthType.h"
+#include "mx/core/generated/LyricFont.h"
 #include "mx/core/generated/Millimeters.h"
 #include "mx/core/generated/NoteSize.h"
 #include "mx/core/generated/NoteSizeType.h"
@@ -26,6 +29,7 @@
 #include "mx/core/generated/SystemLayout.h"
 #include "mx/core/generated/SystemMargins.h"
 #include "mx/core/generated/Tenths.h"
+#include "mx/impl/FontFunctions.h"
 
 namespace mx
 {
@@ -107,6 +111,53 @@ void addDefaultsData(const api::DefaultsData &inDefaults, core::ScoreHeaderGroup
     addPageLayout(inDefaults.pageLayout, outScoreHeaderGroup);
     addSystemMargins(inDefaults, outScoreHeaderGroup);
     addAppearance(inDefaults, outScoreHeaderGroup);
+    addDefaultsFonts(inDefaults, outScoreHeaderGroup);
+}
+
+void addDefaultsFonts(const api::DefaultsData &inDefaults, core::ScoreHeaderGroup &outScoreHeaderGroup)
+{
+    if (!inDefaults.musicFont.has_value() && !inDefaults.wordFont.has_value() && inDefaults.lyricFonts.empty())
+    {
+        return;
+    }
+
+    auto defaults = outScoreHeaderGroup.defaults().value_or(core::Defaults{});
+
+    if (inDefaults.musicFont.has_value())
+    {
+        core::EmptyFont musicFont{};
+        setAttributesFromFontData(*inDefaults.musicFont, musicFont);
+        defaults.setMusicFont(musicFont);
+    }
+
+    if (inDefaults.wordFont.has_value())
+    {
+        core::EmptyFont wordFont{};
+        setAttributesFromFontData(*inDefaults.wordFont, wordFont);
+        defaults.setWordFont(wordFont);
+    }
+
+    if (!inDefaults.lyricFonts.empty())
+    {
+        std::vector<core::LyricFont> lyricFonts;
+        for (const auto &lf : inDefaults.lyricFonts)
+        {
+            core::LyricFont coreLyricFont{};
+            if (!lf.number.empty())
+            {
+                coreLyricFont.setNumber(core::NameToken{lf.number});
+            }
+            if (!lf.name.empty())
+            {
+                coreLyricFont.setName(lf.name);
+            }
+            setAttributesFromFontData(lf.font, coreLyricFont);
+            lyricFonts.emplace_back(std::move(coreLyricFont));
+        }
+        defaults.setLyricFont(std::move(lyricFonts));
+    }
+
+    outScoreHeaderGroup.setDefaults(defaults);
 }
 
 void addScaling(const api::DefaultsData &inDefaults, core::ScoreHeaderGroup &outScoreHeaderGroup)
@@ -246,7 +297,47 @@ api::DefaultsData createDefaults(const core::ScoreHeaderGroup &inScoreHeaderGrou
     addSystemMargins(inScoreHeaderGroup, defaults);
     addStaffLayout(inScoreHeaderGroup, defaults);
     addAppearance(inScoreHeaderGroup, defaults);
+    addDefaultsFonts(inScoreHeaderGroup, defaults);
     return defaults;
+}
+
+void addDefaultsFonts(const core::ScoreHeaderGroup &inScoreHeaderGroup, api::DefaultsData &outDefaults)
+{
+    outDefaults.musicFont = std::nullopt;
+    outDefaults.wordFont = std::nullopt;
+    outDefaults.lyricFonts.clear();
+
+    if (!inScoreHeaderGroup.defaults().has_value())
+    {
+        return;
+    }
+
+    const auto &defaults = *inScoreHeaderGroup.defaults();
+
+    if (defaults.musicFont().has_value())
+    {
+        outDefaults.musicFont = getFontData(*defaults.musicFont());
+    }
+
+    if (defaults.wordFont().has_value())
+    {
+        outDefaults.wordFont = getFontData(*defaults.wordFont());
+    }
+
+    for (const auto &lf : defaults.lyricFont())
+    {
+        api::LyricFontData data{};
+        if (lf.number().has_value())
+        {
+            data.number = lf.number()->value();
+        }
+        if (lf.name().has_value())
+        {
+            data.name = *lf.name();
+        }
+        data.font = getFontData(lf);
+        outDefaults.lyricFonts.emplace_back(std::move(data));
+    }
 }
 
 void addScaling(const core::ScoreHeaderGroup &inScoreHeaderGroup, api::DefaultsData &outDefaults)

--- a/src/private/mx/impl/LayoutFunctions.h
+++ b/src/private/mx/impl/LayoutFunctions.h
@@ -18,6 +18,7 @@ void addScaling(const api::DefaultsData &inDefaults, core::ScoreHeaderGroup &out
 void addPageLayout(const api::PageLayoutData &inPageLayout, core::ScoreHeaderGroup &outScoreHeaderGroup);
 void addSystemMargins(const api::DefaultsData &inDefaults, core::ScoreHeaderGroup &outScoreHeaderGroup);
 void addAppearance(const api::DefaultsData &inDefaults, core::ScoreHeaderGroup &outScoreHeaderGroup);
+void addDefaultsFonts(const api::DefaultsData &inDefaults, core::ScoreHeaderGroup &outScoreHeaderGroup);
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 // core::ScoreHeaderGroup -> api::DefaultsData
@@ -27,5 +28,6 @@ void addPageMargins(const core::ScoreHeaderGroup &inScoreHeaderGroup, api::Defau
 void addSystemMargins(const core::ScoreHeaderGroup &inScoreHeaderGroup, api::DefaultsData &outDefaults);
 void addStaffLayout(const core::ScoreHeaderGroup &inScoreHeaderGroup, api::DefaultsData &outDefaults);
 void addAppearance(const core::ScoreHeaderGroup &inScoreHeaderGroup, api::DefaultsData &outDefaults);
+void addDefaultsFonts(const core::ScoreHeaderGroup &inScoreHeaderGroup, api::DefaultsData &outDefaults);
 } // namespace impl
 } // namespace mx

--- a/src/private/mx/impl/MeasureReader.cpp
+++ b/src/private/mx/impl/MeasureReader.cpp
@@ -611,8 +611,13 @@ void MeasureReader::parseFiguredBass(const core::FiguredBass &inMxFiguredBass, c
 
 void MeasureReader::parsePrint(const core::Print &inMxPrint) const
 {
+    // Per-measure <print> layout is read at the score level, keyed by
+    // measure index, in ScoreReader::scanForSystemInfo and
+    // ScoreReader::scanForPageInfo (which capture new-system, new-page,
+    // page-number, system-layout, staff-layout, and page-layout). The
+    // per-measure music-data hook has no api home of its own, so nothing
+    // is captured here.
     MX_UNUSED(inMxPrint);
-    // std::cout << "print is not supported" << std::endl;
 }
 
 void MeasureReader::parseSound(const core::Sound &inMxSound) const

--- a/src/private/mx/impl/MeasureWriter.cpp
+++ b/src/private/mx/impl/MeasureWriter.cpp
@@ -24,6 +24,7 @@
 #include "mx/core/generated/Print.h"
 #include "mx/core/generated/Repeat.h"
 #include "mx/core/generated/RightLeftMiddle.h"
+#include "mx/core/generated/StaffLayout.h"
 #include "mx/core/generated/SystemLayout.h"
 #include "mx/core/generated/SystemMargins.h"
 #include "mx/core/generated/Tenths.h"
@@ -226,6 +227,15 @@ void MeasureWriter::writeSystemInfo()
         if (needsSystemLayout)
         {
             outLayoutGroup.setSystemLayout(outSystemLayout);
+            outPrint.setLayout(outLayoutGroup);
+        }
+
+        if (inSystemLayout.staffDistance)
+        {
+            core::StaffLayout outStaffLayout{};
+            outStaffLayout.setStaffDistance(
+                core::Tenths{core::Decimal{static_cast<double>(inSystemLayout.staffDistance.value())}});
+            outLayoutGroup.addStaffLayout(outStaffLayout);
             outPrint.setLayout(outLayoutGroup);
         }
     }

--- a/src/private/mx/impl/PageTextFunctions.cpp
+++ b/src/private/mx/impl/PageTextFunctions.cpp
@@ -3,12 +3,16 @@
 // Distributed under the MIT License
 
 #include "mx/impl/PageTextFunctions.h"
+#include "mx/api/ScoreData.h"
+#include "mx/core/Decimal.h"
 #include "mx/core/generated/Credit.h"
 #include "mx/core/generated/CreditChoice.h"
 #include "mx/core/generated/CreditChoiceGroup.h"
 #include "mx/core/generated/CreditChoiceGroupChoice.h"
 #include "mx/core/generated/FormattedTextID.h"
+#include "mx/core/generated/Image.h"
 #include "mx/core/generated/ScoreHeaderGroup.h"
+#include "mx/core/generated/Tenths.h"
 #include "mx/impl/FontFunctions.h"
 #include "mx/impl/PositionFunctions.h"
 
@@ -16,23 +20,86 @@ namespace mx
 {
 namespace impl
 {
-void createPageTextItems(const std::vector<api::PageTextData> &inPageTextItems, core::ScoreHeaderGroup &outHeader)
+namespace
 {
-    for (const auto &p : inPageTextItems)
+api::PageImageData getImageData(const core::Image &image, int pageNumber)
+{
+    api::PageImageData out{};
+    out.source = image.source();
+    out.type = image.type();
+    out.pageNumber = pageNumber;
+
+    if (image.height().has_value())
     {
-        core::FormattedTextID words;
-        words.setValue(p.text);
-        impl::setAttributesFromFontData(p.fontData, words);
-        impl::setAttributesFromPositionData(p.positionData, words);
+        out.height = image.height()->value().value();
+    }
 
-        core::CreditChoiceGroupChoice groupChoice = core::CreditChoiceGroupChoice::creditWords(words);
-        core::CreditChoiceGroup group;
-        group.setChoice(groupChoice);
+    if (image.width().has_value())
+    {
+        out.width = image.width()->value().value();
+    }
 
+    out.positionData = getPositionData(image);
+    // The <credit-image> valign uses the credit-image-specific
+    // ValignImage vocabulary, which PositionData does not model. Avoid
+    // recording a misleading vertical-alignment value.
+    out.positionData.verticalAlignment = api::VerticalAlignment::unspecified;
+    return out;
+}
+
+core::Image makeCoreImage(const api::PageImageData &in)
+{
+    core::Image image{};
+    image.setSource(in.source);
+    image.setType(in.type);
+
+    if (in.height >= 0.0)
+    {
+        image.setHeight(core::Tenths{core::Decimal{in.height}});
+    }
+
+    if (in.width >= 0.0)
+    {
+        image.setWidth(core::Tenths{core::Decimal{in.width}});
+    }
+
+    setAttributesFromPositionData(in.positionData, image);
+    return image;
+}
+} // namespace
+
+void createCredits(const api::ScoreData &inScoreData, core::ScoreHeaderGroup &outHeader)
+{
+    for (const auto &p : inScoreData.pageTextItems)
+    {
         core::Credit credit;
-        credit.setChoice(core::CreditChoice::group(group));
 
-        if (!p.description.empty())
+        // The <credit> content model requires a credit-words/credit-symbol
+        // (or credit-image). Always emit a <credit-words> here; an empty
+        // string preserves a metadata-only credit (one that carried only
+        // credit-type) without dropping it.
+        {
+            core::FormattedTextID words;
+            words.setValue(p.text);
+            impl::setAttributesFromFontData(p.fontData, words);
+            impl::setAttributesFromPositionData(p.positionData, words);
+
+            core::CreditChoiceGroupChoice groupChoice = core::CreditChoiceGroupChoice::creditWords(words);
+            core::CreditChoiceGroup group;
+            group.setChoice(groupChoice);
+            credit.setChoice(core::CreditChoice::group(group));
+        }
+
+        // Emit every credit-type. Prefer the full list; fall back to the
+        // legacy single `description` for callers that only set that.
+        if (!p.creditTypes.empty())
+        {
+            for (const auto &ct : p.creditTypes)
+            {
+                credit.addCreditType(ct);
+            }
+        }
+        else if (!p.description.empty())
         {
             credit.addCreditType(p.description);
         }
@@ -44,41 +111,59 @@ void createPageTextItems(const std::vector<api::PageTextData> &inPageTextItems, 
 
         outHeader.addCredit(credit);
     }
+
+    for (const auto &img : inScoreData.pageImageItems)
+    {
+        core::Credit credit;
+        credit.setChoice(core::CreditChoice::creditImage(makeCoreImage(img)));
+
+        if (img.pageNumber > 0)
+        {
+            credit.setPage(img.pageNumber);
+        }
+
+        outHeader.addCredit(credit);
+    }
 }
 
-void createPageTextItems(const core::ScoreHeaderGroup &inHeader, std::vector<api::PageTextData> &outPageTextItems)
+void createCredits(const core::ScoreHeaderGroup &inHeader, api::ScoreData &outScoreData)
 {
     for (const auto &c : inHeader.credit())
     {
-        if (!c.choice().isGroup())
+        const int pageNumber = c.page().has_value() ? *c.page() : 0;
+
+        if (c.choice().isCreditImage())
         {
+            outScoreData.pageImageItems.push_back(getImageData(c.choice().asCreditImage(), pageNumber));
             continue;
         }
+
+        // Otherwise this is a credit group. Capture its text (if it begins
+        // with <credit-words>) and its credit-type(s). A credit with no
+        // <credit-words> still survives as a metadata-only PageTextData.
+        api::PageTextData pageText{};
+        pageText.pageNumber = pageNumber;
 
         const auto &group = c.choice().asGroup();
-        if (!group.choice().isCreditWords())
+        if (group.choice().isCreditWords())
         {
-            continue;
+            const auto &words = group.choice().asCreditWords();
+            pageText.text = words.value();
+            pageText.positionData = impl::getPositionData(words);
+            pageText.fontData = impl::getFontData(words);
         }
 
-        api::PageTextData pageText{};
-
-        if (c.page().has_value())
+        for (const auto &ct : c.creditType())
         {
-            pageText.pageNumber = *c.page();
+            pageText.creditTypes.emplace_back(ct);
         }
 
-        const auto &words = group.choice().asCreditWords();
-        pageText.text = words.value();
-        pageText.positionData = impl::getPositionData(words);
-        pageText.fontData = impl::getFontData(words);
-
-        if (!c.creditType().empty())
+        if (!pageText.creditTypes.empty())
         {
-            pageText.description = c.creditType().front();
+            pageText.description = pageText.creditTypes.front();
         }
 
-        outPageTextItems.push_back(pageText);
+        outScoreData.pageTextItems.push_back(std::move(pageText));
     }
 }
 } // namespace impl

--- a/src/private/mx/impl/PageTextFunctions.h
+++ b/src/private/mx/impl/PageTextFunctions.h
@@ -8,6 +8,11 @@
 
 namespace mx
 {
+namespace api
+{
+class ScoreData;
+}
+
 namespace core
 {
 class ScoreHeaderGroup;
@@ -15,7 +20,13 @@ class ScoreHeaderGroup;
 
 namespace impl
 {
-void createPageTextItems(const std::vector<api::PageTextData> &inPageTextItems, core::ScoreHeaderGroup &outHeader);
-void createPageTextItems(const core::ScoreHeaderGroup &inHeader, std::vector<api::PageTextData> &outPageTextItems);
+// Reads all `<credit>` elements from the header into the score's
+// pageTextItems (credit-words / no-words credits) and pageImageItems
+// (credit-image).
+void createCredits(const core::ScoreHeaderGroup &inHeader, api::ScoreData &outScoreData);
+
+// Writes the score's pageTextItems and pageImageItems back out as
+// `<credit>` elements on the header.
+void createCredits(const api::ScoreData &inScoreData, core::ScoreHeaderGroup &outHeader);
 } // namespace impl
 } // namespace mx

--- a/src/private/mx/impl/PartWriter.cpp
+++ b/src/private/mx/impl/PartWriter.cpp
@@ -165,6 +165,12 @@ core::ScorePart PartWriter::getScorePart() const
         midiGroup.setMIDIDevice(midiDevice);
     }
 
+    if (myPartData.instrumentData.midiData.name.size() > 0)
+    {
+        addMidiElement = true;
+        midiInstrument.setMIDIName(myPartData.instrumentData.midiData.name);
+    }
+
     if (myPartData.instrumentData.midiData.bank >= 0)
     {
         addMidiElement = true;

--- a/src/private/mx/impl/ScoreReader.cpp
+++ b/src/private/mx/impl/ScoreReader.cpp
@@ -249,7 +249,7 @@ api::ScoreData ScoreReader::getScoreData() const
         myOutScoreData.defaults = createDefaults(myHeaderGroup);
     }
 
-    createPageTextItems(myHeaderGroup, myOutScoreData.pageTextItems);
+    createCredits(myHeaderGroup, myOutScoreData);
 
     auto partMap = reconcileParts(myScorePartwise);
     int divisionsValue = -1;

--- a/src/private/mx/impl/ScoreReader.cpp
+++ b/src/private/mx/impl/ScoreReader.cpp
@@ -23,6 +23,7 @@
 #include "mx/core/generated/ScoreHeaderGroup.h"
 #include "mx/core/generated/ScorePart.h"
 #include "mx/core/generated/ScorePartwise.h"
+#include "mx/core/generated/StaffLayout.h"
 #include "mx/core/generated/SystemLayout.h"
 #include "mx/core/generated/SystemMargins.h"
 #include "mx/core/generated/TypedText.h"
@@ -440,6 +441,19 @@ void ScoreReader::scanForSystemInfo() const
                     systemData.layout.topSystemDistance = systemLayout.topSystemDistance()->value().value();
                 }
             }
+
+            // Per-measure <staff-layout> staff-distance. (We model a single
+            // staff-distance, matching how the defaults staff-layout is
+            // mapped; the first staff-layout's distance is used.)
+            for (const auto &staffLayout : layoutGroup.staffLayout())
+            {
+                if (staffLayout.staffDistance().has_value())
+                {
+                    systemData.layout.staffDistance = staffLayout.staffDistance()->value().value();
+                    break;
+                }
+            }
+
             if (systemData.isUsed())
             {
                 auto &layout = myOutScoreData.layout[measureIndex];

--- a/src/private/mx/impl/ScoreWriter.cpp
+++ b/src/private/mx/impl/ScoreWriter.cpp
@@ -120,7 +120,7 @@ core::ScorePartwise ScoreWriter::getScorePartwise() const
 
     createEncoding(myScoreData.encoding, header);
     addDefaultsData(myScoreData.defaults, header);
-    createPageTextItems(myScoreData.pageTextItems, header);
+    createCredits(myScoreData, header);
 
     using PartPair = std::pair<core::ScorePart, core::PartwisePart>;
     using PartPairs = std::vector<PartPair>;

--- a/src/private/mxtest/api/CreditRoundTripTest.cpp
+++ b/src/private/mxtest/api/CreditRoundTripTest.cpp
@@ -1,0 +1,114 @@
+// MusicXML Class Library
+// Copyright (c) by Matthew James Briggs
+// Distributed under the MIT License
+
+#include "mxtest/control/CompileControl.h"
+#ifdef MX_COMPILE_API_TESTS
+
+#include "cpul/cpulTestHarness.h"
+#include "mx/api/DocumentManager.h"
+#include "mxtest/api/RoundTrip.h"
+
+using namespace std;
+using namespace mx::api;
+
+namespace
+{
+ScoreData makeMinimalScore()
+{
+    VoiceData voiceData;
+    NoteData n;
+    n.tickTimePosition = 0;
+    n.pitchData.step = Step::c;
+    n.pitchData.octave = 5;
+    n.durationData.durationName = DurationName::quarter;
+    n.durationData.durationTimeTicks = DEFAULT_TICKS_PER_QUARTER;
+    voiceData.notes.push_back(n);
+    StaffData staff{};
+    staff.voices.emplace(0, voiceData);
+    MeasureData m;
+    m.staves.push_back(staff);
+
+    PartData pd;
+    pd.uniqueId = "P1";
+    pd.name = "Flute";
+    pd.displayName = "Flute";
+    pd.measures.push_back(m);
+
+    ScoreData s;
+    s.parts.push_back(pd);
+    return s;
+}
+} // namespace
+
+TEST(creditRoundTrip, multipleCreditTypes)
+{
+    auto in = makeMinimalScore();
+    PageTextData credit{};
+    credit.text = "Symphony No. 1";
+    credit.pageNumber = 1;
+    credit.creditTypes = {"title", "subtitle"};
+    in.pageTextItems.push_back(credit);
+
+    const auto out = mxtest::roundTrip(in);
+
+    REQUIRE(out.pageTextItems.size() == 1);
+    const auto &got = out.pageTextItems.at(0);
+    CHECK_EQUAL("Symphony No. 1", got.text);
+    REQUIRE(got.creditTypes.size() == 2);
+    CHECK_EQUAL("title", got.creditTypes.at(0));
+    CHECK_EQUAL("subtitle", got.creditTypes.at(1));
+    // legacy description mirrors the first credit-type
+    CHECK_EQUAL("title", got.description);
+}
+
+TEST(creditRoundTrip, noWordsCreditSurvives)
+{
+    auto in = makeMinimalScore();
+    PageTextData credit{};
+    credit.text = ""; // metadata-only credit: no <credit-words>
+    credit.pageNumber = 2;
+    credit.creditTypes = {"page number"};
+    in.pageTextItems.push_back(credit);
+
+    const auto out = mxtest::roundTrip(in);
+
+    REQUIRE(out.pageTextItems.size() == 1);
+    const auto &got = out.pageTextItems.at(0);
+    CHECK(got.text.empty());
+    CHECK_EQUAL(2, got.pageNumber);
+    REQUIRE(got.creditTypes.size() == 1);
+    CHECK_EQUAL("page number", got.creditTypes.at(0));
+}
+
+TEST(creditRoundTrip, creditImage)
+{
+    auto in = makeMinimalScore();
+    PageImageData img{};
+    img.source = "logo.png";
+    img.type = "image/png";
+    img.width = 200.0;
+    img.height = 100.0;
+    img.pageNumber = 1;
+    img.positionData.isDefaultXSpecified = true;
+    img.positionData.defaultX = 50.0;
+    img.positionData.isDefaultYSpecified = true;
+    img.positionData.defaultY = 60.0;
+    in.pageImageItems.push_back(img);
+
+    const auto out = mxtest::roundTrip(in);
+
+    REQUIRE(out.pageImageItems.size() == 1);
+    const auto &got = out.pageImageItems.at(0);
+    CHECK_EQUAL("logo.png", got.source);
+    CHECK_EQUAL("image/png", got.type);
+    CHECK_EQUAL(200.0, got.width);
+    CHECK_EQUAL(100.0, got.height);
+    CHECK_EQUAL(1, got.pageNumber);
+    CHECK(got.positionData.isDefaultXSpecified);
+    CHECK_EQUAL(50.0, got.positionData.defaultX);
+    CHECK(got.positionData.isDefaultYSpecified);
+    CHECK_EQUAL(60.0, got.positionData.defaultY);
+}
+
+#endif

--- a/src/private/mxtest/api/DefaultsFontsRoundTripTest.cpp
+++ b/src/private/mxtest/api/DefaultsFontsRoundTripTest.cpp
@@ -1,0 +1,100 @@
+// MusicXML Class Library
+// Copyright (c) by Matthew James Briggs
+// Distributed under the MIT License
+
+#include "mxtest/control/CompileControl.h"
+#ifdef MX_COMPILE_API_TESTS
+
+#include "cpul/cpulTestHarness.h"
+#include "mx/api/DocumentManager.h"
+#include "mxtest/api/RoundTrip.h"
+
+using namespace std;
+using namespace mx::api;
+
+namespace
+{
+ScoreData makeMinimalScore()
+{
+    VoiceData voiceData;
+    NoteData n;
+    n.tickTimePosition = 0;
+    n.pitchData.step = Step::c;
+    n.pitchData.octave = 5;
+    n.durationData.durationName = DurationName::quarter;
+    n.durationData.durationTimeTicks = DEFAULT_TICKS_PER_QUARTER;
+    voiceData.notes.push_back(n);
+    StaffData staff{};
+    staff.voices.emplace(0, voiceData);
+    MeasureData m;
+    m.staves.push_back(staff);
+
+    PartData pd;
+    pd.uniqueId = "P1";
+    pd.name = "Flute";
+    pd.displayName = "Flute";
+    pd.measures.push_back(m);
+
+    ScoreData s;
+    // a scaling is required for the <defaults> element to be emitted
+    s.defaults.scalingMillimeters = 7.0;
+    s.defaults.scalingTenths = 40.0;
+    s.parts.push_back(pd);
+    return s;
+}
+} // namespace
+
+TEST(defaultsFontsRoundTrip, wordAndMusicFont)
+{
+    auto in = makeMinimalScore();
+
+    FontData wordFont{};
+    wordFont.fontFamily = {"Times New Roman"};
+    wordFont.sizeType = FontSizeType::point;
+    wordFont.sizePoint = 10.5;
+    wordFont.style = FontStyle::italic;
+    wordFont.weight = FontWeight::bold;
+    in.defaults.wordFont = wordFont;
+
+    FontData musicFont{};
+    musicFont.fontFamily = {"Maestro"};
+    musicFont.sizeType = FontSizeType::point;
+    musicFont.sizePoint = 20.0;
+    in.defaults.musicFont = musicFont;
+
+    const auto out = mxtest::roundTrip(in);
+
+    REQUIRE(out.defaults.wordFont.has_value());
+    CHECK(wordFont == out.defaults.wordFont.value());
+
+    REQUIRE(out.defaults.musicFont.has_value());
+    CHECK(musicFont == out.defaults.musicFont.value());
+}
+
+TEST(defaultsFontsRoundTrip, lyricFonts)
+{
+    auto in = makeMinimalScore();
+
+    LyricFontData lf1{};
+    lf1.number = "1";
+    lf1.name = "verse";
+    lf1.font.fontFamily = {"Arial"};
+    lf1.font.sizeType = FontSizeType::point;
+    lf1.font.sizePoint = 8.0;
+    in.defaults.lyricFonts.push_back(lf1);
+
+    LyricFontData lf2{};
+    lf2.number = "2";
+    lf2.font.fontFamily = {"Courier"};
+    lf2.font.sizeType = FontSizeType::point;
+    lf2.font.sizePoint = 9.0;
+    in.defaults.lyricFonts.push_back(lf2);
+
+    const auto out = mxtest::roundTrip(in);
+
+    REQUIRE(out.defaults.lyricFonts.size() == 2);
+    CHECK(lf1 == out.defaults.lyricFonts.at(0));
+    CHECK(lf2 == out.defaults.lyricFonts.at(1));
+}
+
+#endif

--- a/src/private/mxtest/api/MidiNameRoundTripTest.cpp
+++ b/src/private/mxtest/api/MidiNameRoundTripTest.cpp
@@ -1,0 +1,56 @@
+// MusicXML Class Library
+// Copyright (c) by Matthew James Briggs
+// Distributed under the MIT License
+
+#include "mxtest/control/CompileControl.h"
+#ifdef MX_COMPILE_API_TESTS
+
+#include "cpul/cpulTestHarness.h"
+#include "mx/api/DocumentManager.h"
+#include "mxtest/api/RoundTrip.h"
+
+using namespace std;
+using namespace mx::api;
+
+namespace
+{
+ScoreData makeScoreWithMidiName(const std::string &midiName)
+{
+    VoiceData voiceData;
+    NoteData n;
+    n.tickTimePosition = 0;
+    n.pitchData.step = Step::c;
+    n.pitchData.octave = 5;
+    n.durationData.durationName = DurationName::quarter;
+    n.durationData.durationTimeTicks = DEFAULT_TICKS_PER_QUARTER;
+    voiceData.notes.push_back(n);
+    StaffData staff{};
+    staff.voices.emplace(0, voiceData);
+    MeasureData m;
+    m.staves.push_back(staff);
+
+    PartData pd;
+    pd.uniqueId = "P1";
+    pd.name = "Flute";
+    pd.displayName = "Flute";
+    pd.instrumentData.uniqueId = "P1-I1";
+    pd.instrumentData.midiData.name = midiName;
+    pd.instrumentData.midiData.channel = 1;
+    pd.measures.push_back(m);
+
+    ScoreData s;
+    s.parts.push_back(pd);
+    return s;
+}
+} // namespace
+
+TEST(midiNameRoundTrip, survivesWriteAndRead)
+{
+    const std::string expected = "Flute Player One";
+    const auto in = makeScoreWithMidiName(expected);
+    const auto out = mxtest::roundTrip(in);
+    REQUIRE(out.parts.size() == 1);
+    CHECK_EQUAL(expected, out.parts.at(0).instrumentData.midiData.name);
+}
+
+#endif

--- a/src/private/mxtest/api/PrintLayoutRoundTripTest.cpp
+++ b/src/private/mxtest/api/PrintLayoutRoundTripTest.cpp
@@ -1,0 +1,74 @@
+// MusicXML Class Library
+// Copyright (c) by Matthew James Briggs
+// Distributed under the MIT License
+
+#include "mxtest/control/CompileControl.h"
+#ifdef MX_COMPILE_API_TESTS
+
+#include "cpul/cpulTestHarness.h"
+#include "mx/api/DocumentManager.h"
+#include "mxtest/api/RoundTrip.h"
+
+using namespace std;
+using namespace mx::api;
+
+namespace
+{
+ScoreData makeScoreWithMeasures(int numMeasures)
+{
+    std::vector<MeasureData> measures;
+    for (int i = 0; i < numMeasures; ++i)
+    {
+        VoiceData voiceData;
+        NoteData n;
+        n.tickTimePosition = 0;
+        n.pitchData.step = Step::c;
+        n.pitchData.octave = 5;
+        n.durationData.durationName = DurationName::whole;
+        n.durationData.durationTimeTicks = 4 * DEFAULT_TICKS_PER_QUARTER;
+        voiceData.notes.push_back(n);
+        StaffData staff{};
+        staff.voices.emplace(0, voiceData);
+        MeasureData m;
+        m.staves.push_back(staff);
+        measures.push_back(m);
+    }
+
+    PartData pd;
+    pd.uniqueId = "P1";
+    pd.name = "Flute";
+    pd.displayName = "Flute";
+    pd.measures = measures;
+
+    ScoreData s;
+    s.parts.push_back(pd);
+    return s;
+}
+} // namespace
+
+// Per-measure <print> <staff-layout> staff-distance was written by
+// MeasureWriter but never read back (parsePrint was a no-op and the
+// score-level scan ignored staff-layout). Verify it now survives.
+TEST(printLayoutRoundTrip, perMeasureStaffDistance)
+{
+    auto in = makeScoreWithMeasures(4);
+
+    SystemData sys{};
+    sys.newSystem = Bool::yes;
+    sys.layout.staffDistance = 87.5;
+    sys.layout.systemDistance = 120.0;
+    in.layout.emplace(2, LayoutData{sys, PageData{}});
+
+    const auto out = mxtest::roundTrip(in);
+
+    const auto it = out.layout.find(2);
+    REQUIRE(it != out.layout.end());
+    const auto &sysOut = it->second.system;
+    CHECK(Bool::yes == sysOut.newSystem);
+    REQUIRE(static_cast<bool>(sysOut.layout.staffDistance));
+    CHECK_EQUAL(87.5, sysOut.layout.staffDistance.value());
+    REQUIRE(static_cast<bool>(sysOut.layout.systemDistance));
+    CHECK_EQUAL(120.0, sysOut.layout.systemDistance.value());
+}
+
+#endif


### PR DESCRIPTION
Addresses issues found during an `mx::api` audit; sections 3 (#192), 2.4 (#189), 2.2 (#187), 2.1 (#186) of the checked-in audit doc.

**Scope notes:** credit-image valign uses the image-specific `ValignImage` vocabulary (not modeled); `credit-symbol` glyph not modeled (structure preserved). Per-measure print new-system/new-page/page-number/system-layout/page-layout already round-trip at score level keyed by measure index.

## Test plan
- [x] `MidiNameRoundTripTest.cpp`, `DefaultsFontsRoundTripTest.cpp`, `CreditRoundTripTest.cpp`, `PrintLayoutRoundTripTest.cpp` (red before fix, green after)
- [x] `make test` green (229 cases), `make check` green, `make test-api-roundtrip` baseline unchanged

## References

- Closes #192
- Closes #189
- Closes #187
- Closes #186
