### PR TITLE
feat: implement rehearsal writing in DirectionWriter

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -122,3 +122,28 @@ locally.
 | `src/private/mx/core/generated/Document.h` | The core document model (parse, serialize, Document class) |
 | `src/private/mxtest/corert/CoreRoundtripImpl.cpp` | The corert test runner (discover, parse, serialize, compare) |
 | `src/private/mxtest/corert/Compare.cpp` | DOM normalization and comparison engine used by corert and api tests |
+
+## Git Authorship
+
+The git commit Author and Committer fields are for the user's information, not yours. No Co-Authored-By either.
+
+Correct:
+
+```text
+Author: The User <the.user@gmail.com>
+Date:   Sat Jun 20 10:31:06 2026 +0000
+
+    Blah
+```
+
+Incorrect:
+
+```text
+Author: Claude <noreply@anthropic.com>
+Date:   Sat Jun 20 10:31:06 2026 +0000
+
+    Blah
+
+    Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
+    Claude-Session: https://claude.ai/code/session_01S42a2LXrZb5GUk9cY7Hdru
+```

--- a/src/include/mx/api/RehearsalData.h
+++ b/src/include/mx/api/RehearsalData.h
@@ -14,6 +14,7 @@ namespace api
 {
 enum class RehearsalEnclosure
 {
+    unspecified,
     rectangle,
     square,
     oval,
@@ -36,7 +37,7 @@ class RehearsalData
 
     RehearsalData()
         : text{}, positionData{}, isColorSpecified{false}, colorData{}, fontData{},
-          enclosure{RehearsalEnclosure::rectangle}
+          enclosure{RehearsalEnclosure::unspecified}
     {
     }
 };

--- a/src/private/mx/impl/DirectionReader.cpp
+++ b/src/private/mx/impl/DirectionReader.cpp
@@ -314,7 +314,12 @@ void DirectionReader::parseRehearsal(const core::DirectionType &directionType)
         api::RehearsalData outRehearsal;
         outRehearsal.text = rehearsal.value();
         outRehearsal.positionData = getPositionData(rehearsal);
-        outRehearsal.colorData = getColor(rehearsal);
+        outRehearsal.fontData = getFontData(rehearsal);
+        outRehearsal.isColorSpecified = rehearsal.color().has_value();
+        if (outRehearsal.isColorSpecified)
+        {
+            outRehearsal.colorData = getColor(rehearsal);
+        }
         if (rehearsal.enclosure().has_value())
         {
             switch (rehearsal.enclosure()->tag())

--- a/src/private/mx/impl/DirectionWriter.cpp
+++ b/src/private/mx/impl/DirectionWriter.cpp
@@ -449,6 +449,49 @@ std::vector<core::MusicDataChoice> DirectionWriter::getDirectionLikeThings()
         addDirectionType(std::move(dt), direction);
     }
 
+    for (const auto &item : myDirectionData.rehearsals)
+    {
+        core::FormattedTextID rehearsal{};
+        rehearsal.setValue(item.text);
+        setAttributesFromPositionData(item.positionData, rehearsal);
+        setAttributesFromFontData(item.fontData, rehearsal);
+        if (item.isColorSpecified)
+        {
+            setAttributesFromColorData(item.colorData, rehearsal);
+        }
+        switch (item.enclosure)
+        {
+        case api::RehearsalEnclosure::rectangle:
+            rehearsal.setEnclosure(core::EnclosureShape::rectangle());
+            break;
+        case api::RehearsalEnclosure::square:
+            rehearsal.setEnclosure(core::EnclosureShape::square());
+            break;
+        case api::RehearsalEnclosure::oval:
+            rehearsal.setEnclosure(core::EnclosureShape::oval());
+            break;
+        case api::RehearsalEnclosure::circle:
+            rehearsal.setEnclosure(core::EnclosureShape::circle());
+            break;
+        case api::RehearsalEnclosure::bracket:
+            rehearsal.setEnclosure(core::EnclosureShape::bracket());
+            break;
+        case api::RehearsalEnclosure::triangle:
+            rehearsal.setEnclosure(core::EnclosureShape::triangle());
+            break;
+        case api::RehearsalEnclosure::diamond:
+            rehearsal.setEnclosure(core::EnclosureShape::diamond());
+            break;
+        case api::RehearsalEnclosure::none:
+            rehearsal.setEnclosure(core::EnclosureShape::none());
+            break;
+        }
+        core::DirectionType dt{};
+        dt.setChoice(
+            core::DirectionTypeChoice::rehearsal(core::OneOrMore<core::FormattedTextID>{std::move(rehearsal)}));
+        addDirectionType(std::move(dt), direction);
+    }
+
     if (myIsFirstDirectionTypeAdded)
     {
         // The direction has other content; attach the <sound> as a child of the <direction>.

--- a/src/private/mx/impl/DirectionWriter.cpp
+++ b/src/private/mx/impl/DirectionWriter.cpp
@@ -461,6 +461,8 @@ std::vector<core::MusicDataChoice> DirectionWriter::getDirectionLikeThings()
         }
         switch (item.enclosure)
         {
+        case api::RehearsalEnclosure::unspecified:
+            break;
         case api::RehearsalEnclosure::rectangle:
             rehearsal.setEnclosure(core::EnclosureShape::rectangle());
             break;

--- a/src/private/mxtest/api/DirectionDataTest.cpp
+++ b/src/private/mxtest/api/DirectionDataTest.cpp
@@ -273,4 +273,45 @@ TEST(RehearsalRoundTripXml, DirectionData)
 
 T_END;
 
+// Verify that a rehearsal with no enclosure set (RehearsalEnclosure::unspecified) does not emit
+// an enclosure attribute in the serialized XML, and that the field round-trips as unspecified.
+TEST(RehearsalUnspecifiedEnclosureNoPhantomAttribute, DirectionData)
+{
+    ScoreData oscore;
+    oscore.ticksPerQuarter = 10;
+    oscore.parts.emplace_back();
+    auto &opart = oscore.parts.back();
+    opart.measures.emplace_back();
+    auto &omeasure = opart.measures.back();
+    omeasure.staves.emplace_back();
+    auto &ostaff = omeasure.staves.back();
+    auto &ovoice = ostaff.voices[0];
+
+    NoteData onote{};
+    onote.tickTimePosition = 0;
+    onote.durationData.durationTimeTicks = 10;
+    onote.durationData.durationName = DurationName::quarter;
+    ovoice.notes.push_back(onote);
+
+    RehearsalData rehearsal;
+    rehearsal.text = "C";
+    // enclosure left at default (unspecified) — must not appear in XML or round-trip as rectangle
+
+    DirectionData directionData;
+    directionData.tickTimePosition = 0;
+    directionData.rehearsals.push_back(rehearsal);
+    ostaff.directions.push_back(directionData);
+
+    const auto xml = mxtest::toXml(oscore);
+    CHECK(xml.find("enclosure") == std::string::npos);
+
+    const auto rscore = mxtest::roundTrip(oscore);
+    REQUIRE(rscore.parts.front().measures.front().staves.front().directions.size() == 1);
+    REQUIRE(rscore.parts.front().measures.front().staves.front().directions.front().rehearsals.size() == 1);
+    CHECK(RehearsalEnclosure::unspecified ==
+          rscore.parts.front().measures.front().staves.front().directions.front().rehearsals.front().enclosure);
+}
+
+T_END;
+
 #endif

--- a/src/private/mxtest/api/DirectionDataTest.cpp
+++ b/src/private/mxtest/api/DirectionDataTest.cpp
@@ -7,9 +7,11 @@
 
 #include "cpul/cpulTestHarness.h"
 #include "mx/api/DocumentManager.h"
+#include "mx/api/RehearsalData.h"
 #include "mx/api/ScoreData.h"
 #include "mxtest/api/RoundTrip.h"
 #include "mxtest/api/TestHelpers.h"
+#include "mxtest/file/Path.h"
 
 using namespace std;
 using namespace mx::api;
@@ -190,6 +192,83 @@ TEST(OutOfOrderTorture, DirectionData)
         ++rdirection;
         CHECK_EQUAL(tempTickSorter.at(2), rdirection->tickTimePosition);
     }
+}
+
+T_END;
+
+// Parse the synthetic rehearsal file and confirm that mx::api reads the text and enclosure.
+// This pins the core -> api read path and would fail if parseRehearsal regresses.
+TEST(RehearsalSyntheticFileRead, DirectionData)
+{
+    const std::string path = mxtest::getResourcesDirectoryPath() + "synthetic/rehearsal.3.1.xml";
+    auto &docMgr = DocumentManager::getInstance();
+    const auto docIdResult = docMgr.createFromFile(path);
+    REQUIRE(docIdResult.ok());
+    const int docId = docIdResult.value();
+    const auto scoreResult = docMgr.getData(docId);
+    docMgr.destroyDocument(docId);
+    REQUIRE(scoreResult.ok());
+    const auto &score = scoreResult.value();
+    REQUIRE(score.parts.size() == 1);
+    REQUIRE(score.parts.front().measures.size() == 1);
+    REQUIRE(score.parts.front().measures.front().staves.size() == 1);
+    const auto &directions = score.parts.front().measures.front().staves.front().directions;
+    REQUIRE(directions.size() == 1);
+    REQUIRE(directions.front().rehearsals.size() == 1);
+    const auto &rehearsal = directions.front().rehearsals.front();
+    CHECK_EQUAL("x", rehearsal.text);
+    CHECK(RehearsalEnclosure::rectangle == rehearsal.enclosure);
+}
+
+T_END;
+
+// Verify that rehearsal marks survive a full MusicXML serialization/deserialization round trip.
+// This catches the bug where DirectionWriter had no rehearsal write path and rehearsals were
+// silently dropped on output.
+TEST(RehearsalRoundTripXml, DirectionData)
+{
+    ScoreData oscore;
+    oscore.ticksPerQuarter = 10;
+    oscore.parts.emplace_back();
+    auto &opart = oscore.parts.back();
+    opart.measures.emplace_back();
+    auto &omeasure = opart.measures.back();
+    omeasure.staves.emplace_back();
+    auto &ostaff = omeasure.staves.back();
+    auto &ovoice = ostaff.voices[0];
+
+    NoteData onote{};
+    onote.tickTimePosition = 0;
+    onote.durationData.durationTimeTicks = 10;
+    onote.durationData.durationName = DurationName::quarter;
+    ovoice.notes.push_back(onote);
+
+    RehearsalData rehearsal;
+    rehearsal.text = "B";
+    rehearsal.enclosure = RehearsalEnclosure::rectangle;
+    rehearsal.fontData.fontFamily = {"Times New Roman"};
+    rehearsal.fontData.style = FontStyle::normal;
+    rehearsal.fontData.weight = FontWeight::bold;
+    rehearsal.fontData.sizeType = FontSizeType::point;
+    rehearsal.fontData.sizePoint = 12.0;
+    rehearsal.positionData.isDefaultXSpecified = true;
+    rehearsal.positionData.defaultX = 5.0;
+
+    DirectionData directionData;
+    directionData.tickTimePosition = 0;
+    directionData.rehearsals.push_back(rehearsal);
+    ostaff.directions.push_back(directionData);
+
+    const auto rscore = mxtest::roundTrip(oscore);
+    REQUIRE(rscore.parts.size() == 1);
+    REQUIRE(rscore.parts.front().measures.size() == 1);
+    REQUIRE(rscore.parts.front().measures.front().staves.size() == 1);
+    const auto &rdirections = rscore.parts.front().measures.front().staves.front().directions;
+    REQUIRE(rdirections.size() == 1);
+    REQUIRE(rdirections.front().rehearsals.size() == 1);
+    CHECK_EQUAL("B", rdirections.front().rehearsals.front().text);
+    CHECK(RehearsalEnclosure::rectangle == rdirections.front().rehearsals.front().enclosure);
+    CHECK(FontWeight::bold == rdirections.front().rehearsals.front().fontData.weight);
 }
 
 T_END;

--- a/src/private/mxtest/impl/DirectionWriterTest.cpp
+++ b/src/private/mxtest/impl/DirectionWriterTest.cpp
@@ -7,6 +7,7 @@
 
 #include "cpul/cpulTestHarness.h"
 #include "mx/api/OttavaData.h"
+#include "mx/api/RehearsalData.h"
 #include "mx/core/generated/Direction.h"
 #include "mx/core/generated/DirectionType.h"
 #include "mx/core/generated/MusicDataChoice.h"
@@ -113,6 +114,55 @@ TEST(segnoAndCodaRoundTrip, DirectionWriter)
     REQUIRE(roundTripped.codas.size() == 1);
     CHECK(segno == roundTripped.segnos.front());
     CHECK(coda == roundTripped.codas.front());
+}
+
+T_END
+
+// Build a RehearsalData carrying the full attribute set (text, position, color, font, enclosure),
+// write it with DirectionWriter, read it back with DirectionReader, and confirm every field
+// survives the api -> core -> api round trip.
+TEST(rehearsalRoundTrip, DirectionWriter)
+{
+    api::RehearsalData rehearsal;
+    rehearsal.text = "A";
+    rehearsal.positionData.isDefaultXSpecified = true;
+    rehearsal.positionData.defaultX = 10.0;
+    rehearsal.positionData.isDefaultYSpecified = true;
+    rehearsal.positionData.defaultY = 20.0;
+    rehearsal.positionData.isRelativeXSpecified = true;
+    rehearsal.positionData.relativeX = 3.0;
+    rehearsal.positionData.isRelativeYSpecified = true;
+    rehearsal.positionData.relativeY = 4.0;
+    rehearsal.positionData.horizontalAlignmnet = api::HorizontalAlignment::left;
+    rehearsal.positionData.verticalAlignment = api::VerticalAlignment::top;
+    rehearsal.fontData.fontFamily = {"Maestro"};
+    rehearsal.fontData.style = api::FontStyle::italic;
+    rehearsal.fontData.weight = api::FontWeight::bold;
+    rehearsal.fontData.sizeType = api::FontSizeType::point;
+    rehearsal.fontData.sizePoint = 14.0;
+    rehearsal.isColorSpecified = true;
+    rehearsal.colorData.red = 255;
+    rehearsal.colorData.green = 0;
+    rehearsal.colorData.blue = 0;
+    rehearsal.colorData.isAlphaSpecified = true;
+    rehearsal.colorData.alpha = 255;
+    rehearsal.enclosure = api::RehearsalEnclosure::square;
+
+    api::DirectionData directionData;
+    directionData.rehearsals.push_back(rehearsal);
+
+    Cursor cursor{1, 100};
+    DirectionWriter writer{directionData, cursor};
+    const auto mdcSet = writer.getDirectionLikeThings();
+    REQUIRE(mdcSet.size() >= 1);
+    CHECK(mdcSet.front().isDirection());
+    const auto &direction = mdcSet.front().asDirection();
+
+    DirectionReader reader{direction, cursor};
+    const auto roundTripped = reader.getDirectionData();
+
+    REQUIRE(roundTripped.rehearsals.size() == 1);
+    CHECK(rehearsal == roundTripped.rehearsals.front());
 }
 
 T_END


### PR DESCRIPTION
## Summary

`DirectionWriter` had no write path for `RehearsalData`, so rehearsal marks were silently dropped whenever a score was serialized. This adds a loop over `directionData.rehearsals` that emits `<rehearsal>` elements, mirroring the segno/coda pattern from #203.

While wiring up the round-trip test, two gaps in `DirectionReader::parseRehearsal` were also found and fixed: it was not calling `getFontData`, and it was not setting `isColorSpecified` before copying color attributes, so both fields were always lost on the read path. The `isColorSpecified` gap is the same bug class described in #207 (which covers the same pattern in `parseWords` — left for a separate PR).

A post-review fix also adds `RehearsalEnclosure::unspecified` as the new default for `RehearsalData::enclosure`. Previously the default was `rectangle`, so any rehearsal with no `enclosure` attribute in the source XML would silently gain `enclosure="rectangle"` on write-back.

## Changes

- `RehearsalData.h` — added `RehearsalEnclosure::unspecified`; changed `RehearsalData` default enclosure from `rectangle` to `unspecified`.
- `DirectionWriter::getDirectionLikeThings` — new loop over `rehearsals` emitting `<rehearsal>` with text, position, font, color, and enclosure (skipped when `unspecified`).
- `DirectionReader::parseRehearsal` — now reads `fontData` via `getFontData` and correctly gates `colorData` behind `isColorSpecified`.

## Testing

- `rehearsalRoundTrip` (`DirectionWriterTest.cpp`) — api → core → api at the impl layer; covers text, position, font, color, and enclosure shapes. Red before the fix, green after.
- `RehearsalSyntheticFileRead` (`DirectionDataTest.cpp`) — loads `data/synthetic/rehearsal.3.1.xml` and asserts the read path surfaces text and enclosure. Pins the core → api direction.
- `RehearsalRoundTripXml` (`DirectionDataTest.cpp`) — full MusicXML serialization/deserialization round-trip; covers text, enclosure, and font weight.
- `RehearsalUnspecifiedEnclosureNoPhantomAttribute` (`DirectionDataTest.cpp`) — asserts that `enclosure="rectangle"` does not appear in serialized XML when enclosure is unspecified, and that the field round-trips as `unspecified`.
- Full suite: 4101 assertions in 269 test cases, all pass.
- `make test-api-roundtrip` baseline (1 pinned file): still passes.
- `make check` (fmt-check): passes.

## References

- Closes #205
- Closes #134
- Partially addresses #207 (fixes the `parseRehearsal` `isColorSpecified` gap; the `parseWords` half of #207 is left for a separate PR)
- Related to #203 (segno/coda writer; rehearsal was scoped out of that PR)