### PR TITLE
testing: baseline api round-trip discovery run (phase 0, #209)

### DIFF
--- a/src/private/mxtest/api/roundtrip-baseline.txt
+++ b/src/private/mxtest/api/roundtrip-baseline.txt
@@ -15,5 +15,10 @@
 # (never automatic); regression mode requires every file below to pass --
 # zero tolerance.
 #
+# Captured 2026-06-19: discovery re-run over the full corpus (829 discovered,
+# same discovery rules as corert). Results: 1 PASS, 812 FAIL, 0 SKIP,
+# 0 LOADFAIL, 8 GETDATAFAIL, 8 CREATEFAIL. No new files passed; pinned total
+# remains 1.
+#
 # Format: one data/-relative path per line; # starts a comment.
 ksuite/k016a_Miscellaneous_Fields.xml


### PR DESCRIPTION
## Summary

Phase 0 of #208. Ran `make discover-api-roundtrip` (2026-06-19) over the full corpus and updated the baseline header with the aggregate counts. No api code changed; only `roundtrip-baseline.txt` is touched.

Discovery result: **829 discovered, 1 PASS, 812 FAIL, 0 SKIP, 0 LOADFAIL, 8 GETDATAFAIL, 8 CREATEFAIL.**

The single passing file (`ksuite/k016a_Miscellaneous_Fields.xml`) was already pinned, so no new paths are added to the baseline. The header gains a dated entry recording today's counts alongside the existing 2026-06-12 capture.

## Testing

- `make test-api-roundtrip` passes (1 pinned, 0 failed)
- `make check` passes (fmt-check clean)
- Full per-file discovery TSV posted below as a PR comment (evidence per issue spec)

## References

- Closes #209
- Progresses #208

---
_Generated by [Claude Code](https://claude.ai/code/session_01H15EDSpK8uk6ayCgH39mnf)_