### PR TITLE
fix: part-group round-trip fidelity, and a classifier category for supported-element drops

### DIFF
--- a/audit/classify.py
+++ b/audit/classify.py
@@ -24,6 +24,8 @@ Categories:
     D  enum-bug         text/attr value is a known missing enum member
     E  missing-attribute  a partial feature's attribute was dropped
     F  pipeline-error   LOADFAIL / GETDATAFAIL / CREATEFAIL (no actual produced)
+    G  supported-drop   a dropped element class is marked support="full"/"partial"
+                        (an impl round-trip bug or an api.features.xml overstatement)
     unknown            a FAIL that matched none of the above
 """
 
@@ -56,11 +58,12 @@ _CATEGORY_LABELS = {
     "D": "enum bug",
     "E": "missing attribute/element",
     "F": "pipeline error",
+    "G": "supported-element drop",
     "unknown": "unknown",
 }
 
 # Categories that are actionable feature gaps (ranked in the worklist).
-_ACTIONABLE = frozenset({"B", "D", "E"})
+_ACTIONABLE = frozenset({"B", "D", "E", "G"})
 
 
 # --------------------------------------------------------------------------- #
@@ -375,8 +378,18 @@ def classify_entry(
         ):
             cats.append("E")
 
-    # Primary = first match in priority order; the rest are secondary.
-    primary = next((c for c in ("B", "C", "D", "E") if c in cats), None)
+    # G -- a dropped element class the audit marks support="full"/"partial".
+    # Either a genuine impl round-trip bug or an api.features.xml overstatement;
+    # both need human triage (issue #219). Without this the file falls through to
+    # "unknown", since B requires *every* dropped class to be support="none".
+    supported_missing = sorted(t for t in missing if support_of(t) in ("full", "partial"))
+    if supported_missing:
+        cats.append("G")
+
+    # Primary = first match in priority order; the rest are secondary. G is last
+    # so a precise enum/attribute finding still wins when one applies; otherwise
+    # a dropped supported element is surfaced instead of hidden in "unknown".
+    primary = next((c for c in ("B", "C", "D", "E", "G") if c in cats), None)
     if primary is None:
         warn(f"{entry.rel}: unclassified FAIL (missing={rec['missing_elements']}, "
              f"mismatch={rec['mismatch_type']})")
@@ -388,6 +401,8 @@ def classify_entry(
     # Blocking features: what, if fully supported, would unblock this file.
     if primary == "B":
         rec["blocking_features"] = sorted(missing)
+    elif primary == "G":
+        rec["blocking_features"] = supported_missing
     elif primary in ("D", "E") and div is not None and div.element:
         rec["blocking_features"] = [div.element]
 
@@ -464,7 +479,7 @@ def print_summary(report: dict, out_path: Path) -> None:
     total = report["summary"]["total"]
     print(f"Classified {total} files from {report['dump_dir']}\n")
 
-    for cat in ("A", "B", "C", "D", "E", "F", "unknown"):
+    for cat in ("A", "B", "C", "D", "E", "F", "G", "unknown"):
         n = counts.get(cat, 0)
         if n == 0 and cat == "A":
             continue
@@ -473,7 +488,7 @@ def print_summary(report: dict, out_path: Path) -> None:
 
     ranked = _rank_blocking_features(records)
     if ranked:
-        print("\nTop blocking features (ranked by files unblocked; B+D+E):")
+        print("\nTop blocking features (ranked by files unblocked; B+D+E+G):")
         for feat, files, single in ranked[:15]:
             print(f"  {feat:<24}{files:>4} files   ({single} single-blocker)")
 

--- a/audit/tests/test_classify.py
+++ b/audit/tests/test_classify.py
@@ -144,6 +144,35 @@ class ClassifierTest(unittest.TestCase):
         self.assertEqual(rec["primary_category"], "E")
         self.assertEqual(rec["mismatch_type"], "attribute-count")
 
+    def test_supported_element_drop(self) -> None:
+        # backup is support="full" but vanishes. That is not category B (which
+        # needs *every* drop to be support="none"), so it must surface as G
+        # rather than fall through to "unknown".
+        self._pair(
+            "wild/supdrop.xml",
+            _wrap("<backup>1</backup><note><pitch><step>C</step></pitch></note>"),
+            _wrap("<note><pitch><step>C</step></pitch></note>"),
+        )
+        rec = self._classify()["wild/supdrop.xml"]
+        self.assertEqual(rec["primary_category"], "G")
+        self.assertEqual(rec["missing_elements"], ["backup"])
+        self.assertEqual(rec["blocking_features"], ["backup"])
+        self.assertTrue(rec["is_single_blocker"])
+
+    def test_mixed_supported_and_none_drop_is_g(self) -> None:
+        # A supported drop (backup=full) mixed with an unsupported drop
+        # (credit=none) is G, not B -- and only the supported tag is a blocker.
+        self._pair(
+            "wild/mixed.xml",
+            _wrap("<backup>1</backup><credit>c</credit><note/>"),
+            _wrap("<note/>"),
+        )
+        rec = self._classify()["wild/mixed.xml"]
+        self.assertEqual(rec["primary_category"], "G")
+        self.assertEqual(rec["missing_elements"], ["backup", "credit"])
+        self.assertEqual(rec["blocking_features"], ["backup"])
+        self.assertEqual(rec["secondary_categories"], [])
+
     def test_pipeline_error_with_status(self) -> None:
         self._pair("wild/load.xml", _wrap("<note/>"), None)
         self._status("wild/load.xml", "LOADFAIL")

--- a/data/api.features.xml
+++ b/data/api.features.xml
@@ -752,8 +752,12 @@
     <feature name="part-clef" support="none">
       <notes>for-part / part-clef (4.0) not modeled.</notes>
     </feature>
-    <feature name="part-group" support="full">
-      <notes>api::PartGroupData; ScoreReader/ScoreWriter.</notes>
+    <feature name="part-group" support="partial">
+      <attributes>
+        <attribute name="type" support="yes"/>
+        <attribute name="number" support="yes"/>
+      </attributes>
+      <notes>api::PartGroupData via ScoreReader::startPartGroup/ScoreWriter::makePartGroupStart. Round-trips type, number, group-name, group-abbreviation, group-symbol (-&gt;bracketType), group-barline (-&gt;api::GroupBarline), and group-name-display/group-abbreviation-display as best-effort plain text (-&gt;displayName/displayAbbreviation). Partial because group-time and editorial (footnote/level) are not modeled, and formatting attributes on group-name/group-symbol/group-barline/display names (color, default-x, font-*, etc.) are dropped (value only). A part-group start with no matching stop is dropped by design: api::PartGroupData models a complete start..stop span, and an unmatched start is semantically invalid (a constraint beyond XSD).</notes>
     </feature>
     <feature name="part-list" support="full">
       <notes>Drives ScoreData.parts ordering; ScoreReader/ScoreWriter.</notes>

--- a/data/synthetic/accent.3.0.xml
+++ b/data/synthetic/accent.3.0.xml
@@ -8,7 +8,7 @@
     <score-part id="id1">
       <part-name>x</part-name>
     </score-part>
-    <part-group type="start">
+    <part-group type="stop">
       <footnote>x</footnote>
       <level>x</level>
     </part-group>

--- a/data/synthetic/accidental-mark.3.0.xml
+++ b/data/synthetic/accidental-mark.3.0.xml
@@ -8,7 +8,7 @@
     <score-part id="id1">
       <part-name>x</part-name>
     </score-part>
-    <part-group type="start">
+    <part-group type="stop">
       <footnote>x</footnote>
       <level>x</level>
     </part-group>

--- a/data/synthetic/accidental-mark.3.1.xml
+++ b/data/synthetic/accidental-mark.3.1.xml
@@ -8,7 +8,7 @@
     <score-part id="id1">
       <part-name>x</part-name>
     </score-part>
-    <part-group type="start">
+    <part-group type="stop">
       <footnote>x</footnote>
       <level>x</level>
     </part-group>

--- a/data/synthetic/accidental-text.3.0.xml
+++ b/data/synthetic/accidental-text.3.0.xml
@@ -11,7 +11,7 @@
     <score-part id="id1">
       <part-name>x</part-name>
     </score-part>
-    <part-group type="start">
+    <part-group type="stop">
       <footnote>x</footnote>
       <level>x</level>
     </part-group>

--- a/data/synthetic/accidental-text.3.1.xml
+++ b/data/synthetic/accidental-text.3.1.xml
@@ -11,7 +11,7 @@
     <score-part id="id1">
       <part-name>x</part-name>
     </score-part>
-    <part-group type="start">
+    <part-group type="stop">
       <footnote>x</footnote>
       <level>x</level>
     </part-group>

--- a/data/synthetic/accidental.3.0.xml
+++ b/data/synthetic/accidental.3.0.xml
@@ -8,7 +8,7 @@
     <score-part id="id1">
       <part-name>x</part-name>
     </score-part>
-    <part-group type="start">
+    <part-group type="stop">
       <footnote>x</footnote>
       <level>x</level>
     </part-group>

--- a/data/synthetic/accidental.3.1.xml
+++ b/data/synthetic/accidental.3.1.xml
@@ -8,7 +8,7 @@
     <score-part id="id1">
       <part-name>x</part-name>
     </score-part>
-    <part-group type="start">
+    <part-group type="stop">
       <footnote>x</footnote>
       <level>x</level>
     </part-group>

--- a/data/synthetic/accordion-registration.3.0.xml
+++ b/data/synthetic/accordion-registration.3.0.xml
@@ -8,7 +8,7 @@
     <score-part id="id1">
       <part-name>x</part-name>
     </score-part>
-    <part-group type="start">
+    <part-group type="stop">
       <footnote>x</footnote>
       <level>x</level>
     </part-group>

--- a/data/synthetic/accordion-registration.3.1.xml
+++ b/data/synthetic/accordion-registration.3.1.xml
@@ -8,7 +8,7 @@
     <score-part id="id1">
       <part-name>x</part-name>
     </score-part>
-    <part-group type="start">
+    <part-group type="stop">
       <footnote>x</footnote>
       <level>x</level>
     </part-group>

--- a/data/synthetic/arpeggiate.3.0.xml
+++ b/data/synthetic/arpeggiate.3.0.xml
@@ -8,7 +8,7 @@
     <score-part id="id1">
       <part-name>x</part-name>
     </score-part>
-    <part-group type="start">
+    <part-group type="stop">
       <footnote>x</footnote>
       <level>x</level>
     </part-group>

--- a/data/synthetic/arpeggiate.3.1.xml
+++ b/data/synthetic/arpeggiate.3.1.xml
@@ -8,7 +8,7 @@
     <score-part id="id1">
       <part-name>x</part-name>
     </score-part>
-    <part-group type="start">
+    <part-group type="stop">
       <footnote>x</footnote>
       <level>x</level>
     </part-group>

--- a/data/synthetic/arpeggiate.4.0.xml
+++ b/data/synthetic/arpeggiate.4.0.xml
@@ -8,7 +8,7 @@
     <score-part id="id1">
       <part-name>x</part-name>
     </score-part>
-    <part-group type="start">
+    <part-group type="stop">
       <footnote>x</footnote>
       <level>x</level>
     </part-group>

--- a/data/synthetic/arrow-style.3.0.xml
+++ b/data/synthetic/arrow-style.3.0.xml
@@ -8,7 +8,7 @@
     <score-part id="id1">
       <part-name>x</part-name>
     </score-part>
-    <part-group type="start">
+    <part-group type="stop">
       <footnote>x</footnote>
       <level>x</level>
     </part-group>

--- a/data/synthetic/arrow.3.0.xml
+++ b/data/synthetic/arrow.3.0.xml
@@ -8,7 +8,7 @@
     <score-part id="id1">
       <part-name>x</part-name>
     </score-part>
-    <part-group type="start">
+    <part-group type="stop">
       <footnote>x</footnote>
       <level>x</level>
     </part-group>

--- a/data/synthetic/arrow.3.1.xml
+++ b/data/synthetic/arrow.3.1.xml
@@ -8,7 +8,7 @@
     <score-part id="id1">
       <part-name>x</part-name>
     </score-part>
-    <part-group type="start">
+    <part-group type="stop">
       <footnote>x</footnote>
       <level>x</level>
     </part-group>

--- a/data/synthetic/arrowhead.3.1.xml
+++ b/data/synthetic/arrowhead.3.1.xml
@@ -8,7 +8,7 @@
     <score-part id="id1">
       <part-name>x</part-name>
     </score-part>
-    <part-group type="start">
+    <part-group type="stop">
       <footnote>x</footnote>
       <level>x</level>
     </part-group>

--- a/data/synthetic/articulations.3.1.xml
+++ b/data/synthetic/articulations.3.1.xml
@@ -8,7 +8,7 @@
     <score-part id="id1">
       <part-name>x</part-name>
     </score-part>
-    <part-group type="start">
+    <part-group type="stop">
       <footnote>x</footnote>
       <level>x</level>
     </part-group>

--- a/data/synthetic/assess.4.0.xml
+++ b/data/synthetic/assess.4.0.xml
@@ -8,7 +8,7 @@
     <score-part id="id1">
       <part-name>x</part-name>
     </score-part>
-    <part-group type="start">
+    <part-group type="stop">
       <footnote>x</footnote>
       <level>x</level>
     </part-group>

--- a/data/synthetic/bar-style.3.0.xml
+++ b/data/synthetic/bar-style.3.0.xml
@@ -8,7 +8,7 @@
     <score-part id="id1">
       <part-name>x</part-name>
     </score-part>
-    <part-group type="start">
+    <part-group type="stop">
       <footnote>x</footnote>
       <level>x</level>
     </part-group>

--- a/data/synthetic/barline.3.0.xml
+++ b/data/synthetic/barline.3.0.xml
@@ -8,7 +8,7 @@
     <score-part id="id1">
       <part-name>x</part-name>
     </score-part>
-    <part-group type="start">
+    <part-group type="stop">
       <footnote>x</footnote>
       <level>x</level>
     </part-group>

--- a/data/synthetic/barline.3.1.xml
+++ b/data/synthetic/barline.3.1.xml
@@ -8,7 +8,7 @@
     <score-part id="id1">
       <part-name>x</part-name>
     </score-part>
-    <part-group type="start">
+    <part-group type="stop">
       <footnote>x</footnote>
       <level>x</level>
     </part-group>

--- a/data/synthetic/barre.3.0.xml
+++ b/data/synthetic/barre.3.0.xml
@@ -8,7 +8,7 @@
     <score-part id="id1">
       <part-name>x</part-name>
     </score-part>
-    <part-group type="start">
+    <part-group type="stop">
       <footnote>x</footnote>
       <level>x</level>
     </part-group>

--- a/data/synthetic/bass-alter.3.0.xml
+++ b/data/synthetic/bass-alter.3.0.xml
@@ -8,7 +8,7 @@
     <score-part id="id1">
       <part-name>x</part-name>
     </score-part>
-    <part-group type="start">
+    <part-group type="stop">
       <footnote>x</footnote>
       <level>x</level>
     </part-group>

--- a/data/synthetic/bass-separator.4.0.xml
+++ b/data/synthetic/bass-separator.4.0.xml
@@ -8,7 +8,7 @@
     <score-part id="id1">
       <part-name>x</part-name>
     </score-part>
-    <part-group type="start">
+    <part-group type="stop">
       <footnote>x</footnote>
       <level>x</level>
     </part-group>

--- a/data/synthetic/bass-step.3.0.xml
+++ b/data/synthetic/bass-step.3.0.xml
@@ -8,7 +8,7 @@
     <score-part id="id1">
       <part-name>x</part-name>
     </score-part>
-    <part-group type="start">
+    <part-group type="stop">
       <footnote>x</footnote>
       <level>x</level>
     </part-group>

--- a/data/synthetic/bass.4.0.xml
+++ b/data/synthetic/bass.4.0.xml
@@ -8,7 +8,7 @@
     <score-part id="id1">
       <part-name>x</part-name>
     </score-part>
-    <part-group type="start">
+    <part-group type="stop">
       <footnote>x</footnote>
       <level>x</level>
     </part-group>

--- a/data/synthetic/beam.3.0.xml
+++ b/data/synthetic/beam.3.0.xml
@@ -8,7 +8,7 @@
     <score-part id="id1">
       <part-name>x</part-name>
     </score-part>
-    <part-group type="start">
+    <part-group type="stop">
       <footnote>x</footnote>
       <level>x</level>
     </part-group>

--- a/data/synthetic/beam.3.1.xml
+++ b/data/synthetic/beam.3.1.xml
@@ -8,7 +8,7 @@
     <score-part id="id1">
       <part-name>x</part-name>
     </score-part>
-    <part-group type="start">
+    <part-group type="stop">
       <footnote>x</footnote>
       <level>x</level>
     </part-group>

--- a/data/synthetic/beat-repeat.3.0.xml
+++ b/data/synthetic/beat-repeat.3.0.xml
@@ -8,7 +8,7 @@
     <score-part id="id1">
       <part-name>x</part-name>
     </score-part>
-    <part-group type="start">
+    <part-group type="stop">
       <footnote>x</footnote>
       <level>x</level>
     </part-group>

--- a/data/synthetic/beat-type.3.0.xml
+++ b/data/synthetic/beat-type.3.0.xml
@@ -8,7 +8,7 @@
     <score-part id="id1">
       <part-name>x</part-name>
     </score-part>
-    <part-group type="start">
+    <part-group type="stop">
       <footnote>x</footnote>
       <level>x</level>
     </part-group>

--- a/data/synthetic/beat-unit-tied.3.1.xml
+++ b/data/synthetic/beat-unit-tied.3.1.xml
@@ -8,7 +8,7 @@
     <score-part id="id1">
       <part-name>x</part-name>
     </score-part>
-    <part-group type="start">
+    <part-group type="stop">
       <footnote>x</footnote>
       <level>x</level>
     </part-group>

--- a/data/synthetic/beater.3.0.xml
+++ b/data/synthetic/beater.3.0.xml
@@ -8,7 +8,7 @@
     <score-part id="id1">
       <part-name>x</part-name>
     </score-part>
-    <part-group type="start">
+    <part-group type="stop">
       <footnote>x</footnote>
       <level>x</level>
     </part-group>

--- a/data/synthetic/beats.3.0.xml
+++ b/data/synthetic/beats.3.0.xml
@@ -8,7 +8,7 @@
     <score-part id="id1">
       <part-name>x</part-name>
     </score-part>
-    <part-group type="start">
+    <part-group type="stop">
       <footnote>x</footnote>
       <level>x</level>
     </part-group>

--- a/data/synthetic/bend.3.0.xml
+++ b/data/synthetic/bend.3.0.xml
@@ -8,7 +8,7 @@
     <score-part id="id1">
       <part-name>x</part-name>
     </score-part>
-    <part-group type="start">
+    <part-group type="stop">
       <footnote>x</footnote>
       <level>x</level>
     </part-group>

--- a/data/synthetic/bend.4.0.xml
+++ b/data/synthetic/bend.4.0.xml
@@ -8,7 +8,7 @@
     <score-part id="id1">
       <part-name>x</part-name>
     </score-part>
-    <part-group type="start">
+    <part-group type="stop">
       <footnote>x</footnote>
       <level>x</level>
     </part-group>

--- a/data/synthetic/bookmark.3.0.xml
+++ b/data/synthetic/bookmark.3.0.xml
@@ -12,7 +12,7 @@
     <score-part id="id2">
       <part-name>x</part-name>
     </score-part>
-    <part-group type="start">
+    <part-group type="stop">
       <footnote>x</footnote>
       <level>x</level>
     </part-group>

--- a/data/synthetic/bracket.3.0.xml
+++ b/data/synthetic/bracket.3.0.xml
@@ -8,7 +8,7 @@
     <score-part id="id1">
       <part-name>x</part-name>
     </score-part>
-    <part-group type="start">
+    <part-group type="stop">
       <footnote>x</footnote>
       <level>x</level>
     </part-group>

--- a/data/synthetic/bracket.3.1.xml
+++ b/data/synthetic/bracket.3.1.xml
@@ -8,7 +8,7 @@
     <score-part id="id1">
       <part-name>x</part-name>
     </score-part>
-    <part-group type="start">
+    <part-group type="stop">
       <footnote>x</footnote>
       <level>x</level>
     </part-group>

--- a/data/synthetic/brass-bend.3.1.xml
+++ b/data/synthetic/brass-bend.3.1.xml
@@ -8,7 +8,7 @@
     <score-part id="id1">
       <part-name>x</part-name>
     </score-part>
-    <part-group type="start">
+    <part-group type="stop">
       <footnote>x</footnote>
       <level>x</level>
     </part-group>

--- a/data/synthetic/breath-mark.3.0.xml
+++ b/data/synthetic/breath-mark.3.0.xml
@@ -8,7 +8,7 @@
     <score-part id="id1">
       <part-name>x</part-name>
     </score-part>
-    <part-group type="start">
+    <part-group type="stop">
       <footnote>x</footnote>
       <level>x</level>
     </part-group>

--- a/data/synthetic/caesura.3.0.xml
+++ b/data/synthetic/caesura.3.0.xml
@@ -8,7 +8,7 @@
     <score-part id="id1">
       <part-name>x</part-name>
     </score-part>
-    <part-group type="start">
+    <part-group type="stop">
       <footnote>x</footnote>
       <level>x</level>
     </part-group>

--- a/data/synthetic/circular-arrow.3.0.xml
+++ b/data/synthetic/circular-arrow.3.0.xml
@@ -8,7 +8,7 @@
     <score-part id="id1">
       <part-name>x</part-name>
     </score-part>
-    <part-group type="start">
+    <part-group type="stop">
       <footnote>x</footnote>
       <level>x</level>
     </part-group>

--- a/data/synthetic/clef.3.0.xml
+++ b/data/synthetic/clef.3.0.xml
@@ -8,7 +8,7 @@
     <score-part id="id1">
       <part-name>x</part-name>
     </score-part>
-    <part-group type="start">
+    <part-group type="stop">
       <footnote>x</footnote>
       <level>x</level>
     </part-group>

--- a/data/synthetic/clef.3.1.xml
+++ b/data/synthetic/clef.3.1.xml
@@ -8,7 +8,7 @@
     <score-part id="id1">
       <part-name>x</part-name>
     </score-part>
-    <part-group type="start">
+    <part-group type="stop">
       <footnote>x</footnote>
       <level>x</level>
     </part-group>

--- a/data/synthetic/coda.3.0.xml
+++ b/data/synthetic/coda.3.0.xml
@@ -8,7 +8,7 @@
     <score-part id="id1">
       <part-name>x</part-name>
     </score-part>
-    <part-group type="start">
+    <part-group type="stop">
       <footnote>x</footnote>
       <level>x</level>
     </part-group>

--- a/data/synthetic/coda.3.1.xml
+++ b/data/synthetic/coda.3.1.xml
@@ -8,7 +8,7 @@
     <score-part id="id1">
       <part-name>x</part-name>
     </score-part>
-    <part-group type="start">
+    <part-group type="stop">
       <footnote>x</footnote>
       <level>x</level>
     </part-group>

--- a/data/synthetic/concert-score.4.0.xml
+++ b/data/synthetic/concert-score.4.0.xml
@@ -11,7 +11,7 @@
     <score-part id="id1">
       <part-name>x</part-name>
     </score-part>
-    <part-group type="start">
+    <part-group type="stop">
       <footnote>x</footnote>
       <level>x</level>
     </part-group>

--- a/data/synthetic/creator.3.0.xml
+++ b/data/synthetic/creator.3.0.xml
@@ -11,7 +11,7 @@
     <score-part id="id1">
       <part-name>x</part-name>
     </score-part>
-    <part-group type="start">
+    <part-group type="stop">
       <footnote>x</footnote>
       <level>x</level>
     </part-group>

--- a/data/synthetic/credit-image.3.0.xml
+++ b/data/synthetic/credit-image.3.0.xml
@@ -11,7 +11,7 @@
     <score-part id="id1">
       <part-name>x</part-name>
     </score-part>
-    <part-group type="start">
+    <part-group type="stop">
       <footnote>x</footnote>
       <level>x</level>
     </part-group>

--- a/data/synthetic/credit-image.3.1.xml
+++ b/data/synthetic/credit-image.3.1.xml
@@ -11,7 +11,7 @@
     <score-part id="id2">
       <part-name>x</part-name>
     </score-part>
-    <part-group type="start">
+    <part-group type="stop">
       <footnote>x</footnote>
       <level>x</level>
     </part-group>

--- a/data/synthetic/credit-symbol.3.1.xml
+++ b/data/synthetic/credit-symbol.3.1.xml
@@ -12,7 +12,7 @@
     <score-part id="id2">
       <part-name>x</part-name>
     </score-part>
-    <part-group type="start">
+    <part-group type="stop">
       <footnote>x</footnote>
       <level>x</level>
     </part-group>

--- a/data/synthetic/credit-type.3.0.xml
+++ b/data/synthetic/credit-type.3.0.xml
@@ -12,7 +12,7 @@
     <score-part id="id1">
       <part-name>x</part-name>
     </score-part>
-    <part-group type="start">
+    <part-group type="stop">
       <footnote>x</footnote>
       <level>x</level>
     </part-group>

--- a/data/synthetic/credit-words.3.0.xml
+++ b/data/synthetic/credit-words.3.0.xml
@@ -12,7 +12,7 @@
     <score-part id="id1">
       <part-name>x</part-name>
     </score-part>
-    <part-group type="start">
+    <part-group type="stop">
       <footnote>x</footnote>
       <level>x</level>
     </part-group>

--- a/data/synthetic/credit-words.3.1.xml
+++ b/data/synthetic/credit-words.3.1.xml
@@ -12,7 +12,7 @@
     <score-part id="id2">
       <part-name>x</part-name>
     </score-part>
-    <part-group type="start">
+    <part-group type="stop">
       <footnote>x</footnote>
       <level>x</level>
     </part-group>

--- a/data/synthetic/credit.3.1.xml
+++ b/data/synthetic/credit.3.1.xml
@@ -11,7 +11,7 @@
     <score-part id="id2">
       <part-name>x</part-name>
     </score-part>
-    <part-group type="start">
+    <part-group type="stop">
       <footnote>x</footnote>
       <level>x</level>
     </part-group>

--- a/data/synthetic/damp-all.3.0.xml
+++ b/data/synthetic/damp-all.3.0.xml
@@ -8,7 +8,7 @@
     <score-part id="id1">
       <part-name>x</part-name>
     </score-part>
-    <part-group type="start">
+    <part-group type="stop">
       <footnote>x</footnote>
       <level>x</level>
     </part-group>

--- a/data/synthetic/damp-all.3.1.xml
+++ b/data/synthetic/damp-all.3.1.xml
@@ -8,7 +8,7 @@
     <score-part id="id1">
       <part-name>x</part-name>
     </score-part>
-    <part-group type="start">
+    <part-group type="stop">
       <footnote>x</footnote>
       <level>x</level>
     </part-group>

--- a/data/synthetic/damp.3.0.xml
+++ b/data/synthetic/damp.3.0.xml
@@ -8,7 +8,7 @@
     <score-part id="id1">
       <part-name>x</part-name>
     </score-part>
-    <part-group type="start">
+    <part-group type="stop">
       <footnote>x</footnote>
       <level>x</level>
     </part-group>

--- a/data/synthetic/damp.3.1.xml
+++ b/data/synthetic/damp.3.1.xml
@@ -8,7 +8,7 @@
     <score-part id="id1">
       <part-name>x</part-name>
     </score-part>
-    <part-group type="start">
+    <part-group type="stop">
       <footnote>x</footnote>
       <level>x</level>
     </part-group>

--- a/data/synthetic/dashes.3.0.xml
+++ b/data/synthetic/dashes.3.0.xml
@@ -8,7 +8,7 @@
     <score-part id="id1">
       <part-name>x</part-name>
     </score-part>
-    <part-group type="start">
+    <part-group type="stop">
       <footnote>x</footnote>
       <level>x</level>
     </part-group>

--- a/data/synthetic/dashes.3.1.xml
+++ b/data/synthetic/dashes.3.1.xml
@@ -8,7 +8,7 @@
     <score-part id="id1">
       <part-name>x</part-name>
     </score-part>
-    <part-group type="start">
+    <part-group type="stop">
       <footnote>x</footnote>
       <level>x</level>
     </part-group>

--- a/data/synthetic/degree-alter.3.0.xml
+++ b/data/synthetic/degree-alter.3.0.xml
@@ -8,7 +8,7 @@
     <score-part id="id1">
       <part-name>x</part-name>
     </score-part>
-    <part-group type="start">
+    <part-group type="stop">
       <footnote>x</footnote>
       <level>x</level>
     </part-group>

--- a/data/synthetic/degree-type.3.0.xml
+++ b/data/synthetic/degree-type.3.0.xml
@@ -8,7 +8,7 @@
     <score-part id="id1">
       <part-name>x</part-name>
     </score-part>
-    <part-group type="start">
+    <part-group type="stop">
       <footnote>x</footnote>
       <level>x</level>
     </part-group>

--- a/data/synthetic/degree-value.3.0.xml
+++ b/data/synthetic/degree-value.3.0.xml
@@ -8,7 +8,7 @@
     <score-part id="id1">
       <part-name>x</part-name>
     </score-part>
-    <part-group type="start">
+    <part-group type="stop">
       <footnote>x</footnote>
       <level>x</level>
     </part-group>

--- a/data/synthetic/delayed-inverted-turn.3.0.xml
+++ b/data/synthetic/delayed-inverted-turn.3.0.xml
@@ -8,7 +8,7 @@
     <score-part id="id1">
       <part-name>x</part-name>
     </score-part>
-    <part-group type="start">
+    <part-group type="stop">
       <footnote>x</footnote>
       <level>x</level>
     </part-group>

--- a/data/synthetic/delayed-turn.3.0.xml
+++ b/data/synthetic/delayed-turn.3.0.xml
@@ -8,7 +8,7 @@
     <score-part id="id1">
       <part-name>x</part-name>
     </score-part>
-    <part-group type="start">
+    <part-group type="stop">
       <footnote>x</footnote>
       <level>x</level>
     </part-group>

--- a/data/synthetic/detached-legato.3.0.xml
+++ b/data/synthetic/detached-legato.3.0.xml
@@ -8,7 +8,7 @@
     <score-part id="id1">
       <part-name>x</part-name>
     </score-part>
-    <part-group type="start">
+    <part-group type="stop">
       <footnote>x</footnote>
       <level>x</level>
     </part-group>

--- a/data/synthetic/direction-type.3.1.xml
+++ b/data/synthetic/direction-type.3.1.xml
@@ -8,7 +8,7 @@
     <score-part id="id1">
       <part-name>x</part-name>
     </score-part>
-    <part-group type="start">
+    <part-group type="stop">
       <footnote>x</footnote>
       <level>x</level>
     </part-group>

--- a/data/synthetic/direction.3.1.xml
+++ b/data/synthetic/direction.3.1.xml
@@ -8,7 +8,7 @@
     <score-part id="id1">
       <part-name>x</part-name>
     </score-part>
-    <part-group type="start">
+    <part-group type="stop">
       <footnote>x</footnote>
       <level>x</level>
     </part-group>

--- a/data/synthetic/direction.4.0.xml
+++ b/data/synthetic/direction.4.0.xml
@@ -8,7 +8,7 @@
     <score-part id="id1">
       <part-name>x</part-name>
     </score-part>
-    <part-group type="start">
+    <part-group type="stop">
       <footnote>x</footnote>
       <level>x</level>
     </part-group>

--- a/data/synthetic/directive.3.0.xml
+++ b/data/synthetic/directive.3.0.xml
@@ -8,7 +8,7 @@
     <score-part id="id1">
       <part-name>x</part-name>
     </score-part>
-    <part-group type="start">
+    <part-group type="stop">
       <footnote>x</footnote>
       <level>x</level>
     </part-group>

--- a/data/synthetic/display-text.3.0.xml
+++ b/data/synthetic/display-text.3.0.xml
@@ -11,7 +11,7 @@
     <score-part id="id1">
       <part-name>x</part-name>
     </score-part>
-    <part-group type="start">
+    <part-group type="stop">
       <footnote>x</footnote>
       <level>x</level>
     </part-group>

--- a/data/synthetic/doit.3.0.xml
+++ b/data/synthetic/doit.3.0.xml
@@ -8,7 +8,7 @@
     <score-part id="id1">
       <part-name>x</part-name>
     </score-part>
-    <part-group type="start">
+    <part-group type="stop">
       <footnote>x</footnote>
       <level>x</level>
     </part-group>

--- a/data/synthetic/doit.3.1.xml
+++ b/data/synthetic/doit.3.1.xml
@@ -8,7 +8,7 @@
     <score-part id="id1">
       <part-name>x</part-name>
     </score-part>
-    <part-group type="start">
+    <part-group type="stop">
       <footnote>x</footnote>
       <level>x</level>
     </part-group>

--- a/data/synthetic/dot.3.0.xml
+++ b/data/synthetic/dot.3.0.xml
@@ -8,7 +8,7 @@
     <score-part id="id1">
       <part-name>x</part-name>
     </score-part>
-    <part-group type="start">
+    <part-group type="stop">
       <footnote>x</footnote>
       <level>x</level>
     </part-group>

--- a/data/synthetic/double-tongue.3.0.xml
+++ b/data/synthetic/double-tongue.3.0.xml
@@ -8,7 +8,7 @@
     <score-part id="id1">
       <part-name>x</part-name>
     </score-part>
-    <part-group type="start">
+    <part-group type="stop">
       <footnote>x</footnote>
       <level>x</level>
     </part-group>

--- a/data/synthetic/double.3.0.xml
+++ b/data/synthetic/double.3.0.xml
@@ -8,7 +8,7 @@
     <score-part id="id1">
       <part-name>x</part-name>
     </score-part>
-    <part-group type="start">
+    <part-group type="stop">
       <footnote>x</footnote>
       <level>x</level>
     </part-group>

--- a/data/synthetic/double.4.0.xml
+++ b/data/synthetic/double.4.0.xml
@@ -8,7 +8,7 @@
     <score-part id="id1">
       <part-name>x</part-name>
     </score-part>
-    <part-group type="start">
+    <part-group type="stop">
       <footnote>x</footnote>
       <level>x</level>
     </part-group>

--- a/data/synthetic/down-bow.3.0.xml
+++ b/data/synthetic/down-bow.3.0.xml
@@ -8,7 +8,7 @@
     <score-part id="id1">
       <part-name>x</part-name>
     </score-part>
-    <part-group type="start">
+    <part-group type="stop">
       <footnote>x</footnote>
       <level>x</level>
     </part-group>

--- a/data/synthetic/dynamics.3.1.xml
+++ b/data/synthetic/dynamics.3.1.xml
@@ -8,7 +8,7 @@
     <score-part id="id1">
       <part-name>x</part-name>
     </score-part>
-    <part-group type="start">
+    <part-group type="stop">
       <footnote>x</footnote>
       <level>x</level>
     </part-group>

--- a/data/synthetic/effect.3.0.xml
+++ b/data/synthetic/effect.3.0.xml
@@ -8,7 +8,7 @@
     <score-part id="id1">
       <part-name>x</part-name>
     </score-part>
-    <part-group type="start">
+    <part-group type="stop">
       <footnote>x</footnote>
       <level>x</level>
     </part-group>

--- a/data/synthetic/effect.4.0.xml
+++ b/data/synthetic/effect.4.0.xml
@@ -8,7 +8,7 @@
     <score-part id="id1">
       <part-name>x</part-name>
     </score-part>
-    <part-group type="start">
+    <part-group type="stop">
       <footnote>x</footnote>
       <level>x</level>
     </part-group>

--- a/data/synthetic/elevation.3.0.xml
+++ b/data/synthetic/elevation.3.0.xml
@@ -11,7 +11,7 @@
         <elevation>1</elevation>
       </midi-instrument>
     </score-part>
-    <part-group type="start">
+    <part-group type="stop">
       <footnote>x</footnote>
       <level>x</level>
     </part-group>

--- a/data/synthetic/elision.3.0.xml
+++ b/data/synthetic/elision.3.0.xml
@@ -8,7 +8,7 @@
     <score-part id="id1">
       <part-name>x</part-name>
     </score-part>
-    <part-group type="start">
+    <part-group type="stop">
       <footnote>x</footnote>
       <level>x</level>
     </part-group>

--- a/data/synthetic/elision.3.1.xml
+++ b/data/synthetic/elision.3.1.xml
@@ -8,7 +8,7 @@
     <score-part id="id1">
       <part-name>x</part-name>
     </score-part>
-    <part-group type="start">
+    <part-group type="stop">
       <footnote>x</footnote>
       <level>x</level>
     </part-group>

--- a/data/synthetic/encoder.3.0.xml
+++ b/data/synthetic/encoder.3.0.xml
@@ -13,7 +13,7 @@
     <score-part id="id1">
       <part-name>x</part-name>
     </score-part>
-    <part-group type="start">
+    <part-group type="stop">
       <footnote>x</footnote>
       <level>x</level>
     </part-group>

--- a/data/synthetic/encoding-description.3.0.xml
+++ b/data/synthetic/encoding-description.3.0.xml
@@ -13,7 +13,7 @@
     <score-part id="id1">
       <part-name>x</part-name>
     </score-part>
-    <part-group type="start">
+    <part-group type="stop">
       <footnote>x</footnote>
       <level>x</level>
     </part-group>

--- a/data/synthetic/ending.3.0.xml
+++ b/data/synthetic/ending.3.0.xml
@@ -8,7 +8,7 @@
     <score-part id="id1">
       <part-name>x</part-name>
     </score-part>
-    <part-group type="start">
+    <part-group type="stop">
       <footnote>x</footnote>
       <level>x</level>
     </part-group>

--- a/data/synthetic/ending.4.0.xml
+++ b/data/synthetic/ending.4.0.xml
@@ -8,7 +8,7 @@
     <score-part id="id1">
       <part-name>x</part-name>
     </score-part>
-    <part-group type="start">
+    <part-group type="stop">
       <footnote>x</footnote>
       <level>x</level>
     </part-group>

--- a/data/synthetic/except-voice.3.1.xml
+++ b/data/synthetic/except-voice.3.1.xml
@@ -8,7 +8,7 @@
     <score-part id="id1">
       <part-name>x</part-name>
     </score-part>
-    <part-group type="start">
+    <part-group type="stop">
       <footnote>x</footnote>
       <level>x</level>
     </part-group>

--- a/data/synthetic/extend.3.0.xml
+++ b/data/synthetic/extend.3.0.xml
@@ -8,7 +8,7 @@
     <score-part id="id1">
       <part-name>x</part-name>
     </score-part>
-    <part-group type="start">
+    <part-group type="stop">
       <footnote>x</footnote>
       <level>x</level>
     </part-group>

--- a/data/synthetic/eyeglasses.3.0.xml
+++ b/data/synthetic/eyeglasses.3.0.xml
@@ -8,7 +8,7 @@
     <score-part id="id1">
       <part-name>x</part-name>
     </score-part>
-    <part-group type="start">
+    <part-group type="stop">
       <footnote>x</footnote>
       <level>x</level>
     </part-group>

--- a/data/synthetic/eyeglasses.3.1.xml
+++ b/data/synthetic/eyeglasses.3.1.xml
@@ -8,7 +8,7 @@
     <score-part id="id1">
       <part-name>x</part-name>
     </score-part>
-    <part-group type="start">
+    <part-group type="stop">
       <footnote>x</footnote>
       <level>x</level>
     </part-group>

--- a/data/synthetic/falloff.3.0.xml
+++ b/data/synthetic/falloff.3.0.xml
@@ -8,7 +8,7 @@
     <score-part id="id1">
       <part-name>x</part-name>
     </score-part>
-    <part-group type="start">
+    <part-group type="stop">
       <footnote>x</footnote>
       <level>x</level>
     </part-group>

--- a/data/synthetic/falloff.3.1.xml
+++ b/data/synthetic/falloff.3.1.xml
@@ -8,7 +8,7 @@
     <score-part id="id1">
       <part-name>x</part-name>
     </score-part>
-    <part-group type="start">
+    <part-group type="stop">
       <footnote>x</footnote>
       <level>x</level>
     </part-group>

--- a/data/synthetic/feature.3.0.xml
+++ b/data/synthetic/feature.3.0.xml
@@ -8,7 +8,7 @@
     <score-part id="id1">
       <part-name>x</part-name>
     </score-part>
-    <part-group type="start">
+    <part-group type="stop">
       <footnote>x</footnote>
       <level>x</level>
     </part-group>

--- a/data/synthetic/fermata.3.1.xml
+++ b/data/synthetic/fermata.3.1.xml
@@ -8,7 +8,7 @@
     <score-part id="id1">
       <part-name>x</part-name>
     </score-part>
-    <part-group type="start">
+    <part-group type="stop">
       <footnote>x</footnote>
       <level>x</level>
     </part-group>

--- a/data/synthetic/figure-number.3.0.xml
+++ b/data/synthetic/figure-number.3.0.xml
@@ -8,7 +8,7 @@
     <score-part id="id1">
       <part-name>x</part-name>
     </score-part>
-    <part-group type="start">
+    <part-group type="stop">
       <footnote>x</footnote>
       <level>x</level>
     </part-group>

--- a/data/synthetic/figured-bass.3.0.xml
+++ b/data/synthetic/figured-bass.3.0.xml
@@ -8,7 +8,7 @@
     <score-part id="id1">
       <part-name>x</part-name>
     </score-part>
-    <part-group type="start">
+    <part-group type="stop">
       <footnote>x</footnote>
       <level>x</level>
     </part-group>

--- a/data/synthetic/figured-bass.3.1.xml
+++ b/data/synthetic/figured-bass.3.1.xml
@@ -8,7 +8,7 @@
     <score-part id="id1">
       <part-name>x</part-name>
     </score-part>
-    <part-group type="start">
+    <part-group type="stop">
       <footnote>x</footnote>
       <level>x</level>
     </part-group>

--- a/data/synthetic/figured-bass.4.0.xml
+++ b/data/synthetic/figured-bass.4.0.xml
@@ -8,7 +8,7 @@
     <score-part id="id1">
       <part-name>x</part-name>
     </score-part>
-    <part-group type="start">
+    <part-group type="stop">
       <footnote>x</footnote>
       <level>x</level>
     </part-group>

--- a/data/synthetic/fingering.3.0.xml
+++ b/data/synthetic/fingering.3.0.xml
@@ -8,7 +8,7 @@
     <score-part id="id1">
       <part-name>x</part-name>
     </score-part>
-    <part-group type="start">
+    <part-group type="stop">
       <footnote>x</footnote>
       <level>x</level>
     </part-group>

--- a/data/synthetic/fingernails.3.0.xml
+++ b/data/synthetic/fingernails.3.0.xml
@@ -8,7 +8,7 @@
     <score-part id="id1">
       <part-name>x</part-name>
     </score-part>
-    <part-group type="start">
+    <part-group type="stop">
       <footnote>x</footnote>
       <level>x</level>
     </part-group>

--- a/data/synthetic/first-fret.3.0.xml
+++ b/data/synthetic/first-fret.3.0.xml
@@ -8,7 +8,7 @@
     <score-part id="id1">
       <part-name>x</part-name>
     </score-part>
-    <part-group type="start">
+    <part-group type="stop">
       <footnote>x</footnote>
       <level>x</level>
     </part-group>

--- a/data/synthetic/first.4.0.xml
+++ b/data/synthetic/first.4.0.xml
@@ -8,7 +8,7 @@
     <score-part id="id1">
       <part-name>x</part-name>
     </score-part>
-    <part-group type="start">
+    <part-group type="stop">
       <footnote>x</footnote>
       <level>x</level>
     </part-group>

--- a/data/synthetic/flip.3.1.xml
+++ b/data/synthetic/flip.3.1.xml
@@ -8,7 +8,7 @@
     <score-part id="id1">
       <part-name>x</part-name>
     </score-part>
-    <part-group type="start">
+    <part-group type="stop">
       <footnote>x</footnote>
       <level>x</level>
     </part-group>

--- a/data/synthetic/footnote.3.0.xml
+++ b/data/synthetic/footnote.3.0.xml
@@ -8,7 +8,7 @@
     <score-part id="id1">
       <part-name>x</part-name>
     </score-part>
-    <part-group type="start">
+    <part-group type="stop">
       <footnote>x</footnote>
       <level>x</level>
     </part-group>

--- a/data/synthetic/for-part.4.0.xml
+++ b/data/synthetic/for-part.4.0.xml
@@ -8,7 +8,7 @@
     <score-part id="id1">
       <part-name>x</part-name>
     </score-part>
-    <part-group type="start">
+    <part-group type="stop">
       <footnote>x</footnote>
       <level>x</level>
     </part-group>

--- a/data/synthetic/frame.3.0.xml
+++ b/data/synthetic/frame.3.0.xml
@@ -8,7 +8,7 @@
     <score-part id="id1">
       <part-name>x</part-name>
     </score-part>
-    <part-group type="start">
+    <part-group type="stop">
       <footnote>x</footnote>
       <level>x</level>
     </part-group>

--- a/data/synthetic/frame.3.1.xml
+++ b/data/synthetic/frame.3.1.xml
@@ -8,7 +8,7 @@
     <score-part id="id1">
       <part-name>x</part-name>
     </score-part>
-    <part-group type="start">
+    <part-group type="stop">
       <footnote>x</footnote>
       <level>x</level>
     </part-group>

--- a/data/synthetic/fret.3.0.xml
+++ b/data/synthetic/fret.3.0.xml
@@ -8,7 +8,7 @@
     <score-part id="id1">
       <part-name>x</part-name>
     </score-part>
-    <part-group type="start">
+    <part-group type="stop">
       <footnote>x</footnote>
       <level>x</level>
     </part-group>

--- a/data/synthetic/function.3.0.xml
+++ b/data/synthetic/function.3.0.xml
@@ -8,7 +8,7 @@
     <score-part id="id1">
       <part-name>x</part-name>
     </score-part>
-    <part-group type="start">
+    <part-group type="stop">
       <footnote>x</footnote>
       <level>x</level>
     </part-group>

--- a/data/synthetic/glass.3.0.xml
+++ b/data/synthetic/glass.3.0.xml
@@ -8,7 +8,7 @@
     <score-part id="id1">
       <part-name>x</part-name>
     </score-part>
-    <part-group type="start">
+    <part-group type="stop">
       <footnote>x</footnote>
       <level>x</level>
     </part-group>

--- a/data/synthetic/glass.3.1.xml
+++ b/data/synthetic/glass.3.1.xml
@@ -8,7 +8,7 @@
     <score-part id="id1">
       <part-name>x</part-name>
     </score-part>
-    <part-group type="start">
+    <part-group type="stop">
       <footnote>x</footnote>
       <level>x</level>
     </part-group>

--- a/data/synthetic/glissando.3.0.xml
+++ b/data/synthetic/glissando.3.0.xml
@@ -8,7 +8,7 @@
     <score-part id="id1">
       <part-name>x</part-name>
     </score-part>
-    <part-group type="start">
+    <part-group type="stop">
       <footnote>x</footnote>
       <level>x</level>
     </part-group>

--- a/data/synthetic/glissando.3.1.xml
+++ b/data/synthetic/glissando.3.1.xml
@@ -8,7 +8,7 @@
     <score-part id="id1">
       <part-name>x</part-name>
     </score-part>
-    <part-group type="start">
+    <part-group type="stop">
       <footnote>x</footnote>
       <level>x</level>
     </part-group>

--- a/data/synthetic/glyph.3.1.xml
+++ b/data/synthetic/glyph.3.1.xml
@@ -13,7 +13,7 @@
     <score-part id="id1">
       <part-name>x</part-name>
     </score-part>
-    <part-group type="start">
+    <part-group type="stop">
       <footnote>x</footnote>
       <level>x</level>
     </part-group>

--- a/data/synthetic/golpe.3.1.xml
+++ b/data/synthetic/golpe.3.1.xml
@@ -8,7 +8,7 @@
     <score-part id="id1">
       <part-name>x</part-name>
     </score-part>
-    <part-group type="start">
+    <part-group type="stop">
       <footnote>x</footnote>
       <level>x</level>
     </part-group>

--- a/data/synthetic/grace.3.0.xml
+++ b/data/synthetic/grace.3.0.xml
@@ -8,7 +8,7 @@
     <score-part id="id1">
       <part-name>x</part-name>
     </score-part>
-    <part-group type="start">
+    <part-group type="stop">
       <footnote>x</footnote>
       <level>x</level>
     </part-group>

--- a/data/synthetic/group-abbreviation-display.3.0.xml
+++ b/data/synthetic/group-abbreviation-display.3.0.xml
@@ -11,7 +11,7 @@
     <score-part id="id1">
       <part-name>x</part-name>
     </score-part>
-    <part-group type="start">
+    <part-group type="stop">
       <footnote>x</footnote>
       <level>x</level>
     </part-group>

--- a/data/synthetic/group-abbreviation.3.0.xml
+++ b/data/synthetic/group-abbreviation.3.0.xml
@@ -9,7 +9,7 @@
     <score-part id="id1">
       <part-name>x</part-name>
     </score-part>
-    <part-group type="start">
+    <part-group type="stop">
       <footnote>x</footnote>
       <level>x</level>
     </part-group>

--- a/data/synthetic/group-barline.3.0.xml
+++ b/data/synthetic/group-barline.3.0.xml
@@ -9,7 +9,7 @@
     <score-part id="id1">
       <part-name>x</part-name>
     </score-part>
-    <part-group type="start">
+    <part-group type="stop">
       <footnote>x</footnote>
       <level>x</level>
     </part-group>

--- a/data/synthetic/group-link.4.0.xml
+++ b/data/synthetic/group-link.4.0.xml
@@ -11,7 +11,7 @@
       </part-link>
       <part-name>x</part-name>
     </score-part>
-    <part-group type="start">
+    <part-group type="stop">
       <footnote>x</footnote>
       <level>x</level>
     </part-group>

--- a/data/synthetic/group-name-display.3.0.xml
+++ b/data/synthetic/group-name-display.3.0.xml
@@ -11,7 +11,7 @@
     <score-part id="id1">
       <part-name>x</part-name>
     </score-part>
-    <part-group type="start">
+    <part-group type="stop">
       <footnote>x</footnote>
       <level>x</level>
     </part-group>

--- a/data/synthetic/group-name.3.0.xml
+++ b/data/synthetic/group-name.3.0.xml
@@ -9,7 +9,7 @@
     <score-part id="id1">
       <part-name>x</part-name>
     </score-part>
-    <part-group type="start">
+    <part-group type="stop">
       <footnote>x</footnote>
       <level>x</level>
     </part-group>

--- a/data/synthetic/group-symbol.3.0.xml
+++ b/data/synthetic/group-symbol.3.0.xml
@@ -9,7 +9,7 @@
     <score-part id="id1">
       <part-name>x</part-name>
     </score-part>
-    <part-group type="start">
+    <part-group type="stop">
       <footnote>x</footnote>
       <level>x</level>
     </part-group>

--- a/data/synthetic/group-time.3.0.xml
+++ b/data/synthetic/group-time.3.0.xml
@@ -9,7 +9,7 @@
     <score-part id="id1">
       <part-name>x</part-name>
     </score-part>
-    <part-group type="start">
+    <part-group type="stop">
       <footnote>x</footnote>
       <level>x</level>
     </part-group>

--- a/data/synthetic/group.3.0.xml
+++ b/data/synthetic/group.3.0.xml
@@ -9,7 +9,7 @@
       <part-name>x</part-name>
       <group>1</group>
     </score-part>
-    <part-group type="start">
+    <part-group type="stop">
       <footnote>x</footnote>
       <level>x</level>
     </part-group>

--- a/data/synthetic/grouping.3.0.xml
+++ b/data/synthetic/grouping.3.0.xml
@@ -8,7 +8,7 @@
     <score-part id="id1">
       <part-name>x</part-name>
     </score-part>
-    <part-group type="start">
+    <part-group type="stop">
       <footnote>x</footnote>
       <level>x</level>
     </part-group>

--- a/data/synthetic/grouping.3.1.xml
+++ b/data/synthetic/grouping.3.1.xml
@@ -8,7 +8,7 @@
     <score-part id="id1">
       <part-name>x</part-name>
     </score-part>
-    <part-group type="start">
+    <part-group type="stop">
       <footnote>x</footnote>
       <level>x</level>
     </part-group>

--- a/data/synthetic/half-muted.3.1.xml
+++ b/data/synthetic/half-muted.3.1.xml
@@ -8,7 +8,7 @@
     <score-part id="id1">
       <part-name>x</part-name>
     </score-part>
-    <part-group type="start">
+    <part-group type="stop">
       <footnote>x</footnote>
       <level>x</level>
     </part-group>

--- a/data/synthetic/hammer-on.3.0.xml
+++ b/data/synthetic/hammer-on.3.0.xml
@@ -8,7 +8,7 @@
     <score-part id="id1">
       <part-name>x</part-name>
     </score-part>
-    <part-group type="start">
+    <part-group type="stop">
       <footnote>x</footnote>
       <level>x</level>
     </part-group>

--- a/data/synthetic/handbell.3.0.xml
+++ b/data/synthetic/handbell.3.0.xml
@@ -8,7 +8,7 @@
     <score-part id="id1">
       <part-name>x</part-name>
     </score-part>
-    <part-group type="start">
+    <part-group type="stop">
       <footnote>x</footnote>
       <level>x</level>
     </part-group>

--- a/data/synthetic/harmon-closed.3.1.xml
+++ b/data/synthetic/harmon-closed.3.1.xml
@@ -8,7 +8,7 @@
     <score-part id="id1">
       <part-name>x</part-name>
     </score-part>
-    <part-group type="start">
+    <part-group type="stop">
       <footnote>x</footnote>
       <level>x</level>
     </part-group>

--- a/data/synthetic/harmon-mute.3.1.xml
+++ b/data/synthetic/harmon-mute.3.1.xml
@@ -8,7 +8,7 @@
     <score-part id="id1">
       <part-name>x</part-name>
     </score-part>
-    <part-group type="start">
+    <part-group type="stop">
       <footnote>x</footnote>
       <level>x</level>
     </part-group>

--- a/data/synthetic/harmonic.3.0.xml
+++ b/data/synthetic/harmonic.3.0.xml
@@ -8,7 +8,7 @@
     <score-part id="id1">
       <part-name>x</part-name>
     </score-part>
-    <part-group type="start">
+    <part-group type="stop">
       <footnote>x</footnote>
       <level>x</level>
     </part-group>

--- a/data/synthetic/harmony.3.0.xml
+++ b/data/synthetic/harmony.3.0.xml
@@ -8,7 +8,7 @@
     <score-part id="id1">
       <part-name>x</part-name>
     </score-part>
-    <part-group type="start">
+    <part-group type="stop">
       <footnote>x</footnote>
       <level>x</level>
     </part-group>

--- a/data/synthetic/harmony.3.1.xml
+++ b/data/synthetic/harmony.3.1.xml
@@ -8,7 +8,7 @@
     <score-part id="id1">
       <part-name>x</part-name>
     </score-part>
-    <part-group type="start">
+    <part-group type="stop">
       <footnote>x</footnote>
       <level>x</level>
     </part-group>

--- a/data/synthetic/harmony.4.0.xml
+++ b/data/synthetic/harmony.4.0.xml
@@ -8,7 +8,7 @@
     <score-part id="id1">
       <part-name>x</part-name>
     </score-part>
-    <part-group type="start">
+    <part-group type="stop">
       <footnote>x</footnote>
       <level>x</level>
     </part-group>

--- a/data/synthetic/harp-pedals.3.0.xml
+++ b/data/synthetic/harp-pedals.3.0.xml
@@ -8,7 +8,7 @@
     <score-part id="id1">
       <part-name>x</part-name>
     </score-part>
-    <part-group type="start">
+    <part-group type="stop">
       <footnote>x</footnote>
       <level>x</level>
     </part-group>

--- a/data/synthetic/harp-pedals.3.1.xml
+++ b/data/synthetic/harp-pedals.3.1.xml
@@ -8,7 +8,7 @@
     <score-part id="id1">
       <part-name>x</part-name>
     </score-part>
-    <part-group type="start">
+    <part-group type="stop">
       <footnote>x</footnote>
       <level>x</level>
     </part-group>

--- a/data/synthetic/haydn.3.1.xml
+++ b/data/synthetic/haydn.3.1.xml
@@ -8,7 +8,7 @@
     <score-part id="id1">
       <part-name>x</part-name>
     </score-part>
-    <part-group type="start">
+    <part-group type="stop">
       <footnote>x</footnote>
       <level>x</level>
     </part-group>

--- a/data/synthetic/heel.3.0.xml
+++ b/data/synthetic/heel.3.0.xml
@@ -8,7 +8,7 @@
     <score-part id="id1">
       <part-name>x</part-name>
     </score-part>
-    <part-group type="start">
+    <part-group type="stop">
       <footnote>x</footnote>
       <level>x</level>
     </part-group>

--- a/data/synthetic/hole-closed.3.0.xml
+++ b/data/synthetic/hole-closed.3.0.xml
@@ -8,7 +8,7 @@
     <score-part id="id1">
       <part-name>x</part-name>
     </score-part>
-    <part-group type="start">
+    <part-group type="stop">
       <footnote>x</footnote>
       <level>x</level>
     </part-group>

--- a/data/synthetic/hole-shape.3.0.xml
+++ b/data/synthetic/hole-shape.3.0.xml
@@ -8,7 +8,7 @@
     <score-part id="id1">
       <part-name>x</part-name>
     </score-part>
-    <part-group type="start">
+    <part-group type="stop">
       <footnote>x</footnote>
       <level>x</level>
     </part-group>

--- a/data/synthetic/hole-type.3.0.xml
+++ b/data/synthetic/hole-type.3.0.xml
@@ -8,7 +8,7 @@
     <score-part id="id1">
       <part-name>x</part-name>
     </score-part>
-    <part-group type="start">
+    <part-group type="stop">
       <footnote>x</footnote>
       <level>x</level>
     </part-group>

--- a/data/synthetic/hole.3.0.xml
+++ b/data/synthetic/hole.3.0.xml
@@ -8,7 +8,7 @@
     <score-part id="id1">
       <part-name>x</part-name>
     </score-part>
-    <part-group type="start">
+    <part-group type="stop">
       <footnote>x</footnote>
       <level>x</level>
     </part-group>

--- a/data/synthetic/humming.3.0.xml
+++ b/data/synthetic/humming.3.0.xml
@@ -8,7 +8,7 @@
     <score-part id="id1">
       <part-name>x</part-name>
     </score-part>
-    <part-group type="start">
+    <part-group type="stop">
       <footnote>x</footnote>
       <level>x</level>
     </part-group>

--- a/data/synthetic/image.3.0.xml
+++ b/data/synthetic/image.3.0.xml
@@ -8,7 +8,7 @@
     <score-part id="id1">
       <part-name>x</part-name>
     </score-part>
-    <part-group type="start">
+    <part-group type="stop">
       <footnote>x</footnote>
       <level>x</level>
     </part-group>

--- a/data/synthetic/image.3.1.xml
+++ b/data/synthetic/image.3.1.xml
@@ -8,7 +8,7 @@
     <score-part id="id1">
       <part-name>x</part-name>
     </score-part>
-    <part-group type="start">
+    <part-group type="stop">
       <footnote>x</footnote>
       <level>x</level>
     </part-group>

--- a/data/synthetic/instrument-abbreviation.3.0.xml
+++ b/data/synthetic/instrument-abbreviation.3.0.xml
@@ -13,7 +13,7 @@
         <solo />
       </score-instrument>
     </score-part>
-    <part-group type="start">
+    <part-group type="stop">
       <footnote>x</footnote>
       <level>x</level>
     </part-group>

--- a/data/synthetic/instrument-change.4.0.xml
+++ b/data/synthetic/instrument-change.4.0.xml
@@ -8,7 +8,7 @@
     <score-part id="id1">
       <part-name>x</part-name>
     </score-part>
-    <part-group type="start">
+    <part-group type="stop">
       <footnote>x</footnote>
       <level>x</level>
     </part-group>

--- a/data/synthetic/instrument-link.4.0.xml
+++ b/data/synthetic/instrument-link.4.0.xml
@@ -11,7 +11,7 @@
       </part-link>
       <part-name>x</part-name>
     </score-part>
-    <part-group type="start">
+    <part-group type="stop">
       <footnote>x</footnote>
       <level>x</level>
     </part-group>

--- a/data/synthetic/instrument-name.3.0.xml
+++ b/data/synthetic/instrument-name.3.0.xml
@@ -12,7 +12,7 @@
         <solo />
       </score-instrument>
     </score-part>
-    <part-group type="start">
+    <part-group type="stop">
       <footnote>x</footnote>
       <level>x</level>
     </part-group>

--- a/data/synthetic/instrument-sound-enum.3.0.xml
+++ b/data/synthetic/instrument-sound-enum.3.0.xml
@@ -13,7 +13,7 @@
         <solo />
       </score-instrument>
     </score-part>
-    <part-group type="start">
+    <part-group type="stop">
       <footnote>x</footnote>
       <level>x</level>
     </part-group>

--- a/data/synthetic/instrument-sound.3.0.xml
+++ b/data/synthetic/instrument-sound.3.0.xml
@@ -13,7 +13,7 @@
         <solo />
       </score-instrument>
     </score-part>
-    <part-group type="start">
+    <part-group type="stop">
       <footnote>x</footnote>
       <level>x</level>
     </part-group>

--- a/data/synthetic/interchangeable.3.0.xml
+++ b/data/synthetic/interchangeable.3.0.xml
@@ -8,7 +8,7 @@
     <score-part id="id1">
       <part-name>x</part-name>
     </score-part>
-    <part-group type="start">
+    <part-group type="stop">
       <footnote>x</footnote>
       <level>x</level>
     </part-group>

--- a/data/synthetic/inversion.3.0.xml
+++ b/data/synthetic/inversion.3.0.xml
@@ -8,7 +8,7 @@
     <score-part id="id1">
       <part-name>x</part-name>
     </score-part>
-    <part-group type="start">
+    <part-group type="stop">
       <footnote>x</footnote>
       <level>x</level>
     </part-group>

--- a/data/synthetic/inversion.4.0.xml
+++ b/data/synthetic/inversion.4.0.xml
@@ -8,7 +8,7 @@
     <score-part id="id1">
       <part-name>x</part-name>
     </score-part>
-    <part-group type="start">
+    <part-group type="stop">
       <footnote>x</footnote>
       <level>x</level>
     </part-group>

--- a/data/synthetic/inverted-mordent.3.0.xml
+++ b/data/synthetic/inverted-mordent.3.0.xml
@@ -8,7 +8,7 @@
     <score-part id="id1">
       <part-name>x</part-name>
     </score-part>
-    <part-group type="start">
+    <part-group type="stop">
       <footnote>x</footnote>
       <level>x</level>
     </part-group>

--- a/data/synthetic/inverted-turn.3.0.xml
+++ b/data/synthetic/inverted-turn.3.0.xml
@@ -8,7 +8,7 @@
     <score-part id="id1">
       <part-name>x</part-name>
     </score-part>
-    <part-group type="start">
+    <part-group type="stop">
       <footnote>x</footnote>
       <level>x</level>
     </part-group>

--- a/data/synthetic/inverted-vertical-turn.3.1.xml
+++ b/data/synthetic/inverted-vertical-turn.3.1.xml
@@ -8,7 +8,7 @@
     <score-part id="id1">
       <part-name>x</part-name>
     </score-part>
-    <part-group type="start">
+    <part-group type="stop">
       <footnote>x</footnote>
       <level>x</level>
     </part-group>

--- a/data/synthetic/ipa.3.0.xml
+++ b/data/synthetic/ipa.3.0.xml
@@ -8,7 +8,7 @@
     <score-part id="id1">
       <part-name>x</part-name>
     </score-part>
-    <part-group type="start">
+    <part-group type="stop">
       <footnote>x</footnote>
       <level>x</level>
     </part-group>

--- a/data/synthetic/key-octave.3.0.xml
+++ b/data/synthetic/key-octave.3.0.xml
@@ -8,7 +8,7 @@
     <score-part id="id1">
       <part-name>x</part-name>
     </score-part>
-    <part-group type="start">
+    <part-group type="stop">
       <footnote>x</footnote>
       <level>x</level>
     </part-group>

--- a/data/synthetic/key.3.0.xml
+++ b/data/synthetic/key.3.0.xml
@@ -8,7 +8,7 @@
     <score-part id="id1">
       <part-name>x</part-name>
     </score-part>
-    <part-group type="start">
+    <part-group type="stop">
       <footnote>x</footnote>
       <level>x</level>
     </part-group>

--- a/data/synthetic/key.3.1.xml
+++ b/data/synthetic/key.3.1.xml
@@ -8,7 +8,7 @@
     <score-part id="id1">
       <part-name>x</part-name>
     </score-part>
-    <part-group type="start">
+    <part-group type="stop">
       <footnote>x</footnote>
       <level>x</level>
     </part-group>

--- a/data/synthetic/kind.3.0.xml
+++ b/data/synthetic/kind.3.0.xml
@@ -8,7 +8,7 @@
     <score-part id="id1">
       <part-name>x</part-name>
     </score-part>
-    <part-group type="start">
+    <part-group type="stop">
       <footnote>x</footnote>
       <level>x</level>
     </part-group>

--- a/data/synthetic/laughing.3.0.xml
+++ b/data/synthetic/laughing.3.0.xml
@@ -8,7 +8,7 @@
     <score-part id="id1">
       <part-name>x</part-name>
     </score-part>
-    <part-group type="start">
+    <part-group type="stop">
       <footnote>x</footnote>
       <level>x</level>
     </part-group>

--- a/data/synthetic/left-divider.3.0.xml
+++ b/data/synthetic/left-divider.3.0.xml
@@ -16,7 +16,7 @@
     <score-part id="id1">
       <part-name>x</part-name>
     </score-part>
-    <part-group type="start">
+    <part-group type="stop">
       <footnote>x</footnote>
       <level>x</level>
     </part-group>

--- a/data/synthetic/level.3.0.xml
+++ b/data/synthetic/level.3.0.xml
@@ -8,7 +8,7 @@
     <score-part id="id1">
       <part-name>x</part-name>
     </score-part>
-    <part-group type="start">
+    <part-group type="stop">
       <footnote>x</footnote>
       <level>x</level>
     </part-group>

--- a/data/synthetic/level.4.0.xml
+++ b/data/synthetic/level.4.0.xml
@@ -8,7 +8,7 @@
     <score-part id="id1">
       <part-name>x</part-name>
     </score-part>
-    <part-group type="start">
+    <part-group type="stop">
       <footnote>x</footnote>
       <level>x</level>
     </part-group>

--- a/data/synthetic/line-detail.4.0.xml
+++ b/data/synthetic/line-detail.4.0.xml
@@ -8,7 +8,7 @@
     <score-part id="id1">
       <part-name>x</part-name>
     </score-part>
-    <part-group type="start">
+    <part-group type="stop">
       <footnote>x</footnote>
       <level>x</level>
     </part-group>

--- a/data/synthetic/link.3.0.xml
+++ b/data/synthetic/link.3.0.xml
@@ -12,7 +12,7 @@
     <score-part id="id1">
       <part-name>x</part-name>
     </score-part>
-    <part-group type="start">
+    <part-group type="stop">
       <footnote>x</footnote>
       <level>x</level>
     </part-group>

--- a/data/synthetic/listen.4.0.xml
+++ b/data/synthetic/listen.4.0.xml
@@ -8,7 +8,7 @@
     <score-part id="id1">
       <part-name>x</part-name>
     </score-part>
-    <part-group type="start">
+    <part-group type="stop">
       <footnote>x</footnote>
       <level>x</level>
     </part-group>

--- a/data/synthetic/listening.4.0.xml
+++ b/data/synthetic/listening.4.0.xml
@@ -8,7 +8,7 @@
     <score-part id="id1">
       <part-name>x</part-name>
     </score-part>
-    <part-group type="start">
+    <part-group type="stop">
       <footnote>x</footnote>
       <level>x</level>
     </part-group>

--- a/data/synthetic/lyric-font.3.0.xml
+++ b/data/synthetic/lyric-font.3.0.xml
@@ -11,7 +11,7 @@
     <score-part id="id1">
       <part-name>x</part-name>
     </score-part>
-    <part-group type="start">
+    <part-group type="stop">
       <footnote>x</footnote>
       <level>x</level>
     </part-group>

--- a/data/synthetic/lyric-language.3.0.xml
+++ b/data/synthetic/lyric-language.3.0.xml
@@ -11,7 +11,7 @@
     <score-part id="id1">
       <part-name>x</part-name>
     </score-part>
-    <part-group type="start">
+    <part-group type="stop">
       <footnote>x</footnote>
       <level>x</level>
     </part-group>

--- a/data/synthetic/lyric.3.0.xml
+++ b/data/synthetic/lyric.3.0.xml
@@ -8,7 +8,7 @@
     <score-part id="id1">
       <part-name>x</part-name>
     </score-part>
-    <part-group type="start">
+    <part-group type="stop">
       <footnote>x</footnote>
       <level>x</level>
     </part-group>

--- a/data/synthetic/lyric.3.1.xml
+++ b/data/synthetic/lyric.3.1.xml
@@ -8,7 +8,7 @@
     <score-part id="id1">
       <part-name>x</part-name>
     </score-part>
-    <part-group type="start">
+    <part-group type="stop">
       <footnote>x</footnote>
       <level>x</level>
     </part-group>

--- a/data/synthetic/measure-distance.3.0.xml
+++ b/data/synthetic/measure-distance.3.0.xml
@@ -8,7 +8,7 @@
     <score-part id="id1">
       <part-name>x</part-name>
     </score-part>
-    <part-group type="start">
+    <part-group type="stop">
       <footnote>x</footnote>
       <level>x</level>
     </part-group>

--- a/data/synthetic/measure-layout.3.0.xml
+++ b/data/synthetic/measure-layout.3.0.xml
@@ -8,7 +8,7 @@
     <score-part id="id1">
       <part-name>x</part-name>
     </score-part>
-    <part-group type="start">
+    <part-group type="stop">
       <footnote>x</footnote>
       <level>x</level>
     </part-group>

--- a/data/synthetic/measure-numbering.3.0.xml
+++ b/data/synthetic/measure-numbering.3.0.xml
@@ -8,7 +8,7 @@
     <score-part id="id1">
       <part-name>x</part-name>
     </score-part>
-    <part-group type="start">
+    <part-group type="stop">
       <footnote>x</footnote>
       <level>x</level>
     </part-group>

--- a/data/synthetic/measure-numbering.4.0.xml
+++ b/data/synthetic/measure-numbering.4.0.xml
@@ -8,7 +8,7 @@
     <score-part id="id1">
       <part-name>x</part-name>
     </score-part>
-    <part-group type="start">
+    <part-group type="stop">
       <footnote>x</footnote>
       <level>x</level>
     </part-group>

--- a/data/synthetic/measure-repeat.3.0.xml
+++ b/data/synthetic/measure-repeat.3.0.xml
@@ -8,7 +8,7 @@
     <score-part id="id1">
       <part-name>x</part-name>
     </score-part>
-    <part-group type="start">
+    <part-group type="stop">
       <footnote>x</footnote>
       <level>x</level>
     </part-group>

--- a/data/synthetic/measure-style.3.0.xml
+++ b/data/synthetic/measure-style.3.0.xml
@@ -8,7 +8,7 @@
     <score-part id="id1">
       <part-name>x</part-name>
     </score-part>
-    <part-group type="start">
+    <part-group type="stop">
       <footnote>x</footnote>
       <level>x</level>
     </part-group>

--- a/data/synthetic/measure-style.3.1.xml
+++ b/data/synthetic/measure-style.3.1.xml
@@ -8,7 +8,7 @@
     <score-part id="id1">
       <part-name>x</part-name>
     </score-part>
-    <part-group type="start">
+    <part-group type="stop">
       <footnote>x</footnote>
       <level>x</level>
     </part-group>

--- a/data/synthetic/measure.3.0.xml
+++ b/data/synthetic/measure.3.0.xml
@@ -8,7 +8,7 @@
     <score-part id="id1">
       <part-name>x</part-name>
     </score-part>
-    <part-group type="start">
+    <part-group type="stop">
       <footnote>x</footnote>
       <level>x</level>
     </part-group>

--- a/data/synthetic/measure.3.1.xml
+++ b/data/synthetic/measure.3.1.xml
@@ -8,7 +8,7 @@
     <score-part id="id1">
       <part-name>x</part-name>
     </score-part>
-    <part-group type="start">
+    <part-group type="stop">
       <footnote>x</footnote>
       <level>x</level>
     </part-group>

--- a/data/synthetic/membrane.3.0.xml
+++ b/data/synthetic/membrane.3.0.xml
@@ -8,7 +8,7 @@
     <score-part id="id1">
       <part-name>x</part-name>
     </score-part>
-    <part-group type="start">
+    <part-group type="stop">
       <footnote>x</footnote>
       <level>x</level>
     </part-group>

--- a/data/synthetic/membrane.4.0.xml
+++ b/data/synthetic/membrane.4.0.xml
@@ -8,7 +8,7 @@
     <score-part id="id1">
       <part-name>x</part-name>
     </score-part>
-    <part-group type="start">
+    <part-group type="stop">
       <footnote>x</footnote>
       <level>x</level>
     </part-group>

--- a/data/synthetic/metal.3.0.xml
+++ b/data/synthetic/metal.3.0.xml
@@ -8,7 +8,7 @@
     <score-part id="id1">
       <part-name>x</part-name>
     </score-part>
-    <part-group type="start">
+    <part-group type="stop">
       <footnote>x</footnote>
       <level>x</level>
     </part-group>

--- a/data/synthetic/metal.4.0.xml
+++ b/data/synthetic/metal.4.0.xml
@@ -8,7 +8,7 @@
     <score-part id="id1">
       <part-name>x</part-name>
     </score-part>
-    <part-group type="start">
+    <part-group type="stop">
       <footnote>x</footnote>
       <level>x</level>
     </part-group>

--- a/data/synthetic/metronome-arrows.3.1.xml
+++ b/data/synthetic/metronome-arrows.3.1.xml
@@ -8,7 +8,7 @@
     <score-part id="id1">
       <part-name>x</part-name>
     </score-part>
-    <part-group type="start">
+    <part-group type="stop">
       <footnote>x</footnote>
       <level>x</level>
     </part-group>

--- a/data/synthetic/metronome-beam.3.0.xml
+++ b/data/synthetic/metronome-beam.3.0.xml
@@ -8,7 +8,7 @@
     <score-part id="id1">
       <part-name>x</part-name>
     </score-part>
-    <part-group type="start">
+    <part-group type="stop">
       <footnote>x</footnote>
       <level>x</level>
     </part-group>

--- a/data/synthetic/metronome-dot.3.0.xml
+++ b/data/synthetic/metronome-dot.3.0.xml
@@ -8,7 +8,7 @@
     <score-part id="id1">
       <part-name>x</part-name>
     </score-part>
-    <part-group type="start">
+    <part-group type="stop">
       <footnote>x</footnote>
       <level>x</level>
     </part-group>

--- a/data/synthetic/metronome-note.3.0.xml
+++ b/data/synthetic/metronome-note.3.0.xml
@@ -8,7 +8,7 @@
     <score-part id="id1">
       <part-name>x</part-name>
     </score-part>
-    <part-group type="start">
+    <part-group type="stop">
       <footnote>x</footnote>
       <level>x</level>
     </part-group>

--- a/data/synthetic/metronome-relation.3.0.xml
+++ b/data/synthetic/metronome-relation.3.0.xml
@@ -8,7 +8,7 @@
     <score-part id="id1">
       <part-name>x</part-name>
     </score-part>
-    <part-group type="start">
+    <part-group type="stop">
       <footnote>x</footnote>
       <level>x</level>
     </part-group>

--- a/data/synthetic/metronome-tied.3.1.xml
+++ b/data/synthetic/metronome-tied.3.1.xml
@@ -8,7 +8,7 @@
     <score-part id="id1">
       <part-name>x</part-name>
     </score-part>
-    <part-group type="start">
+    <part-group type="stop">
       <footnote>x</footnote>
       <level>x</level>
     </part-group>

--- a/data/synthetic/metronome-tuplet.3.0.xml
+++ b/data/synthetic/metronome-tuplet.3.0.xml
@@ -8,7 +8,7 @@
     <score-part id="id1">
       <part-name>x</part-name>
     </score-part>
-    <part-group type="start">
+    <part-group type="stop">
       <footnote>x</footnote>
       <level>x</level>
     </part-group>

--- a/data/synthetic/metronome-type.3.0.xml
+++ b/data/synthetic/metronome-type.3.0.xml
@@ -8,7 +8,7 @@
     <score-part id="id1">
       <part-name>x</part-name>
     </score-part>
-    <part-group type="start">
+    <part-group type="stop">
       <footnote>x</footnote>
       <level>x</level>
     </part-group>

--- a/data/synthetic/metronome.3.0.xml
+++ b/data/synthetic/metronome.3.0.xml
@@ -8,7 +8,7 @@
     <score-part id="id1">
       <part-name>x</part-name>
     </score-part>
-    <part-group type="start">
+    <part-group type="stop">
       <footnote>x</footnote>
       <level>x</level>
     </part-group>

--- a/data/synthetic/metronome.3.1.xml
+++ b/data/synthetic/metronome.3.1.xml
@@ -8,7 +8,7 @@
     <score-part id="id1">
       <part-name>x</part-name>
     </score-part>
-    <part-group type="start">
+    <part-group type="stop">
       <footnote>x</footnote>
       <level>x</level>
     </part-group>

--- a/data/synthetic/metronome.4.0.xml
+++ b/data/synthetic/metronome.4.0.xml
@@ -8,7 +8,7 @@
     <score-part id="id1">
       <part-name>x</part-name>
     </score-part>
-    <part-group type="start">
+    <part-group type="stop">
       <footnote>x</footnote>
       <level>x</level>
     </part-group>

--- a/data/synthetic/midi-device.3.0.xml
+++ b/data/synthetic/midi-device.3.0.xml
@@ -9,7 +9,7 @@
       <part-name>x</part-name>
       <midi-device port="1" id="id2">x</midi-device>
     </score-part>
-    <part-group type="start">
+    <part-group type="stop">
       <footnote>x</footnote>
       <level>x</level>
     </part-group>

--- a/data/synthetic/midi-name.3.0.xml
+++ b/data/synthetic/midi-name.3.0.xml
@@ -11,7 +11,7 @@
         <midi-name>1</midi-name>
       </midi-instrument>
     </score-part>
-    <part-group type="start">
+    <part-group type="stop">
       <footnote>x</footnote>
       <level>x</level>
     </part-group>

--- a/data/synthetic/miscellaneous-field.3.0.xml
+++ b/data/synthetic/miscellaneous-field.3.0.xml
@@ -13,7 +13,7 @@
     <score-part id="id1">
       <part-name>x</part-name>
     </score-part>
-    <part-group type="start">
+    <part-group type="stop">
       <footnote>x</footnote>
       <level>x</level>
     </part-group>

--- a/data/synthetic/mordent.3.0.xml
+++ b/data/synthetic/mordent.3.0.xml
@@ -8,7 +8,7 @@
     <score-part id="id1">
       <part-name>x</part-name>
     </score-part>
-    <part-group type="start">
+    <part-group type="stop">
       <footnote>x</footnote>
       <level>x</level>
     </part-group>

--- a/data/synthetic/movement-number.3.0.xml
+++ b/data/synthetic/movement-number.3.0.xml
@@ -9,7 +9,7 @@
     <score-part id="id1">
       <part-name>x</part-name>
     </score-part>
-    <part-group type="start">
+    <part-group type="stop">
       <footnote>x</footnote>
       <level>x</level>
     </part-group>

--- a/data/synthetic/movement-title.3.0.xml
+++ b/data/synthetic/movement-title.3.0.xml
@@ -9,7 +9,7 @@
     <score-part id="id1">
       <part-name>x</part-name>
     </score-part>
-    <part-group type="start">
+    <part-group type="stop">
       <footnote>x</footnote>
       <level>x</level>
     </part-group>

--- a/data/synthetic/multiple-rest.3.0.xml
+++ b/data/synthetic/multiple-rest.3.0.xml
@@ -8,7 +8,7 @@
     <score-part id="id1">
       <part-name>x</part-name>
     </score-part>
-    <part-group type="start">
+    <part-group type="stop">
       <footnote>x</footnote>
       <level>x</level>
     </part-group>

--- a/data/synthetic/music-font.3.0.xml
+++ b/data/synthetic/music-font.3.0.xml
@@ -11,7 +11,7 @@
     <score-part id="id1">
       <part-name>x</part-name>
     </score-part>
-    <part-group type="start">
+    <part-group type="stop">
       <footnote>x</footnote>
       <level>x</level>
     </part-group>

--- a/data/synthetic/mute.3.0.xml
+++ b/data/synthetic/mute.3.0.xml
@@ -8,7 +8,7 @@
     <score-part id="id1">
       <part-name>x</part-name>
     </score-part>
-    <part-group type="start">
+    <part-group type="stop">
       <footnote>x</footnote>
       <level>x</level>
     </part-group>

--- a/data/synthetic/n.3.1.xml
+++ b/data/synthetic/n.3.1.xml
@@ -8,7 +8,7 @@
     <score-part id="id1">
       <part-name>x</part-name>
     </score-part>
-    <part-group type="start">
+    <part-group type="stop">
       <footnote>x</footnote>
       <level>x</level>
     </part-group>

--- a/data/synthetic/non-arpeggiate.3.0.xml
+++ b/data/synthetic/non-arpeggiate.3.0.xml
@@ -8,7 +8,7 @@
     <score-part id="id1">
       <part-name>x</part-name>
     </score-part>
-    <part-group type="start">
+    <part-group type="stop">
       <footnote>x</footnote>
       <level>x</level>
     </part-group>

--- a/data/synthetic/non-arpeggiate.3.1.xml
+++ b/data/synthetic/non-arpeggiate.3.1.xml
@@ -8,7 +8,7 @@
     <score-part id="id1">
       <part-name>x</part-name>
     </score-part>
-    <part-group type="start">
+    <part-group type="stop">
       <footnote>x</footnote>
       <level>x</level>
     </part-group>

--- a/data/synthetic/notations.3.0.xml
+++ b/data/synthetic/notations.3.0.xml
@@ -8,7 +8,7 @@
     <score-part id="id1">
       <part-name>x</part-name>
     </score-part>
-    <part-group type="start">
+    <part-group type="stop">
       <footnote>x</footnote>
       <level>x</level>
     </part-group>

--- a/data/synthetic/notations.3.1.xml
+++ b/data/synthetic/notations.3.1.xml
@@ -8,7 +8,7 @@
     <score-part id="id1">
       <part-name>x</part-name>
     </score-part>
-    <part-group type="start">
+    <part-group type="stop">
       <footnote>x</footnote>
       <level>x</level>
     </part-group>

--- a/data/synthetic/note.3.0.xml
+++ b/data/synthetic/note.3.0.xml
@@ -8,7 +8,7 @@
     <score-part id="id1">
       <part-name>x</part-name>
     </score-part>
-    <part-group type="start">
+    <part-group type="stop">
       <footnote>x</footnote>
       <level>x</level>
     </part-group>

--- a/data/synthetic/note.3.1.xml
+++ b/data/synthetic/note.3.1.xml
@@ -8,7 +8,7 @@
     <score-part id="id1">
       <part-name>x</part-name>
     </score-part>
-    <part-group type="start">
+    <part-group type="stop">
       <footnote>x</footnote>
       <level>x</level>
     </part-group>

--- a/data/synthetic/notehead-text.3.0.xml
+++ b/data/synthetic/notehead-text.3.0.xml
@@ -8,7 +8,7 @@
     <score-part id="id1">
       <part-name>x</part-name>
     </score-part>
-    <part-group type="start">
+    <part-group type="stop">
       <footnote>x</footnote>
       <level>x</level>
     </part-group>

--- a/data/synthetic/notehead.3.0.xml
+++ b/data/synthetic/notehead.3.0.xml
@@ -8,7 +8,7 @@
     <score-part id="id1">
       <part-name>x</part-name>
     </score-part>
-    <part-group type="start">
+    <part-group type="stop">
       <footnote>x</footnote>
       <level>x</level>
     </part-group>

--- a/data/synthetic/notehead.3.1.xml
+++ b/data/synthetic/notehead.3.1.xml
@@ -8,7 +8,7 @@
     <score-part id="id1">
       <part-name>x</part-name>
     </score-part>
-    <part-group type="start">
+    <part-group type="stop">
       <footnote>x</footnote>
       <level>x</level>
     </part-group>

--- a/data/synthetic/numeral-alter.4.0.xml
+++ b/data/synthetic/numeral-alter.4.0.xml
@@ -8,7 +8,7 @@
     <score-part id="id1">
       <part-name>x</part-name>
     </score-part>
-    <part-group type="start">
+    <part-group type="stop">
       <footnote>x</footnote>
       <level>x</level>
     </part-group>

--- a/data/synthetic/numeral-fifths.4.0.xml
+++ b/data/synthetic/numeral-fifths.4.0.xml
@@ -8,7 +8,7 @@
     <score-part id="id1">
       <part-name>x</part-name>
     </score-part>
-    <part-group type="start">
+    <part-group type="stop">
       <footnote>x</footnote>
       <level>x</level>
     </part-group>

--- a/data/synthetic/numeral-key.4.0.xml
+++ b/data/synthetic/numeral-key.4.0.xml
@@ -8,7 +8,7 @@
     <score-part id="id1">
       <part-name>x</part-name>
     </score-part>
-    <part-group type="start">
+    <part-group type="stop">
       <footnote>x</footnote>
       <level>x</level>
     </part-group>

--- a/data/synthetic/numeral-mode.4.0.xml
+++ b/data/synthetic/numeral-mode.4.0.xml
@@ -8,7 +8,7 @@
     <score-part id="id1">
       <part-name>x</part-name>
     </score-part>
-    <part-group type="start">
+    <part-group type="stop">
       <footnote>x</footnote>
       <level>x</level>
     </part-group>

--- a/data/synthetic/numeral-root.4.0.xml
+++ b/data/synthetic/numeral-root.4.0.xml
@@ -8,7 +8,7 @@
     <score-part id="id1">
       <part-name>x</part-name>
     </score-part>
-    <part-group type="start">
+    <part-group type="stop">
       <footnote>x</footnote>
       <level>x</level>
     </part-group>

--- a/data/synthetic/numeral.4.0.xml
+++ b/data/synthetic/numeral.4.0.xml
@@ -8,7 +8,7 @@
     <score-part id="id1">
       <part-name>x</part-name>
     </score-part>
-    <part-group type="start">
+    <part-group type="stop">
       <footnote>x</footnote>
       <level>x</level>
     </part-group>

--- a/data/synthetic/octave-shift.3.0.xml
+++ b/data/synthetic/octave-shift.3.0.xml
@@ -8,7 +8,7 @@
     <score-part id="id1">
       <part-name>x</part-name>
     </score-part>
-    <part-group type="start">
+    <part-group type="stop">
       <footnote>x</footnote>
       <level>x</level>
     </part-group>

--- a/data/synthetic/octave-shift.3.1.xml
+++ b/data/synthetic/octave-shift.3.1.xml
@@ -8,7 +8,7 @@
     <score-part id="id1">
       <part-name>x</part-name>
     </score-part>
-    <part-group type="start">
+    <part-group type="stop">
       <footnote>x</footnote>
       <level>x</level>
     </part-group>

--- a/data/synthetic/open-string.3.0.xml
+++ b/data/synthetic/open-string.3.0.xml
@@ -8,7 +8,7 @@
     <score-part id="id1">
       <part-name>x</part-name>
     </score-part>
-    <part-group type="start">
+    <part-group type="stop">
       <footnote>x</footnote>
       <level>x</level>
     </part-group>

--- a/data/synthetic/open.3.1.xml
+++ b/data/synthetic/open.3.1.xml
@@ -8,7 +8,7 @@
     <score-part id="id1">
       <part-name>x</part-name>
     </score-part>
-    <part-group type="start">
+    <part-group type="stop">
       <footnote>x</footnote>
       <level>x</level>
     </part-group>

--- a/data/synthetic/opus.3.0.xml
+++ b/data/synthetic/opus.3.0.xml
@@ -11,7 +11,7 @@
     <score-part id="id1">
       <part-name>x</part-name>
     </score-part>
-    <part-group type="start">
+    <part-group type="stop">
       <footnote>x</footnote>
       <level>x</level>
     </part-group>

--- a/data/synthetic/ornaments.3.1.xml
+++ b/data/synthetic/ornaments.3.1.xml
@@ -8,7 +8,7 @@
     <score-part id="id1">
       <part-name>x</part-name>
     </score-part>
-    <part-group type="start">
+    <part-group type="stop">
       <footnote>x</footnote>
       <level>x</level>
     </part-group>

--- a/data/synthetic/other-appearance.3.0.xml
+++ b/data/synthetic/other-appearance.3.0.xml
@@ -13,7 +13,7 @@
     <score-part id="id1">
       <part-name>x</part-name>
     </score-part>
-    <part-group type="start">
+    <part-group type="stop">
       <footnote>x</footnote>
       <level>x</level>
     </part-group>

--- a/data/synthetic/other-articulation.3.0.xml
+++ b/data/synthetic/other-articulation.3.0.xml
@@ -8,7 +8,7 @@
     <score-part id="id1">
       <part-name>x</part-name>
     </score-part>
-    <part-group type="start">
+    <part-group type="stop">
       <footnote>x</footnote>
       <level>x</level>
     </part-group>

--- a/data/synthetic/other-articulation.3.1.xml
+++ b/data/synthetic/other-articulation.3.1.xml
@@ -8,7 +8,7 @@
     <score-part id="id1">
       <part-name>x</part-name>
     </score-part>
-    <part-group type="start">
+    <part-group type="stop">
       <footnote>x</footnote>
       <level>x</level>
     </part-group>

--- a/data/synthetic/other-direction.3.0.xml
+++ b/data/synthetic/other-direction.3.0.xml
@@ -8,7 +8,7 @@
     <score-part id="id1">
       <part-name>x</part-name>
     </score-part>
-    <part-group type="start">
+    <part-group type="stop">
       <footnote>x</footnote>
       <level>x</level>
     </part-group>

--- a/data/synthetic/other-direction.3.1.xml
+++ b/data/synthetic/other-direction.3.1.xml
@@ -8,7 +8,7 @@
     <score-part id="id1">
       <part-name>x</part-name>
     </score-part>
-    <part-group type="start">
+    <part-group type="stop">
       <footnote>x</footnote>
       <level>x</level>
     </part-group>

--- a/data/synthetic/other-dynamics.3.0.xml
+++ b/data/synthetic/other-dynamics.3.0.xml
@@ -8,7 +8,7 @@
     <score-part id="id1">
       <part-name>x</part-name>
     </score-part>
-    <part-group type="start">
+    <part-group type="stop">
       <footnote>x</footnote>
       <level>x</level>
     </part-group>

--- a/data/synthetic/other-dynamics.3.1.xml
+++ b/data/synthetic/other-dynamics.3.1.xml
@@ -8,7 +8,7 @@
     <score-part id="id1">
       <part-name>x</part-name>
     </score-part>
-    <part-group type="start">
+    <part-group type="stop">
       <footnote>x</footnote>
       <level>x</level>
     </part-group>

--- a/data/synthetic/other-listen.4.0.xml
+++ b/data/synthetic/other-listen.4.0.xml
@@ -8,7 +8,7 @@
     <score-part id="id1">
       <part-name>x</part-name>
     </score-part>
-    <part-group type="start">
+    <part-group type="stop">
       <footnote>x</footnote>
       <level>x</level>
     </part-group>

--- a/data/synthetic/other-listening.4.0.xml
+++ b/data/synthetic/other-listening.4.0.xml
@@ -8,7 +8,7 @@
     <score-part id="id1">
       <part-name>x</part-name>
     </score-part>
-    <part-group type="start">
+    <part-group type="stop">
       <footnote>x</footnote>
       <level>x</level>
     </part-group>

--- a/data/synthetic/other-notation.3.0.xml
+++ b/data/synthetic/other-notation.3.0.xml
@@ -8,7 +8,7 @@
     <score-part id="id1">
       <part-name>x</part-name>
     </score-part>
-    <part-group type="start">
+    <part-group type="stop">
       <footnote>x</footnote>
       <level>x</level>
     </part-group>

--- a/data/synthetic/other-notation.3.1.xml
+++ b/data/synthetic/other-notation.3.1.xml
@@ -8,7 +8,7 @@
     <score-part id="id1">
       <part-name>x</part-name>
     </score-part>
-    <part-group type="start">
+    <part-group type="stop">
       <footnote>x</footnote>
       <level>x</level>
     </part-group>

--- a/data/synthetic/other-ornament.3.0.xml
+++ b/data/synthetic/other-ornament.3.0.xml
@@ -8,7 +8,7 @@
     <score-part id="id1">
       <part-name>x</part-name>
     </score-part>
-    <part-group type="start">
+    <part-group type="stop">
       <footnote>x</footnote>
       <level>x</level>
     </part-group>

--- a/data/synthetic/other-ornament.3.1.xml
+++ b/data/synthetic/other-ornament.3.1.xml
@@ -8,7 +8,7 @@
     <score-part id="id1">
       <part-name>x</part-name>
     </score-part>
-    <part-group type="start">
+    <part-group type="stop">
       <footnote>x</footnote>
       <level>x</level>
     </part-group>

--- a/data/synthetic/other-percussion.3.0.xml
+++ b/data/synthetic/other-percussion.3.0.xml
@@ -8,7 +8,7 @@
     <score-part id="id1">
       <part-name>x</part-name>
     </score-part>
-    <part-group type="start">
+    <part-group type="stop">
       <footnote>x</footnote>
       <level>x</level>
     </part-group>

--- a/data/synthetic/other-percussion.3.1.xml
+++ b/data/synthetic/other-percussion.3.1.xml
@@ -8,7 +8,7 @@
     <score-part id="id1">
       <part-name>x</part-name>
     </score-part>
-    <part-group type="start">
+    <part-group type="stop">
       <footnote>x</footnote>
       <level>x</level>
     </part-group>

--- a/data/synthetic/other-play.3.0.xml
+++ b/data/synthetic/other-play.3.0.xml
@@ -8,7 +8,7 @@
     <score-part id="id1">
       <part-name>x</part-name>
     </score-part>
-    <part-group type="start">
+    <part-group type="stop">
       <footnote>x</footnote>
       <level>x</level>
     </part-group>

--- a/data/synthetic/other-technical.3.0.xml
+++ b/data/synthetic/other-technical.3.0.xml
@@ -8,7 +8,7 @@
     <score-part id="id1">
       <part-name>x</part-name>
     </score-part>
-    <part-group type="start">
+    <part-group type="stop">
       <footnote>x</footnote>
       <level>x</level>
     </part-group>

--- a/data/synthetic/other-technical.3.1.xml
+++ b/data/synthetic/other-technical.3.1.xml
@@ -8,7 +8,7 @@
     <score-part id="id1">
       <part-name>x</part-name>
     </score-part>
-    <part-group type="start">
+    <part-group type="stop">
       <footnote>x</footnote>
       <level>x</level>
     </part-group>

--- a/data/synthetic/part-abbreviation-display.3.0.xml
+++ b/data/synthetic/part-abbreviation-display.3.0.xml
@@ -11,7 +11,7 @@
         <display-text>x</display-text>
       </part-abbreviation-display>
     </score-part>
-    <part-group type="start">
+    <part-group type="stop">
       <footnote>x</footnote>
       <level>x</level>
     </part-group>

--- a/data/synthetic/part-abbreviation.3.0.xml
+++ b/data/synthetic/part-abbreviation.3.0.xml
@@ -9,7 +9,7 @@
       <part-name>x</part-name>
       <part-abbreviation default-x="1" default-y="1" relative-x="1" relative-y="1" font-family="x" font-style="normal" font-size="1" font-weight="normal" color="#FF000000" print-object="yes" justify="left">x</part-abbreviation>
     </score-part>
-    <part-group type="start">
+    <part-group type="stop">
       <footnote>x</footnote>
       <level>x</level>
     </part-group>

--- a/data/synthetic/part-clef.4.0.xml
+++ b/data/synthetic/part-clef.4.0.xml
@@ -8,7 +8,7 @@
     <score-part id="id1">
       <part-name>x</part-name>
     </score-part>
-    <part-group type="start">
+    <part-group type="stop">
       <footnote>x</footnote>
       <level>x</level>
     </part-group>

--- a/data/synthetic/part-link.4.0.xml
+++ b/data/synthetic/part-link.4.0.xml
@@ -9,7 +9,7 @@
       <part-link xlink:href="http://example.com" xlink:type="simple" xlink:role="http://example.com/role" xlink:title="x" xlink:show="new" xlink:actuate="onRequest" />
       <part-name>x</part-name>
     </score-part>
-    <part-group type="start">
+    <part-group type="stop">
       <footnote>x</footnote>
       <level>x</level>
     </part-group>

--- a/data/synthetic/part-name-display.3.0.xml
+++ b/data/synthetic/part-name-display.3.0.xml
@@ -11,7 +11,7 @@
         <display-text>x</display-text>
       </part-name-display>
     </score-part>
-    <part-group type="start">
+    <part-group type="stop">
       <footnote>x</footnote>
       <level>x</level>
     </part-group>

--- a/data/synthetic/part-name.3.0.xml
+++ b/data/synthetic/part-name.3.0.xml
@@ -8,7 +8,7 @@
     <score-part id="id1">
       <part-name default-x="1" default-y="1" relative-x="1" relative-y="1" font-family="x" font-style="normal" font-size="1" font-weight="normal" color="#FF000000" print-object="yes" justify="left">x</part-name>
     </score-part>
-    <part-group type="start">
+    <part-group type="stop">
       <footnote>x</footnote>
       <level>x</level>
     </part-group>

--- a/data/synthetic/part-symbol.3.0.xml
+++ b/data/synthetic/part-symbol.3.0.xml
@@ -8,7 +8,7 @@
     <score-part id="id1">
       <part-name>x</part-name>
     </score-part>
-    <part-group type="start">
+    <part-group type="stop">
       <footnote>x</footnote>
       <level>x</level>
     </part-group>

--- a/data/synthetic/part-transpose.4.0.xml
+++ b/data/synthetic/part-transpose.4.0.xml
@@ -8,7 +8,7 @@
     <score-part id="id1">
       <part-name>x</part-name>
     </score-part>
-    <part-group type="start">
+    <part-group type="stop">
       <footnote>x</footnote>
       <level>x</level>
     </part-group>

--- a/data/synthetic/pedal.3.0.xml
+++ b/data/synthetic/pedal.3.0.xml
@@ -8,7 +8,7 @@
     <score-part id="id1">
       <part-name>x</part-name>
     </score-part>
-    <part-group type="start">
+    <part-group type="stop">
       <footnote>x</footnote>
       <level>x</level>
     </part-group>

--- a/data/synthetic/pedal.3.1.xml
+++ b/data/synthetic/pedal.3.1.xml
@@ -8,7 +8,7 @@
     <score-part id="id1">
       <part-name>x</part-name>
     </score-part>
-    <part-group type="start">
+    <part-group type="stop">
       <footnote>x</footnote>
       <level>x</level>
     </part-group>

--- a/data/synthetic/per-minute.3.0.xml
+++ b/data/synthetic/per-minute.3.0.xml
@@ -8,7 +8,7 @@
     <score-part id="id1">
       <part-name>x</part-name>
     </score-part>
-    <part-group type="start">
+    <part-group type="stop">
       <footnote>x</footnote>
       <level>x</level>
     </part-group>

--- a/data/synthetic/percussion.3.0.xml
+++ b/data/synthetic/percussion.3.0.xml
@@ -8,7 +8,7 @@
     <score-part id="id1">
       <part-name>x</part-name>
     </score-part>
-    <part-group type="start">
+    <part-group type="stop">
       <footnote>x</footnote>
       <level>x</level>
     </part-group>

--- a/data/synthetic/percussion.3.1.xml
+++ b/data/synthetic/percussion.3.1.xml
@@ -8,7 +8,7 @@
     <score-part id="id1">
       <part-name>x</part-name>
     </score-part>
-    <part-group type="start">
+    <part-group type="stop">
       <footnote>x</footnote>
       <level>x</level>
     </part-group>

--- a/data/synthetic/pf.3.1.xml
+++ b/data/synthetic/pf.3.1.xml
@@ -8,7 +8,7 @@
     <score-part id="id1">
       <part-name>x</part-name>
     </score-part>
-    <part-group type="start">
+    <part-group type="stop">
       <footnote>x</footnote>
       <level>x</level>
     </part-group>

--- a/data/synthetic/pitched.3.0.xml
+++ b/data/synthetic/pitched.3.0.xml
@@ -8,7 +8,7 @@
     <score-part id="id1">
       <part-name>x</part-name>
     </score-part>
-    <part-group type="start">
+    <part-group type="stop">
       <footnote>x</footnote>
       <level>x</level>
     </part-group>

--- a/data/synthetic/pitched.3.1.xml
+++ b/data/synthetic/pitched.3.1.xml
@@ -8,7 +8,7 @@
     <score-part id="id1">
       <part-name>x</part-name>
     </score-part>
-    <part-group type="start">
+    <part-group type="stop">
       <footnote>x</footnote>
       <level>x</level>
     </part-group>

--- a/data/synthetic/play.3.0.xml
+++ b/data/synthetic/play.3.0.xml
@@ -8,7 +8,7 @@
     <score-part id="id1">
       <part-name>x</part-name>
     </score-part>
-    <part-group type="start">
+    <part-group type="stop">
       <footnote>x</footnote>
       <level>x</level>
     </part-group>

--- a/data/synthetic/player-name.4.0.xml
+++ b/data/synthetic/player-name.4.0.xml
@@ -11,7 +11,7 @@
         <player-name>1</player-name>
       </player>
     </score-part>
-    <part-group type="start">
+    <part-group type="stop">
       <footnote>x</footnote>
       <level>x</level>
     </part-group>

--- a/data/synthetic/player.4.0.xml
+++ b/data/synthetic/player.4.0.xml
@@ -11,7 +11,7 @@
         <player-name>1</player-name>
       </player>
     </score-part>
-    <part-group type="start">
+    <part-group type="stop">
       <footnote>x</footnote>
       <level>x</level>
     </part-group>

--- a/data/synthetic/plop.3.0.xml
+++ b/data/synthetic/plop.3.0.xml
@@ -8,7 +8,7 @@
     <score-part id="id1">
       <part-name>x</part-name>
     </score-part>
-    <part-group type="start">
+    <part-group type="stop">
       <footnote>x</footnote>
       <level>x</level>
     </part-group>

--- a/data/synthetic/plop.3.1.xml
+++ b/data/synthetic/plop.3.1.xml
@@ -8,7 +8,7 @@
     <score-part id="id1">
       <part-name>x</part-name>
     </score-part>
-    <part-group type="start">
+    <part-group type="stop">
       <footnote>x</footnote>
       <level>x</level>
     </part-group>

--- a/data/synthetic/pluck.3.0.xml
+++ b/data/synthetic/pluck.3.0.xml
@@ -8,7 +8,7 @@
     <score-part id="id1">
       <part-name>x</part-name>
     </score-part>
-    <part-group type="start">
+    <part-group type="stop">
       <footnote>x</footnote>
       <level>x</level>
     </part-group>

--- a/data/synthetic/prefix.3.0.xml
+++ b/data/synthetic/prefix.3.0.xml
@@ -8,7 +8,7 @@
     <score-part id="id1">
       <part-name>x</part-name>
     </score-part>
-    <part-group type="start">
+    <part-group type="stop">
       <footnote>x</footnote>
       <level>x</level>
     </part-group>

--- a/data/synthetic/principal-voice.3.0.xml
+++ b/data/synthetic/principal-voice.3.0.xml
@@ -8,7 +8,7 @@
     <score-part id="id1">
       <part-name>x</part-name>
     </score-part>
-    <part-group type="start">
+    <part-group type="stop">
       <footnote>x</footnote>
       <level>x</level>
     </part-group>

--- a/data/synthetic/principal-voice.3.1.xml
+++ b/data/synthetic/principal-voice.3.1.xml
@@ -8,7 +8,7 @@
     <score-part id="id1">
       <part-name>x</part-name>
     </score-part>
-    <part-group type="start">
+    <part-group type="stop">
       <footnote>x</footnote>
       <level>x</level>
     </part-group>

--- a/data/synthetic/print.3.0.xml
+++ b/data/synthetic/print.3.0.xml
@@ -8,7 +8,7 @@
     <score-part id="id1">
       <part-name>x</part-name>
     </score-part>
-    <part-group type="start">
+    <part-group type="stop">
       <footnote>x</footnote>
       <level>x</level>
     </part-group>

--- a/data/synthetic/print.3.1.xml
+++ b/data/synthetic/print.3.1.xml
@@ -8,7 +8,7 @@
     <score-part id="id1">
       <part-name>x</part-name>
     </score-part>
-    <part-group type="start">
+    <part-group type="stop">
       <footnote>x</footnote>
       <level>x</level>
     </part-group>

--- a/data/synthetic/pull-off.3.0.xml
+++ b/data/synthetic/pull-off.3.0.xml
@@ -8,7 +8,7 @@
     <score-part id="id1">
       <part-name>x</part-name>
     </score-part>
-    <part-group type="start">
+    <part-group type="stop">
       <footnote>x</footnote>
       <level>x</level>
     </part-group>

--- a/data/synthetic/rehearsal.3.0.xml
+++ b/data/synthetic/rehearsal.3.0.xml
@@ -8,7 +8,7 @@
     <score-part id="id1">
       <part-name>x</part-name>
     </score-part>
-    <part-group type="start">
+    <part-group type="stop">
       <footnote>x</footnote>
       <level>x</level>
     </part-group>

--- a/data/synthetic/rehearsal.3.1.xml
+++ b/data/synthetic/rehearsal.3.1.xml
@@ -8,7 +8,7 @@
     <score-part id="id1">
       <part-name>x</part-name>
     </score-part>
-    <part-group type="start">
+    <part-group type="stop">
       <footnote>x</footnote>
       <level>x</level>
     </part-group>

--- a/data/synthetic/relation.3.0.xml
+++ b/data/synthetic/relation.3.0.xml
@@ -11,7 +11,7 @@
     <score-part id="id1">
       <part-name>x</part-name>
     </score-part>
-    <part-group type="start">
+    <part-group type="stop">
       <footnote>x</footnote>
       <level>x</level>
     </part-group>

--- a/data/synthetic/release.4.0.xml
+++ b/data/synthetic/release.4.0.xml
@@ -8,7 +8,7 @@
     <score-part id="id1">
       <part-name>x</part-name>
     </score-part>
-    <part-group type="start">
+    <part-group type="stop">
       <footnote>x</footnote>
       <level>x</level>
     </part-group>

--- a/data/synthetic/repeat.4.0.xml
+++ b/data/synthetic/repeat.4.0.xml
@@ -8,7 +8,7 @@
     <score-part id="id1">
       <part-name>x</part-name>
     </score-part>
-    <part-group type="start">
+    <part-group type="stop">
       <footnote>x</footnote>
       <level>x</level>
     </part-group>

--- a/data/synthetic/right-divider.3.0.xml
+++ b/data/synthetic/right-divider.3.0.xml
@@ -16,7 +16,7 @@
     <score-part id="id1">
       <part-name>x</part-name>
     </score-part>
-    <part-group type="start">
+    <part-group type="stop">
       <footnote>x</footnote>
       <level>x</level>
     </part-group>

--- a/data/synthetic/rights.3.0.xml
+++ b/data/synthetic/rights.3.0.xml
@@ -11,7 +11,7 @@
     <score-part id="id1">
       <part-name>x</part-name>
     </score-part>
-    <part-group type="start">
+    <part-group type="stop">
       <footnote>x</footnote>
       <level>x</level>
     </part-group>

--- a/data/synthetic/root-alter.3.0.xml
+++ b/data/synthetic/root-alter.3.0.xml
@@ -8,7 +8,7 @@
     <score-part id="id1">
       <part-name>x</part-name>
     </score-part>
-    <part-group type="start">
+    <part-group type="stop">
       <footnote>x</footnote>
       <level>x</level>
     </part-group>

--- a/data/synthetic/root-step.3.0.xml
+++ b/data/synthetic/root-step.3.0.xml
@@ -8,7 +8,7 @@
     <score-part id="id1">
       <part-name>x</part-name>
     </score-part>
-    <part-group type="start">
+    <part-group type="stop">
       <footnote>x</footnote>
       <level>x</level>
     </part-group>

--- a/data/synthetic/schleifer.3.0.xml
+++ b/data/synthetic/schleifer.3.0.xml
@@ -8,7 +8,7 @@
     <score-part id="id1">
       <part-name>x</part-name>
     </score-part>
-    <part-group type="start">
+    <part-group type="stop">
       <footnote>x</footnote>
       <level>x</level>
     </part-group>

--- a/data/synthetic/scoop.3.0.xml
+++ b/data/synthetic/scoop.3.0.xml
@@ -8,7 +8,7 @@
     <score-part id="id1">
       <part-name>x</part-name>
     </score-part>
-    <part-group type="start">
+    <part-group type="stop">
       <footnote>x</footnote>
       <level>x</level>
     </part-group>

--- a/data/synthetic/scoop.3.1.xml
+++ b/data/synthetic/scoop.3.1.xml
@@ -8,7 +8,7 @@
     <score-part id="id1">
       <part-name>x</part-name>
     </score-part>
-    <part-group type="start">
+    <part-group type="stop">
       <footnote>x</footnote>
       <level>x</level>
     </part-group>

--- a/data/synthetic/scordatura.3.1.xml
+++ b/data/synthetic/scordatura.3.1.xml
@@ -8,7 +8,7 @@
     <score-part id="id1">
       <part-name>x</part-name>
     </score-part>
-    <part-group type="start">
+    <part-group type="stop">
       <footnote>x</footnote>
       <level>x</level>
     </part-group>

--- a/data/synthetic/second.4.0.xml
+++ b/data/synthetic/second.4.0.xml
@@ -8,7 +8,7 @@
     <score-part id="id1">
       <part-name>x</part-name>
     </score-part>
-    <part-group type="start">
+    <part-group type="stop">
       <footnote>x</footnote>
       <level>x</level>
     </part-group>

--- a/data/synthetic/segno.3.0.xml
+++ b/data/synthetic/segno.3.0.xml
@@ -8,7 +8,7 @@
     <score-part id="id1">
       <part-name>x</part-name>
     </score-part>
-    <part-group type="start">
+    <part-group type="stop">
       <footnote>x</footnote>
       <level>x</level>
     </part-group>

--- a/data/synthetic/segno.3.1.xml
+++ b/data/synthetic/segno.3.1.xml
@@ -8,7 +8,7 @@
     <score-part id="id1">
       <part-name>x</part-name>
     </score-part>
-    <part-group type="start">
+    <part-group type="stop">
       <footnote>x</footnote>
       <level>x</level>
     </part-group>

--- a/data/synthetic/semi-pitched.3.0.xml
+++ b/data/synthetic/semi-pitched.3.0.xml
@@ -8,7 +8,7 @@
     <score-part id="id1">
       <part-name>x</part-name>
     </score-part>
-    <part-group type="start">
+    <part-group type="stop">
       <footnote>x</footnote>
       <level>x</level>
     </part-group>

--- a/data/synthetic/senza-misura.3.0.xml
+++ b/data/synthetic/senza-misura.3.0.xml
@@ -8,7 +8,7 @@
     <score-part id="id1">
       <part-name>x</part-name>
     </score-part>
-    <part-group type="start">
+    <part-group type="stop">
       <footnote>x</footnote>
       <level>x</level>
     </part-group>

--- a/data/synthetic/sfzp.3.1.xml
+++ b/data/synthetic/sfzp.3.1.xml
@@ -8,7 +8,7 @@
     <score-part id="id1">
       <part-name>x</part-name>
     </score-part>
-    <part-group type="start">
+    <part-group type="stop">
       <footnote>x</footnote>
       <level>x</level>
     </part-group>

--- a/data/synthetic/shake.3.0.xml
+++ b/data/synthetic/shake.3.0.xml
@@ -8,7 +8,7 @@
     <score-part id="id1">
       <part-name>x</part-name>
     </score-part>
-    <part-group type="start">
+    <part-group type="stop">
       <footnote>x</footnote>
       <level>x</level>
     </part-group>

--- a/data/synthetic/slash-dot.3.0.xml
+++ b/data/synthetic/slash-dot.3.0.xml
@@ -8,7 +8,7 @@
     <score-part id="id1">
       <part-name>x</part-name>
     </score-part>
-    <part-group type="start">
+    <part-group type="stop">
       <footnote>x</footnote>
       <level>x</level>
     </part-group>

--- a/data/synthetic/slash-type.3.0.xml
+++ b/data/synthetic/slash-type.3.0.xml
@@ -8,7 +8,7 @@
     <score-part id="id1">
       <part-name>x</part-name>
     </score-part>
-    <part-group type="start">
+    <part-group type="stop">
       <footnote>x</footnote>
       <level>x</level>
     </part-group>

--- a/data/synthetic/slash.3.0.xml
+++ b/data/synthetic/slash.3.0.xml
@@ -8,7 +8,7 @@
     <score-part id="id1">
       <part-name>x</part-name>
     </score-part>
-    <part-group type="start">
+    <part-group type="stop">
       <footnote>x</footnote>
       <level>x</level>
     </part-group>

--- a/data/synthetic/slide.3.0.xml
+++ b/data/synthetic/slide.3.0.xml
@@ -8,7 +8,7 @@
     <score-part id="id1">
       <part-name>x</part-name>
     </score-part>
-    <part-group type="start">
+    <part-group type="stop">
       <footnote>x</footnote>
       <level>x</level>
     </part-group>

--- a/data/synthetic/slide.3.1.xml
+++ b/data/synthetic/slide.3.1.xml
@@ -8,7 +8,7 @@
     <score-part id="id1">
       <part-name>x</part-name>
     </score-part>
-    <part-group type="start">
+    <part-group type="stop">
       <footnote>x</footnote>
       <level>x</level>
     </part-group>

--- a/data/synthetic/slur.3.0.xml
+++ b/data/synthetic/slur.3.0.xml
@@ -8,7 +8,7 @@
     <score-part id="id1">
       <part-name>x</part-name>
     </score-part>
-    <part-group type="start">
+    <part-group type="stop">
       <footnote>x</footnote>
       <level>x</level>
     </part-group>

--- a/data/synthetic/slur.3.1.xml
+++ b/data/synthetic/slur.3.1.xml
@@ -8,7 +8,7 @@
     <score-part id="id1">
       <part-name>x</part-name>
     </score-part>
-    <part-group type="start">
+    <part-group type="stop">
       <footnote>x</footnote>
       <level>x</level>
     </part-group>

--- a/data/synthetic/smear.3.1.xml
+++ b/data/synthetic/smear.3.1.xml
@@ -8,7 +8,7 @@
     <score-part id="id1">
       <part-name>x</part-name>
     </score-part>
-    <part-group type="start">
+    <part-group type="stop">
       <footnote>x</footnote>
       <level>x</level>
     </part-group>

--- a/data/synthetic/snap-pizzicato.3.0.xml
+++ b/data/synthetic/snap-pizzicato.3.0.xml
@@ -8,7 +8,7 @@
     <score-part id="id1">
       <part-name>x</part-name>
     </score-part>
-    <part-group type="start">
+    <part-group type="stop">
       <footnote>x</footnote>
       <level>x</level>
     </part-group>

--- a/data/synthetic/soft-accent.3.1.xml
+++ b/data/synthetic/soft-accent.3.1.xml
@@ -8,7 +8,7 @@
     <score-part id="id1">
       <part-name>x</part-name>
     </score-part>
-    <part-group type="start">
+    <part-group type="stop">
       <footnote>x</footnote>
       <level>x</level>
     </part-group>

--- a/data/synthetic/software.3.0.xml
+++ b/data/synthetic/software.3.0.xml
@@ -13,7 +13,7 @@
     <score-part id="id1">
       <part-name>x</part-name>
     </score-part>
-    <part-group type="start">
+    <part-group type="stop">
       <footnote>x</footnote>
       <level>x</level>
     </part-group>

--- a/data/synthetic/sound.3.0.xml
+++ b/data/synthetic/sound.3.0.xml
@@ -8,7 +8,7 @@
     <score-part id="id1">
       <part-name>x</part-name>
     </score-part>
-    <part-group type="start">
+    <part-group type="stop">
       <footnote>x</footnote>
       <level>x</level>
     </part-group>

--- a/data/synthetic/sound.3.1.xml
+++ b/data/synthetic/sound.3.1.xml
@@ -8,7 +8,7 @@
     <score-part id="id1">
       <part-name>x</part-name>
     </score-part>
-    <part-group type="start">
+    <part-group type="stop">
       <footnote>x</footnote>
       <level>x</level>
     </part-group>

--- a/data/synthetic/source.3.0.xml
+++ b/data/synthetic/source.3.0.xml
@@ -11,7 +11,7 @@
     <score-part id="id1">
       <part-name>x</part-name>
     </score-part>
-    <part-group type="start">
+    <part-group type="stop">
       <footnote>x</footnote>
       <level>x</level>
     </part-group>

--- a/data/synthetic/spiccato.3.0.xml
+++ b/data/synthetic/spiccato.3.0.xml
@@ -8,7 +8,7 @@
     <score-part id="id1">
       <part-name>x</part-name>
     </score-part>
-    <part-group type="start">
+    <part-group type="stop">
       <footnote>x</footnote>
       <level>x</level>
     </part-group>

--- a/data/synthetic/staccatissimo.3.0.xml
+++ b/data/synthetic/staccatissimo.3.0.xml
@@ -8,7 +8,7 @@
     <score-part id="id1">
       <part-name>x</part-name>
     </score-part>
-    <part-group type="start">
+    <part-group type="stop">
       <footnote>x</footnote>
       <level>x</level>
     </part-group>

--- a/data/synthetic/staccato.3.0.xml
+++ b/data/synthetic/staccato.3.0.xml
@@ -8,7 +8,7 @@
     <score-part id="id1">
       <part-name>x</part-name>
     </score-part>
-    <part-group type="start">
+    <part-group type="stop">
       <footnote>x</footnote>
       <level>x</level>
     </part-group>

--- a/data/synthetic/staff-divide.3.1.xml
+++ b/data/synthetic/staff-divide.3.1.xml
@@ -8,7 +8,7 @@
     <score-part id="id1">
       <part-name>x</part-name>
     </score-part>
-    <part-group type="start">
+    <part-group type="stop">
       <footnote>x</footnote>
       <level>x</level>
     </part-group>

--- a/data/synthetic/staff-size.4.0.xml
+++ b/data/synthetic/staff-size.4.0.xml
@@ -8,7 +8,7 @@
     <score-part id="id1">
       <part-name>x</part-name>
     </score-part>
-    <part-group type="start">
+    <part-group type="stop">
       <footnote>x</footnote>
       <level>x</level>
     </part-group>

--- a/data/synthetic/staff-type.3.0.xml
+++ b/data/synthetic/staff-type.3.0.xml
@@ -8,7 +8,7 @@
     <score-part id="id1">
       <part-name>x</part-name>
     </score-part>
-    <part-group type="start">
+    <part-group type="stop">
       <footnote>x</footnote>
       <level>x</level>
     </part-group>

--- a/data/synthetic/stem.3.0.xml
+++ b/data/synthetic/stem.3.0.xml
@@ -8,7 +8,7 @@
     <score-part id="id1">
       <part-name>x</part-name>
     </score-part>
-    <part-group type="start">
+    <part-group type="stop">
       <footnote>x</footnote>
       <level>x</level>
     </part-group>

--- a/data/synthetic/stick-location.3.0.xml
+++ b/data/synthetic/stick-location.3.0.xml
@@ -8,7 +8,7 @@
     <score-part id="id1">
       <part-name>x</part-name>
     </score-part>
-    <part-group type="start">
+    <part-group type="stop">
       <footnote>x</footnote>
       <level>x</level>
     </part-group>

--- a/data/synthetic/stick-material.3.0.xml
+++ b/data/synthetic/stick-material.3.0.xml
@@ -8,7 +8,7 @@
     <score-part id="id1">
       <part-name>x</part-name>
     </score-part>
-    <part-group type="start">
+    <part-group type="stop">
       <footnote>x</footnote>
       <level>x</level>
     </part-group>

--- a/data/synthetic/stick-type.3.0.xml
+++ b/data/synthetic/stick-type.3.0.xml
@@ -8,7 +8,7 @@
     <score-part id="id1">
       <part-name>x</part-name>
     </score-part>
-    <part-group type="start">
+    <part-group type="stop">
       <footnote>x</footnote>
       <level>x</level>
     </part-group>

--- a/data/synthetic/stick.3.0.xml
+++ b/data/synthetic/stick.3.0.xml
@@ -8,7 +8,7 @@
     <score-part id="id1">
       <part-name>x</part-name>
     </score-part>
-    <part-group type="start">
+    <part-group type="stop">
       <footnote>x</footnote>
       <level>x</level>
     </part-group>

--- a/data/synthetic/stick.3.1.xml
+++ b/data/synthetic/stick.3.1.xml
@@ -8,7 +8,7 @@
     <score-part id="id1">
       <part-name>x</part-name>
     </score-part>
-    <part-group type="start">
+    <part-group type="stop">
       <footnote>x</footnote>
       <level>x</level>
     </part-group>

--- a/data/synthetic/stopped.3.0.xml
+++ b/data/synthetic/stopped.3.0.xml
@@ -8,7 +8,7 @@
     <score-part id="id1">
       <part-name>x</part-name>
     </score-part>
-    <part-group type="start">
+    <part-group type="stop">
       <footnote>x</footnote>
       <level>x</level>
     </part-group>

--- a/data/synthetic/stopped.3.1.xml
+++ b/data/synthetic/stopped.3.1.xml
@@ -8,7 +8,7 @@
     <score-part id="id1">
       <part-name>x</part-name>
     </score-part>
-    <part-group type="start">
+    <part-group type="stop">
       <footnote>x</footnote>
       <level>x</level>
     </part-group>

--- a/data/synthetic/straight.4.0.xml
+++ b/data/synthetic/straight.4.0.xml
@@ -8,7 +8,7 @@
     <score-part id="id1">
       <part-name>x</part-name>
     </score-part>
-    <part-group type="start">
+    <part-group type="stop">
       <footnote>x</footnote>
       <level>x</level>
     </part-group>

--- a/data/synthetic/stress.3.0.xml
+++ b/data/synthetic/stress.3.0.xml
@@ -8,7 +8,7 @@
     <score-part id="id1">
       <part-name>x</part-name>
     </score-part>
-    <part-group type="start">
+    <part-group type="stop">
       <footnote>x</footnote>
       <level>x</level>
     </part-group>

--- a/data/synthetic/string-mute.3.0.xml
+++ b/data/synthetic/string-mute.3.0.xml
@@ -8,7 +8,7 @@
     <score-part id="id1">
       <part-name>x</part-name>
     </score-part>
-    <part-group type="start">
+    <part-group type="stop">
       <footnote>x</footnote>
       <level>x</level>
     </part-group>

--- a/data/synthetic/string-mute.3.1.xml
+++ b/data/synthetic/string-mute.3.1.xml
@@ -8,7 +8,7 @@
     <score-part id="id1">
       <part-name>x</part-name>
     </score-part>
-    <part-group type="start">
+    <part-group type="stop">
       <footnote>x</footnote>
       <level>x</level>
     </part-group>

--- a/data/synthetic/string.3.0.xml
+++ b/data/synthetic/string.3.0.xml
@@ -8,7 +8,7 @@
     <score-part id="id1">
       <part-name>x</part-name>
     </score-part>
-    <part-group type="start">
+    <part-group type="stop">
       <footnote>x</footnote>
       <level>x</level>
     </part-group>

--- a/data/synthetic/strong-accent.3.0.xml
+++ b/data/synthetic/strong-accent.3.0.xml
@@ -8,7 +8,7 @@
     <score-part id="id1">
       <part-name>x</part-name>
     </score-part>
-    <part-group type="start">
+    <part-group type="stop">
       <footnote>x</footnote>
       <level>x</level>
     </part-group>

--- a/data/synthetic/suffix.3.0.xml
+++ b/data/synthetic/suffix.3.0.xml
@@ -8,7 +8,7 @@
     <score-part id="id1">
       <part-name>x</part-name>
     </score-part>
-    <part-group type="start">
+    <part-group type="stop">
       <footnote>x</footnote>
       <level>x</level>
     </part-group>

--- a/data/synthetic/swing-style.4.0.xml
+++ b/data/synthetic/swing-style.4.0.xml
@@ -8,7 +8,7 @@
     <score-part id="id1">
       <part-name>x</part-name>
     </score-part>
-    <part-group type="start">
+    <part-group type="stop">
       <footnote>x</footnote>
       <level>x</level>
     </part-group>

--- a/data/synthetic/swing-type.4.0.xml
+++ b/data/synthetic/swing-type.4.0.xml
@@ -8,7 +8,7 @@
     <score-part id="id1">
       <part-name>x</part-name>
     </score-part>
-    <part-group type="start">
+    <part-group type="stop">
       <footnote>x</footnote>
       <level>x</level>
     </part-group>

--- a/data/synthetic/swing.4.0.xml
+++ b/data/synthetic/swing.4.0.xml
@@ -8,7 +8,7 @@
     <score-part id="id1">
       <part-name>x</part-name>
     </score-part>
-    <part-group type="start">
+    <part-group type="stop">
       <footnote>x</footnote>
       <level>x</level>
     </part-group>

--- a/data/synthetic/symbol.3.1.xml
+++ b/data/synthetic/symbol.3.1.xml
@@ -8,7 +8,7 @@
     <score-part id="id1">
       <part-name>x</part-name>
     </score-part>
-    <part-group type="start">
+    <part-group type="stop">
       <footnote>x</footnote>
       <level>x</level>
     </part-group>

--- a/data/synthetic/sync.4.0.xml
+++ b/data/synthetic/sync.4.0.xml
@@ -8,7 +8,7 @@
     <score-part id="id1">
       <part-name>x</part-name>
     </score-part>
-    <part-group type="start">
+    <part-group type="stop">
       <footnote>x</footnote>
       <level>x</level>
     </part-group>

--- a/data/synthetic/tap.3.0.xml
+++ b/data/synthetic/tap.3.0.xml
@@ -8,7 +8,7 @@
     <score-part id="id1">
       <part-name>x</part-name>
     </score-part>
-    <part-group type="start">
+    <part-group type="stop">
       <footnote>x</footnote>
       <level>x</level>
     </part-group>

--- a/data/synthetic/tap.3.1.xml
+++ b/data/synthetic/tap.3.1.xml
@@ -8,7 +8,7 @@
     <score-part id="id1">
       <part-name>x</part-name>
     </score-part>
-    <part-group type="start">
+    <part-group type="stop">
       <footnote>x</footnote>
       <level>x</level>
     </part-group>

--- a/data/synthetic/technical.3.1.xml
+++ b/data/synthetic/technical.3.1.xml
@@ -8,7 +8,7 @@
     <score-part id="id1">
       <part-name>x</part-name>
     </score-part>
-    <part-group type="start">
+    <part-group type="stop">
       <footnote>x</footnote>
       <level>x</level>
     </part-group>

--- a/data/synthetic/tenuto.3.0.xml
+++ b/data/synthetic/tenuto.3.0.xml
@@ -8,7 +8,7 @@
     <score-part id="id1">
       <part-name>x</part-name>
     </score-part>
-    <part-group type="start">
+    <part-group type="stop">
       <footnote>x</footnote>
       <level>x</level>
     </part-group>

--- a/data/synthetic/text.3.0.xml
+++ b/data/synthetic/text.3.0.xml
@@ -8,7 +8,7 @@
     <score-part id="id1">
       <part-name>x</part-name>
     </score-part>
-    <part-group type="start">
+    <part-group type="stop">
       <footnote>x</footnote>
       <level>x</level>
     </part-group>

--- a/data/synthetic/thumb-position.3.0.xml
+++ b/data/synthetic/thumb-position.3.0.xml
@@ -8,7 +8,7 @@
     <score-part id="id1">
       <part-name>x</part-name>
     </score-part>
-    <part-group type="start">
+    <part-group type="stop">
       <footnote>x</footnote>
       <level>x</level>
     </part-group>

--- a/data/synthetic/tie.3.0.xml
+++ b/data/synthetic/tie.3.0.xml
@@ -8,7 +8,7 @@
     <score-part id="id1">
       <part-name>x</part-name>
     </score-part>
-    <part-group type="start">
+    <part-group type="stop">
       <footnote>x</footnote>
       <level>x</level>
     </part-group>

--- a/data/synthetic/tied.3.0.xml
+++ b/data/synthetic/tied.3.0.xml
@@ -8,7 +8,7 @@
     <score-part id="id1">
       <part-name>x</part-name>
     </score-part>
-    <part-group type="start">
+    <part-group type="stop">
       <footnote>x</footnote>
       <level>x</level>
     </part-group>

--- a/data/synthetic/tied.3.1.xml
+++ b/data/synthetic/tied.3.1.xml
@@ -8,7 +8,7 @@
     <score-part id="id1">
       <part-name>x</part-name>
     </score-part>
-    <part-group type="start">
+    <part-group type="stop">
       <footnote>x</footnote>
       <level>x</level>
     </part-group>

--- a/data/synthetic/time-relation.3.0.xml
+++ b/data/synthetic/time-relation.3.0.xml
@@ -8,7 +8,7 @@
     <score-part id="id1">
       <part-name>x</part-name>
     </score-part>
-    <part-group type="start">
+    <part-group type="stop">
       <footnote>x</footnote>
       <level>x</level>
     </part-group>

--- a/data/synthetic/time.3.0.xml
+++ b/data/synthetic/time.3.0.xml
@@ -8,7 +8,7 @@
     <score-part id="id1">
       <part-name>x</part-name>
     </score-part>
-    <part-group type="start">
+    <part-group type="stop">
       <footnote>x</footnote>
       <level>x</level>
     </part-group>

--- a/data/synthetic/time.3.1.xml
+++ b/data/synthetic/time.3.1.xml
@@ -8,7 +8,7 @@
     <score-part id="id1">
       <part-name>x</part-name>
     </score-part>
-    <part-group type="start">
+    <part-group type="stop">
       <footnote>x</footnote>
       <level>x</level>
     </part-group>

--- a/data/synthetic/timpani.3.0.xml
+++ b/data/synthetic/timpani.3.0.xml
@@ -8,7 +8,7 @@
     <score-part id="id1">
       <part-name>x</part-name>
     </score-part>
-    <part-group type="start">
+    <part-group type="stop">
       <footnote>x</footnote>
       <level>x</level>
     </part-group>

--- a/data/synthetic/timpani.4.0.xml
+++ b/data/synthetic/timpani.4.0.xml
@@ -8,7 +8,7 @@
     <score-part id="id1">
       <part-name>x</part-name>
     </score-part>
-    <part-group type="start">
+    <part-group type="stop">
       <footnote>x</footnote>
       <level>x</level>
     </part-group>

--- a/data/synthetic/toe.3.0.xml
+++ b/data/synthetic/toe.3.0.xml
@@ -8,7 +8,7 @@
     <score-part id="id1">
       <part-name>x</part-name>
     </score-part>
-    <part-group type="start">
+    <part-group type="stop">
       <footnote>x</footnote>
       <level>x</level>
     </part-group>

--- a/data/synthetic/transpose.3.0.xml
+++ b/data/synthetic/transpose.3.0.xml
@@ -8,7 +8,7 @@
     <score-part id="id1">
       <part-name>x</part-name>
     </score-part>
-    <part-group type="start">
+    <part-group type="stop">
       <footnote>x</footnote>
       <level>x</level>
     </part-group>

--- a/data/synthetic/transpose.3.1.xml
+++ b/data/synthetic/transpose.3.1.xml
@@ -8,7 +8,7 @@
     <score-part id="id1">
       <part-name>x</part-name>
     </score-part>
-    <part-group type="start">
+    <part-group type="stop">
       <footnote>x</footnote>
       <level>x</level>
     </part-group>

--- a/data/synthetic/tremolo.3.0.xml
+++ b/data/synthetic/tremolo.3.0.xml
@@ -8,7 +8,7 @@
     <score-part id="id1">
       <part-name>x</part-name>
     </score-part>
-    <part-group type="start">
+    <part-group type="stop">
       <footnote>x</footnote>
       <level>x</level>
     </part-group>

--- a/data/synthetic/tremolo.3.1.xml
+++ b/data/synthetic/tremolo.3.1.xml
@@ -8,7 +8,7 @@
     <score-part id="id1">
       <part-name>x</part-name>
     </score-part>
-    <part-group type="start">
+    <part-group type="stop">
       <footnote>x</footnote>
       <level>x</level>
     </part-group>

--- a/data/synthetic/trill-mark.3.0.xml
+++ b/data/synthetic/trill-mark.3.0.xml
@@ -8,7 +8,7 @@
     <score-part id="id1">
       <part-name>x</part-name>
     </score-part>
-    <part-group type="start">
+    <part-group type="stop">
       <footnote>x</footnote>
       <level>x</level>
     </part-group>

--- a/data/synthetic/triple-tongue.3.0.xml
+++ b/data/synthetic/triple-tongue.3.0.xml
@@ -8,7 +8,7 @@
     <score-part id="id1">
       <part-name>x</part-name>
     </score-part>
-    <part-group type="start">
+    <part-group type="stop">
       <footnote>x</footnote>
       <level>x</level>
     </part-group>

--- a/data/synthetic/tuplet-dot.3.0.xml
+++ b/data/synthetic/tuplet-dot.3.0.xml
@@ -8,7 +8,7 @@
     <score-part id="id1">
       <part-name>x</part-name>
     </score-part>
-    <part-group type="start">
+    <part-group type="stop">
       <footnote>x</footnote>
       <level>x</level>
     </part-group>

--- a/data/synthetic/tuplet-number.3.0.xml
+++ b/data/synthetic/tuplet-number.3.0.xml
@@ -8,7 +8,7 @@
     <score-part id="id1">
       <part-name>x</part-name>
     </score-part>
-    <part-group type="start">
+    <part-group type="stop">
       <footnote>x</footnote>
       <level>x</level>
     </part-group>

--- a/data/synthetic/tuplet-type.3.0.xml
+++ b/data/synthetic/tuplet-type.3.0.xml
@@ -8,7 +8,7 @@
     <score-part id="id1">
       <part-name>x</part-name>
     </score-part>
-    <part-group type="start">
+    <part-group type="stop">
       <footnote>x</footnote>
       <level>x</level>
     </part-group>

--- a/data/synthetic/tuplet.3.0.xml
+++ b/data/synthetic/tuplet.3.0.xml
@@ -8,7 +8,7 @@
     <score-part id="id1">
       <part-name>x</part-name>
     </score-part>
-    <part-group type="start">
+    <part-group type="stop">
       <footnote>x</footnote>
       <level>x</level>
     </part-group>

--- a/data/synthetic/tuplet.3.1.xml
+++ b/data/synthetic/tuplet.3.1.xml
@@ -8,7 +8,7 @@
     <score-part id="id1">
       <part-name>x</part-name>
     </score-part>
-    <part-group type="start">
+    <part-group type="stop">
       <footnote>x</footnote>
       <level>x</level>
     </part-group>

--- a/data/synthetic/turn.3.0.xml
+++ b/data/synthetic/turn.3.0.xml
@@ -8,7 +8,7 @@
     <score-part id="id1">
       <part-name>x</part-name>
     </score-part>
-    <part-group type="start">
+    <part-group type="stop">
       <footnote>x</footnote>
       <level>x</level>
     </part-group>

--- a/data/synthetic/unstress.3.0.xml
+++ b/data/synthetic/unstress.3.0.xml
@@ -8,7 +8,7 @@
     <score-part id="id1">
       <part-name>x</part-name>
     </score-part>
-    <part-group type="start">
+    <part-group type="stop">
       <footnote>x</footnote>
       <level>x</level>
     </part-group>

--- a/data/synthetic/up-bow.3.0.xml
+++ b/data/synthetic/up-bow.3.0.xml
@@ -8,7 +8,7 @@
     <score-part id="id1">
       <part-name>x</part-name>
     </score-part>
-    <part-group type="start">
+    <part-group type="stop">
       <footnote>x</footnote>
       <level>x</level>
     </part-group>

--- a/data/synthetic/vertical-turn.3.0.xml
+++ b/data/synthetic/vertical-turn.3.0.xml
@@ -8,7 +8,7 @@
     <score-part id="id1">
       <part-name>x</part-name>
     </score-part>
-    <part-group type="start">
+    <part-group type="stop">
       <footnote>x</footnote>
       <level>x</level>
     </part-group>

--- a/data/synthetic/virtual-library.3.0.xml
+++ b/data/synthetic/virtual-library.3.0.xml
@@ -15,7 +15,7 @@
         </virtual-instrument>
       </score-instrument>
     </score-part>
-    <part-group type="start">
+    <part-group type="stop">
       <footnote>x</footnote>
       <level>x</level>
     </part-group>

--- a/data/synthetic/virtual-name.3.0.xml
+++ b/data/synthetic/virtual-name.3.0.xml
@@ -15,7 +15,7 @@
         </virtual-instrument>
       </score-instrument>
     </score-part>
-    <part-group type="start">
+    <part-group type="stop">
       <footnote>x</footnote>
       <level>x</level>
     </part-group>

--- a/data/synthetic/voice.3.0.xml
+++ b/data/synthetic/voice.3.0.xml
@@ -8,7 +8,7 @@
     <score-part id="id1">
       <part-name>x</part-name>
     </score-part>
-    <part-group type="start">
+    <part-group type="stop">
       <footnote>x</footnote>
       <level>x</level>
     </part-group>

--- a/data/synthetic/wait.4.0.xml
+++ b/data/synthetic/wait.4.0.xml
@@ -8,7 +8,7 @@
     <score-part id="id1">
       <part-name>x</part-name>
     </score-part>
-    <part-group type="start">
+    <part-group type="stop">
       <footnote>x</footnote>
       <level>x</level>
     </part-group>

--- a/data/synthetic/wavy-line.3.0.xml
+++ b/data/synthetic/wavy-line.3.0.xml
@@ -8,7 +8,7 @@
     <score-part id="id1">
       <part-name>x</part-name>
     </score-part>
-    <part-group type="start">
+    <part-group type="stop">
       <footnote>x</footnote>
       <level>x</level>
     </part-group>

--- a/data/synthetic/wavy-line.4.0.xml
+++ b/data/synthetic/wavy-line.4.0.xml
@@ -8,7 +8,7 @@
     <score-part id="id1">
       <part-name>x</part-name>
     </score-part>
-    <part-group type="start">
+    <part-group type="stop">
       <footnote>x</footnote>
       <level>x</level>
     </part-group>

--- a/data/synthetic/wedge.3.0.xml
+++ b/data/synthetic/wedge.3.0.xml
@@ -8,7 +8,7 @@
     <score-part id="id1">
       <part-name>x</part-name>
     </score-part>
-    <part-group type="start">
+    <part-group type="stop">
       <footnote>x</footnote>
       <level>x</level>
     </part-group>

--- a/data/synthetic/wedge.3.1.xml
+++ b/data/synthetic/wedge.3.1.xml
@@ -8,7 +8,7 @@
     <score-part id="id1">
       <part-name>x</part-name>
     </score-part>
-    <part-group type="start">
+    <part-group type="stop">
       <footnote>x</footnote>
       <level>x</level>
     </part-group>

--- a/data/synthetic/with-bar.3.0.xml
+++ b/data/synthetic/with-bar.3.0.xml
@@ -8,7 +8,7 @@
     <score-part id="id1">
       <part-name>x</part-name>
     </score-part>
-    <part-group type="start">
+    <part-group type="stop">
       <footnote>x</footnote>
       <level>x</level>
     </part-group>

--- a/data/synthetic/wood.3.0.xml
+++ b/data/synthetic/wood.3.0.xml
@@ -8,7 +8,7 @@
     <score-part id="id1">
       <part-name>x</part-name>
     </score-part>
-    <part-group type="start">
+    <part-group type="stop">
       <footnote>x</footnote>
       <level>x</level>
     </part-group>

--- a/data/synthetic/wood.4.0.xml
+++ b/data/synthetic/wood.4.0.xml
@@ -8,7 +8,7 @@
     <score-part id="id1">
       <part-name>x</part-name>
     </score-part>
-    <part-group type="start">
+    <part-group type="stop">
       <footnote>x</footnote>
       <level>x</level>
     </part-group>

--- a/data/synthetic/word-font.3.0.xml
+++ b/data/synthetic/word-font.3.0.xml
@@ -11,7 +11,7 @@
     <score-part id="id1">
       <part-name>x</part-name>
     </score-part>
-    <part-group type="start">
+    <part-group type="stop">
       <footnote>x</footnote>
       <level>x</level>
     </part-group>

--- a/data/synthetic/words.3.0.xml
+++ b/data/synthetic/words.3.0.xml
@@ -8,7 +8,7 @@
     <score-part id="id1">
       <part-name>x</part-name>
     </score-part>
-    <part-group type="start">
+    <part-group type="stop">
       <footnote>x</footnote>
       <level>x</level>
     </part-group>

--- a/data/synthetic/words.3.1.xml
+++ b/data/synthetic/words.3.1.xml
@@ -8,7 +8,7 @@
     <score-part id="id1">
       <part-name>x</part-name>
     </score-part>
-    <part-group type="start">
+    <part-group type="stop">
       <footnote>x</footnote>
       <level>x</level>
     </part-group>

--- a/data/synthetic/work-number.3.0.xml
+++ b/data/synthetic/work-number.3.0.xml
@@ -11,7 +11,7 @@
     <score-part id="id1">
       <part-name>x</part-name>
     </score-part>
-    <part-group type="start">
+    <part-group type="stop">
       <footnote>x</footnote>
       <level>x</level>
     </part-group>

--- a/data/synthetic/work-title.3.0.xml
+++ b/data/synthetic/work-title.3.0.xml
@@ -11,7 +11,7 @@
     <score-part id="id1">
       <part-name>x</part-name>
     </score-part>
-    <part-group type="start">
+    <part-group type="stop">
       <footnote>x</footnote>
       <level>x</level>
     </part-group>

--- a/docs/ai/design/api-roundtrip-classifier.md
+++ b/docs/ai/design/api-roundtrip-classifier.md
@@ -178,15 +178,25 @@ presence/absence of `.actual.xml` remains the FAIL-vs-pipeline-error signal; the
 `.status` sidecar only refines *which* pipeline error. The sidecar lives in the
 gitignored dump dir and is never checked in.
 
-### A note on `support="full"`/`"partial"` drops
+### Category G — `support="full"`/`"partial"` drops
 
 A dropped element whose `api.features.xml` support is `full` or `partial` does
 **not** satisfy category B (drop-only) — B requires *every* missing class to be
-`support="none"`. Such a file falls through to `unknown` and is logged, because a
-class that is supposed to round-trip but vanished is a genuine correctness bug or
-a partial-drop, not an expected feature gap. This is the intended behavior: the
-multiset makes the distinction provable across the whole file rather than hiding
-it behind whatever the first positional divergence happened to be.
+`support="none"`. A class that is supposed to round-trip but vanished is either a
+genuine impl round-trip bug or an `api.features.xml` overstatement; both are
+actionable and need human triage (issue #219). These files are assigned
+**category G**, with the dropped supported classes as their `blocking_features`,
+rather than being buried in `unknown`. G is evaluated last (after B/C/D/E), so a
+precise enum (D) or attribute (E) finding still wins when the first divergence
+matches one; otherwise the supported drop is surfaced. The multiset makes this
+provable across the whole file rather than hiding it behind whatever the first
+positional divergence happened to be.
+
+`part-group` was the motivating case: marked `support="full"` yet the single
+most-dropped element, which turned out to be partly an audit overstatement
+(corrected to `partial`) and partly malformed synthetic input (unmatched
+start/stop, fixed in the corpus). Surfacing such drops as G instead of `unknown`
+is what makes that triage discoverable.
 
 ## Dependency decision
 

--- a/src/include/mx/api/PartGroupData.h
+++ b/src/include/mx/api/PartGroupData.h
@@ -21,6 +21,17 @@ enum class BracketType
     square
 };
 
+// Whether the group should have common barlines, mirroring the MusicXML
+// <group-barline> element. `unspecified` means the source carried no
+// <group-barline> (and none is written back).
+enum class GroupBarline
+{
+    unspecified,
+    yes,
+    no,
+    mensurstrich
+};
+
 // The part-group element indicates groupings of parts in the score, usually indicated
 // by braces and brackets. Braces that are used for multi-staff parts should be defined
 // in the attributes element for that part. The part-group start element appears before
@@ -46,7 +57,7 @@ class PartGroupData
     std::string abbreviation;
     std::string displayAbbreviation;
     BracketType bracketType;
-    // TODO - group barline
+    GroupBarline groupBarline;
     // TODO - group time
     // TODO - group editorial
 
@@ -55,7 +66,9 @@ class PartGroupData
     // -1 indicates the absence of a number attribute
     int number;
 
-    PartGroupData() : firstPartIndex{-1}, lastPartIndex{-1}, name{}, number{-1}
+    PartGroupData()
+        : firstPartIndex{-1}, lastPartIndex{-1}, name{}, bracketType{BracketType::unspecified},
+          groupBarline{GroupBarline::unspecified}, number{-1}
     {
     }
 };
@@ -67,6 +80,8 @@ MXAPI_EQUALS_MEMBER(name)
 MXAPI_EQUALS_MEMBER(displayName)
 MXAPI_EQUALS_MEMBER(abbreviation)
 MXAPI_EQUALS_MEMBER(displayAbbreviation)
+MXAPI_EQUALS_MEMBER(bracketType)
+MXAPI_EQUALS_MEMBER(groupBarline)
 MXAPI_EQUALS_END;
 MXAPI_NOT_EQUALS_AND_VECTORS(PartGroupData);
 } // namespace api

--- a/src/private/mx/impl/Converter.cpp
+++ b/src/private/mx/impl/Converter.cpp
@@ -370,6 +370,12 @@ const Converter::EnumMap<core::GroupSymbolValue, api::BracketType> Converter::br
     {core::GroupSymbolValue::square(), api::BracketType::square},
 };
 
+const Converter::EnumMap<core::GroupBarlineValue, api::GroupBarline> Converter::groupBarlineMap = {
+    {core::GroupBarlineValue::yes(), api::GroupBarline::yes},
+    {core::GroupBarlineValue::no(), api::GroupBarline::no},
+    {core::GroupBarlineValue::mensurstrich(), api::GroupBarline::mensurstrich},
+};
+
 const Converter::EnumMap<core::RightLeftMiddle, api::HorizontalAlignment> Converter::barlinePlacementMap = {
     {core::RightLeftMiddle::right(), api::HorizontalAlignment::right},
     {core::RightLeftMiddle::left(), api::HorizontalAlignment::left},
@@ -1606,6 +1612,16 @@ core::GroupSymbolValue Converter::convert(api::BracketType value) const
 api::BracketType Converter::convert(core::GroupSymbolValue value) const
 {
     return findApiItem(bracketMap, api::BracketType::unspecified, value);
+}
+
+core::GroupBarlineValue Converter::convert(api::GroupBarline value) const
+{
+    return findCoreItem(groupBarlineMap, core::GroupBarlineValue::yes(), value);
+}
+
+api::GroupBarline Converter::convert(core::GroupBarlineValue value) const
+{
+    return findApiItem(groupBarlineMap, api::GroupBarline::unspecified, value);
 }
 
 core::FermataShape Converter::convertFermata(api::MarkType value) const

--- a/src/private/mx/impl/Converter.h
+++ b/src/private/mx/impl/Converter.h
@@ -22,6 +22,7 @@
 #include "mx/core/generated/FermataShape.h"
 #include "mx/core/generated/FontStyle.h"
 #include "mx/core/generated/FontWeight.h"
+#include "mx/core/generated/GroupBarlineValue.h"
 #include "mx/core/generated/GroupSymbolValue.h"
 #include "mx/core/generated/KindValue.h"
 #include "mx/core/generated/LeftCenterRight.h"
@@ -142,6 +143,9 @@ class Converter
     core::GroupSymbolValue convert(api::BracketType value) const;
     api::BracketType convert(core::GroupSymbolValue value) const;
 
+    core::GroupBarlineValue convert(api::GroupBarline value) const;
+    api::GroupBarline convert(core::GroupBarlineValue value) const;
+
     core::FermataShape convertFermata(api::MarkType value) const;
     api::MarkType convertFermata(core::FermataShape value) const;
 
@@ -184,6 +188,7 @@ class Converter
     const static EnumMap<core::StartStopDiscontinue, api::EndingType> endingMap;
     const static EnumMap<core::LineEnd, api::LineHook> lineStopMap;
     const static EnumMap<core::GroupSymbolValue, api::BracketType> bracketMap;
+    const static EnumMap<core::GroupBarlineValue, api::GroupBarline> groupBarlineMap;
     const static EnumMap<core::FermataShape, api::MarkType> fermataMap;
     const static EnumMap<core::SoundID, api::SoundID> instrumentMap;
     const static EnumMap<core::KindValue, api::ChordKind> kindMap;

--- a/src/private/mx/impl/NameDisplayFunctions.cpp
+++ b/src/private/mx/impl/NameDisplayFunctions.cpp
@@ -1,0 +1,51 @@
+// MusicXML Class Library
+// Copyright (c) by Matthew James Briggs
+// Distributed under the MIT License
+
+#include "mx/impl/NameDisplayFunctions.h"
+
+#include "mx/core/generated/AccidentalValue.h"
+#include "mx/core/generated/FormattedText.h"
+#include "mx/core/generated/NameDisplay.h"
+#include "mx/core/generated/NameDisplayChoice.h"
+
+#include <sstream>
+
+namespace mx
+{
+namespace impl
+{
+std::string extractDisplayText(const core::NameDisplay &nameDisplay)
+{
+    std::stringstream ss;
+    for (const auto &c : nameDisplay.choice())
+    {
+        if (c.isDisplayText())
+        {
+            ss << c.asDisplayText().value();
+        }
+        else if (c.isAccidentalText())
+        {
+            if (c.asAccidentalText().value().tag() == core::AccidentalValue::Tag::flat)
+            {
+                ss << "b"; // TODO - support accidental text correctly
+            }
+            else if (c.asAccidentalText().value().tag() == core::AccidentalValue::Tag::sharp)
+            {
+                ss << "#";
+            }
+        }
+    }
+    return ss.str();
+}
+
+core::NameDisplay makeNameDisplay(const std::string &text)
+{
+    core::NameDisplay nameDisplay{};
+    core::FormattedText ft{};
+    ft.setValue(text);
+    nameDisplay.addChoice(core::NameDisplayChoice::displayText(ft));
+    return nameDisplay;
+}
+} // namespace impl
+} // namespace mx

--- a/src/private/mx/impl/NameDisplayFunctions.h
+++ b/src/private/mx/impl/NameDisplayFunctions.h
@@ -1,0 +1,31 @@
+// MusicXML Class Library
+// Copyright (c) by Matthew James Briggs
+// Distributed under the MIT License
+
+#pragma once
+
+#include <string>
+
+namespace mx
+{
+namespace core
+{
+class NameDisplay;
+}
+} // namespace mx
+
+namespace mx
+{
+namespace impl
+{
+// Best-effort plain-text extraction from a MusicXML name-display element
+// (<part-name-display>, <group-name-display>, etc.): the concatenated
+// <display-text> runs, with <accidental-text> rendered as "b"/"#". Formatting
+// attributes are not preserved -- the api models display names as plain text.
+std::string extractDisplayText(const core::NameDisplay &nameDisplay);
+
+// Build a minimal name-display carrying a single <display-text> run. The
+// inverse of extractDisplayText for plain-text display names.
+core::NameDisplay makeNameDisplay(const std::string &text);
+} // namespace impl
+} // namespace mx

--- a/src/private/mx/impl/PartReader.cpp
+++ b/src/private/mx/impl/PartReader.cpp
@@ -28,6 +28,7 @@
 #include "mx/core/generated/VirtualInstrumentDataGroupChoice.h"
 #include "mx/impl/Converter.h"
 #include "mx/impl/MeasureReader.h"
+#include "mx/impl/NameDisplayFunctions.h"
 #include "mx/impl/PrintFunctions.h"
 #include "mx/utility/Throw.h"
 #include "mx/utility/Unused.h"
@@ -189,30 +190,6 @@ void PartReader::parseScorePart() const
     {
         parseMidiDeviceInstrumentGroup(myScorePart.midiGroup().front());
     }
-}
-
-std::string PartReader::extractDisplayText(const core::NameDisplay &nameDisplay) const
-{
-    std::stringstream ss;
-    for (const auto &c : nameDisplay.choice())
-    {
-        if (c.isDisplayText())
-        {
-            ss << c.asDisplayText().value();
-        }
-        else if (c.isAccidentalText())
-        {
-            if (c.asAccidentalText().value().tag() == core::AccidentalValue::Tag::flat)
-            {
-                ss << "b"; // TODO - support accidental text correctly
-            }
-            else if (c.asAccidentalText().value().tag() == core::AccidentalValue::Tag::sharp)
-            {
-                ss << "#";
-            }
-        }
-    }
-    return ss.str();
 }
 
 void PartReader::parseScoreInstrument(const core::ScoreInstrument &scoreInstrument) const

--- a/src/private/mx/impl/PartReader.h
+++ b/src/private/mx/impl/PartReader.h
@@ -21,7 +21,6 @@ class ScoreInstrument;
 class VirtualInstrument;
 class ScorePartMIDIGroup;
 class MIDIInstrument;
-class NameDisplay;
 } // namespace core
 
 namespace impl
@@ -52,7 +51,6 @@ class PartReader
 
     int calculateNumStaves() const;
     void parseScorePart() const;
-    std::string extractDisplayText(const core::NameDisplay &nameDisplay) const;
     void parseScoreInstrument(const core::ScoreInstrument &scoreInstrument) const;
     void parseVirtualInstrument(const core::VirtualInstrument &virtualInstrument) const;
     void parseMidiDeviceInstrumentGroup(const core::ScorePartMIDIGroup &grp) const;

--- a/src/private/mx/impl/PartWriter.cpp
+++ b/src/private/mx/impl/PartWriter.cpp
@@ -33,6 +33,7 @@
 #include "mx/impl/Converter.h"
 #include "mx/impl/MeasureCursor.h"
 #include "mx/impl/MeasureWriter.h"
+#include "mx/impl/NameDisplayFunctions.h"
 #include "mx/impl/ScoreWriter.h"
 
 #include <sstream>
@@ -68,20 +69,12 @@ core::ScorePart PartWriter::getScorePart() const
 
     if (myPartData.displayName.size() > 0)
     {
-        core::NameDisplay nameDisplay{};
-        core::FormattedText ft{};
-        ft.setValue(myPartData.displayName);
-        nameDisplay.addChoice(core::NameDisplayChoice::displayText(ft));
-        scorePart.setPartNameDisplay(nameDisplay);
+        scorePart.setPartNameDisplay(makeNameDisplay(myPartData.displayName));
     }
 
     if (myPartData.displayAbbreviation.size() > 0)
     {
-        core::NameDisplay nameDisplay{};
-        core::FormattedText ft{};
-        ft.setValue(myPartData.displayAbbreviation);
-        nameDisplay.addChoice(core::NameDisplayChoice::displayText(ft));
-        scorePart.setPartAbbreviationDisplay(nameDisplay);
+        scorePart.setPartAbbreviationDisplay(makeNameDisplay(myPartData.displayAbbreviation));
     }
 
     core::ScoreInstrument scoreInstrument{};

--- a/src/private/mx/impl/ScoreReader.cpp
+++ b/src/private/mx/impl/ScoreReader.cpp
@@ -33,6 +33,7 @@
 #include "mx/impl/EncodingFunctions.h"
 #include "mx/impl/LayoutFunctions.h"
 #include "mx/impl/LcmGcd.h"
+#include "mx/impl/NameDisplayFunctions.h"
 #include "mx/impl/PageTextFunctions.h"
 #include "mx/impl/PartReader.h"
 #include "mx/impl/TimeReader.h"
@@ -294,9 +295,19 @@ void ScoreReader::startPartGroup(int partIndex, const core::PartGroup &inPartGro
         grpData.name = inPartGroup.groupName()->value();
     }
 
+    if (inPartGroup.groupNameDisplay().has_value())
+    {
+        grpData.displayName = extractDisplayText(*inPartGroup.groupNameDisplay());
+    }
+
     if (inPartGroup.groupAbbreviation().has_value())
     {
         grpData.abbreviation = inPartGroup.groupAbbreviation()->value();
+    }
+
+    if (inPartGroup.groupAbbreviationDisplay().has_value())
+    {
+        grpData.displayAbbreviation = extractDisplayText(*inPartGroup.groupAbbreviationDisplay());
     }
 
     if (inPartGroup.groupSymbol().has_value())
@@ -305,11 +316,16 @@ void ScoreReader::startPartGroup(int partIndex, const core::PartGroup &inPartGro
         grpData.bracketType = c.convert(inPartGroup.groupSymbol()->value());
     }
 
+    if (inPartGroup.groupBarline().has_value())
+    {
+        Converter c;
+        grpData.groupBarline = c.convert(inPartGroup.groupBarline()->value());
+    }
+
     grpData.firstPartIndex = partIndex;
 
-    // TODO - group name display
-    // TODO - group abbreviation display
-    // TODO - barline, etc
+    // TODO - group time
+    // TODO - editorial (footnote/level)
 
     myPartGroupStack.push_front(grpData);
 }

--- a/src/private/mx/impl/ScoreWriter.cpp
+++ b/src/private/mx/impl/ScoreWriter.cpp
@@ -8,6 +8,7 @@
 #include "mx/core/generated/GroupName.h"
 #include "mx/core/generated/GroupSymbol.h"
 #include "mx/core/generated/Identification.h"
+#include "mx/core/generated/NameDisplay.h"
 #include "mx/core/generated/PartGroup.h"
 #include "mx/core/generated/PartList.h"
 #include "mx/core/generated/PartListChoice.h"
@@ -20,6 +21,7 @@
 #include "mx/impl/Converter.h"
 #include "mx/impl/EncodingFunctions.h"
 #include "mx/impl/LayoutFunctions.h"
+#include "mx/impl/NameDisplayFunctions.h"
 #include "mx/impl/PageTextFunctions.h"
 #include "mx/impl/PartReader.h"
 #include "mx/impl/PartWriter.h"
@@ -293,6 +295,23 @@ core::PartGroup ScoreWriter::makePartGroupStart(const api::PartGroupData &apiGrp
         mxGrp.setGroupName(groupName);
     }
 
+    if (apiGrp.displayName.size() > 0)
+    {
+        mxGrp.setGroupNameDisplay(makeNameDisplay(apiGrp.displayName));
+    }
+
+    if (apiGrp.abbreviation.size() > 0)
+    {
+        core::GroupName groupAbbreviation{};
+        groupAbbreviation.setValue(apiGrp.abbreviation);
+        mxGrp.setGroupAbbreviation(groupAbbreviation);
+    }
+
+    if (apiGrp.displayAbbreviation.size() > 0)
+    {
+        mxGrp.setGroupAbbreviationDisplay(makeNameDisplay(apiGrp.displayAbbreviation));
+    }
+
     Converter converter;
     if (apiGrp.bracketType != api::BracketType::unspecified)
     {
@@ -302,11 +321,14 @@ core::PartGroup ScoreWriter::makePartGroupStart(const api::PartGroupData &apiGrp
         mxGrp.setGroupSymbol(groupSymbol);
     }
 
-    // TODO - make group barline configurable
-
-    core::GroupBarline groupBarline{};
-    groupBarline.setValue(core::GroupBarlineValue::yes());
-    mxGrp.setGroupBarline(groupBarline);
+    // group-barline is only written when the source modeled one; the api no
+    // longer fabricates a constant "yes" (see issue #219).
+    if (apiGrp.groupBarline != api::GroupBarline::unspecified)
+    {
+        core::GroupBarline groupBarline{};
+        groupBarline.setValue(converter.convert(apiGrp.groupBarline));
+        mxGrp.setGroupBarline(groupBarline);
+    }
 
     return mxGrp;
 }

--- a/src/private/mxtest/api/PartGroupRoundTripTest.cpp
+++ b/src/private/mxtest/api/PartGroupRoundTripTest.cpp
@@ -1,0 +1,100 @@
+// MusicXML Class Library
+// Copyright (c) by Matthew James Briggs
+// Distributed under the MIT License
+
+#include "mxtest/control/CompileControl.h"
+#ifdef MX_COMPILE_API_TESTS
+
+#include "cpul/cpulTestHarness.h"
+#include "mx/api/DocumentManager.h"
+#include "mxtest/api/RoundTrip.h"
+
+using namespace mx::api;
+
+namespace
+{
+PartData makeSimplePart(const std::string &id, const std::string &name)
+{
+    VoiceData voice;
+    NoteData n;
+    n.tickTimePosition = 0;
+    n.pitchData.step = Step::c;
+    n.pitchData.octave = 5;
+    n.durationData.durationName = DurationName::quarter;
+    n.durationData.durationTimeTicks = DEFAULT_TICKS_PER_QUARTER;
+    voice.notes.push_back(n);
+    StaffData staff{};
+    staff.voices.emplace(0, voice);
+    MeasureData m;
+    m.staves.push_back(staff);
+    PartData pd;
+    pd.uniqueId = id;
+    pd.name = name;
+    pd.measures.push_back(m);
+    return pd;
+}
+
+ScoreData makeTwoPartScore()
+{
+    ScoreData s;
+    s.parts.push_back(makeSimplePart("P1", "Violin I"));
+    s.parts.push_back(makeSimplePart("P2", "Violin II"));
+    return s;
+}
+} // namespace
+
+// Regression test for issue #219. A well-formed part-group spanning two parts
+// must round-trip through mx::api with full fidelity. Before the fix the writer
+// dropped group-abbreviation and both display names, and fabricated a constant
+// <group-barline>yes</group-barline> regardless of input -- so the marked
+// CHECKs below were the red lines that the fix turns green.
+TEST(partGroupRoundTrip, fullFidelity)
+{
+    auto in = makeTwoPartScore();
+    PartGroupData grp;
+    grp.firstPartIndex = 0;
+    grp.lastPartIndex = 1;
+    grp.number = 1;
+    grp.name = "Violins";
+    grp.displayName = "Violins (display)";
+    grp.abbreviation = "Vlns";
+    grp.displayAbbreviation = "Vlns (display)";
+    grp.bracketType = BracketType::bracket;
+    grp.groupBarline = GroupBarline::no;
+    in.partGroups.push_back(grp);
+
+    const auto out = mxtest::roundTrip(in);
+
+    REQUIRE(out.partGroups.size() == 1);
+    const auto &got = out.partGroups.at(0);
+    CHECK_EQUAL(0, got.firstPartIndex);
+    CHECK_EQUAL(1, got.lastPartIndex);
+    CHECK_EQUAL(1, got.number);
+    CHECK_EQUAL("Violins", got.name);
+    CHECK_EQUAL("Violins (display)", got.displayName);      // red before #219 fix (dropped)
+    CHECK_EQUAL("Vlns", got.abbreviation);                  // red before #219 fix (dropped)
+    CHECK_EQUAL("Vlns (display)", got.displayAbbreviation); // red before #219 fix (dropped)
+    CHECK(BracketType::bracket == got.bracketType);
+    CHECK(GroupBarline::no == got.groupBarline); // red before #219 fix (fabricated yes)
+}
+
+// A part-group that carries no <group-barline> must NOT gain a fabricated one on
+// write. (Previously every group was emitted with <group-barline>yes</group-barline>.)
+TEST(partGroupRoundTrip, noFabricatedBarline)
+{
+    auto in = makeTwoPartScore();
+    PartGroupData grp;
+    grp.firstPartIndex = 0;
+    grp.lastPartIndex = 1;
+    grp.name = "Group";
+    grp.bracketType = BracketType::brace;
+    // groupBarline left unspecified on purpose.
+    in.partGroups.push_back(grp);
+
+    const auto out = mxtest::roundTrip(in);
+
+    REQUIRE(out.partGroups.size() == 1);
+    CHECK(GroupBarline::unspecified == out.partGroups.at(0).groupBarline);
+}
+
+#endif


### PR DESCRIPTION
## Summary

Progresses #219 in two parts: fix part-group round-trip, and make the round-trip classifier surface the dropped-supported-element signal #219 is about (instead of burying it in `unknown`).

### part-group round-trip (mx::api / mx::impl)

#219 flagged part-group as the most-dropped `support=full` element on api round-trip (373 files). It was two problems:

1. Misleading corpus signal. All 373 drops were synthetic files with an unmatched `<part-group type="start">` (no stop) -- schema-valid but semantically invalid, a start/stop pairing constraint XSD cannot express. `mx::api` correctly drops an unmatched start (it models a complete start..stop span), and zero real-world files drop part-group. Fixed by making the synthetic part-groups well-formed (trailing `start` -> `stop`, 386 files; schema-valid per version, audit surface unchanged).

2. Overstated support. Even well-formed groups lost data on write: `group-abbreviation` read but never written, `group-barline` fabricated as a constant `yes`, `displayName`/`displayAbbreviation` dead. Now: model `group-barline` (`api::GroupBarline`), write `group-abbreviation`, wire the display names to `group-name-display`/`group-abbreviation-display` via a shared `NameDisplayFunctions` helper. `api.features.xml` corrected `full` -> `partial`; `group-time`/editorial stay unmodeled by design.

### classifier (audit/classify.py)

The classifier put every file dropping a `support=full`/`partial` element into `unknown` -- category B only fires when every dropped class is `support=none`, so any file mixing a supported drop with unsupported ones (nearly all) fell through. That buried #219's premise: 759 of 828 files were `unknown`. Added category G (supported-element drop): an actionable impl-bug-or-audit-overstatement signal, evaluated after B/C/D/E (a precise enum/attribute finding still wins) and listing the dropped supported classes as `blocking_features`. On the corpus this moves 575 files out of `unknown` (-> 183) and ranks the real offenders: staff (280), lyric (117), text (115), voice (96), measure-numbering (88).

## Testing

- [x] New `partGroupRoundTrip` test: red before the part-group fix, green after
- [x] Full api/impl suite: 4113 assertions / 271 cases
- [x] corert over the corpus: 830 files (the 386 synthetic edits round-trip in `mx::core`)
- [x] `make test-audit`: 13 cases incl. 2 new category-G tests
- [x] api round-trip: files dropping part-group 373 -> 0; classifier `unknown` 759 -> 183
- [x] Changed synthetic files schema-valid (3.0/3.1/4.0); `make check` and the api-roundtrip regression gate pass

No corpus files become green (each still drops `footnote`/`level`/`staff`), so the pinned baseline is unchanged; the targeted test is the demonstration.

## References

- Progresses #219
- Part of #208
- Surfaced by #211 / #217