### PR TITLE
feat: round-trip direction voice and pin the synthetic segno/coda fixtures

### DIFF
--- a/data/corpus.xml
+++ b/data/corpus.xml
@@ -2486,7 +2486,7 @@
         <file version="3.0">synthetic/work-title.3.0.xml</file>
       </synthetic-files>
     </element>
-    <element name="duration" total-files="446" wild-files="437" synthetic-files="9" min-synthetic-version="3.0">
+    <element name="duration" total-files="450" wild-files="437" synthetic-files="13" min-synthetic-version="3.0">
       <wild-files count="437">
         <file>custom/musescore-slur-start-stop.musicxml</file>
         <file>custom/segno_coda_roundtrip.3.0.xml</file>
@@ -2502,8 +2502,10 @@
         <file>foundsuite/Deutscher Tanz D.820.1.xml</file>
         <!-- 425 more -->
       </wild-files>
-      <synthetic-files count="9" min-version="3.0">
+      <synthetic-files count="13" min-version="3.0">
         <file version="3.0">synthetic/cancel.location.3.0.xml</file>
+        <file version="3.0">synthetic/coda.3.0.xml</file>
+        <file version="3.1">synthetic/coda.3.1.xml</file>
         <file version="3.0">synthetic/figure-number.3.0.xml</file>
         <file version="3.0">synthetic/figured-bass.3.0.xml</file>
         <file version="3.1">synthetic/figured-bass.3.1.xml</file>
@@ -2511,10 +2513,12 @@
         <file version="3.0">synthetic/key-accidental.3.0.xml</file>
         <file version="3.1">synthetic/key-accidental.smufl.3.1.xml</file>
         <file version="3.0">synthetic/prefix.3.0.xml</file>
+        <file version="3.0">synthetic/segno.3.0.xml</file>
+        <file version="3.1">synthetic/segno.3.1.xml</file>
         <file version="3.0">synthetic/suffix.3.0.xml</file>
       </synthetic-files>
     </element>
-    <element name="attributes" total-files="471" wild-files="435" synthetic-files="36" min-synthetic-version="3.0">
+    <element name="attributes" total-files="475" wild-files="435" synthetic-files="40" min-synthetic-version="3.0">
       <wild-files count="435">
         <file>custom/musescore-slur-start-stop.musicxml</file>
         <file>custom/segno_coda_roundtrip.3.0.xml</file>
@@ -2530,13 +2534,15 @@
         <file>foundsuite/Deutscher Tanz D.820.1.xml</file>
         <!-- 423 more -->
       </wild-files>
-      <synthetic-files count="36" min-version="3.0">
+      <synthetic-files count="40" min-version="3.0">
         <file version="3.0">synthetic/beat-repeat.3.0.xml</file>
         <file version="3.0">synthetic/beat-type.3.0.xml</file>
         <file version="3.0">synthetic/beats.3.0.xml</file>
         <file version="3.0">synthetic/cancel.location.3.0.xml</file>
         <file version="3.0">synthetic/clef.3.0.xml</file>
         <file version="3.1">synthetic/clef.3.1.xml</file>
+        <file version="3.0">synthetic/coda.3.0.xml</file>
+        <file version="3.1">synthetic/coda.3.1.xml</file>
         <file version="3.0">synthetic/directive.3.0.xml</file>
         <file version="3.0">synthetic/double.3.0.xml</file>
         <file version="4.0">synthetic/double.4.0.xml</file>
@@ -2556,6 +2562,8 @@
         <file version="4.0">synthetic/part-clef.4.0.xml</file>
         <file version="3.0">synthetic/part-symbol.3.0.xml</file>
         <file version="4.0">synthetic/part-transpose.4.0.xml</file>
+        <file version="3.0">synthetic/segno.3.0.xml</file>
+        <file version="3.1">synthetic/segno.3.1.xml</file>
         <file version="3.0">synthetic/senza-misura.3.0.xml</file>
         <file version="3.0">synthetic/slash-dot.3.0.xml</file>
         <file version="3.0">synthetic/slash-type.3.0.xml</file>
@@ -2569,7 +2577,7 @@
         <file version="3.1">synthetic/transpose.3.1.xml</file>
       </synthetic-files>
     </element>
-    <element name="divisions" total-files="438" wild-files="435" synthetic-files="3" min-synthetic-version="3.0">
+    <element name="divisions" total-files="442" wild-files="435" synthetic-files="7" min-synthetic-version="3.0">
       <wild-files count="435">
         <file>custom/musescore-slur-start-stop.musicxml</file>
         <file>custom/segno_coda_roundtrip.3.0.xml</file>
@@ -2585,13 +2593,17 @@
         <file>foundsuite/Deutscher Tanz D.820.1.xml</file>
         <!-- 423 more -->
       </wild-files>
-      <synthetic-files count="3" min-version="3.0">
+      <synthetic-files count="7" min-version="3.0">
         <file version="3.0">synthetic/cancel.location.3.0.xml</file>
+        <file version="3.0">synthetic/coda.3.0.xml</file>
+        <file version="3.1">synthetic/coda.3.1.xml</file>
         <file version="3.0">synthetic/key-accidental.3.0.xml</file>
         <file version="3.1">synthetic/key-accidental.smufl.3.1.xml</file>
+        <file version="3.0">synthetic/segno.3.0.xml</file>
+        <file version="3.1">synthetic/segno.3.1.xml</file>
       </synthetic-files>
     </element>
-    <element name="note" total-files="653" wild-files="435" synthetic-files="218" min-synthetic-version="3.0">
+    <element name="note" total-files="657" wild-files="435" synthetic-files="222" min-synthetic-version="3.0">
       <attributes>
         <attribute name="default-x" wild-files="145" synthetic-files="2"/>
         <attribute name="default-y" wild-files="58" synthetic-files="2"/>
@@ -2630,7 +2642,7 @@
         <file>foundsuite/Deutscher Tanz D.820.1.xml</file>
         <!-- 423 more -->
       </wild-files>
-      <synthetic-files count="218" min-version="3.0">
+      <synthetic-files count="222" min-version="3.0">
         <file version="3.0">synthetic/accent.3.0.xml</file>
         <file version="3.0">synthetic/accidental-mark.3.0.xml</file>
         <file version="3.1">synthetic/accidental-mark.3.1.xml</file>
@@ -2657,6 +2669,8 @@
         <file version="3.0">synthetic/caesura.3.0.xml</file>
         <file version="3.0">synthetic/cancel.location.3.0.xml</file>
         <file version="3.0">synthetic/circular-arrow.3.0.xml</file>
+        <file version="3.0">synthetic/coda.3.0.xml</file>
+        <file version="3.1">synthetic/coda.3.1.xml</file>
         <file version="4.0">synthetic/concert-score.4.0.xml</file>
         <file version="3.0">synthetic/creator.3.0.xml</file>
         <file version="3.0">synthetic/credit-image.3.0.xml</file>
@@ -2795,6 +2809,8 @@
         <file version="3.0">synthetic/schleifer.3.0.xml</file>
         <file version="3.0">synthetic/scoop.3.0.xml</file>
         <file version="3.1">synthetic/scoop.3.1.xml</file>
+        <file version="3.0">synthetic/segno.3.0.xml</file>
+        <file version="3.1">synthetic/segno.3.1.xml</file>
         <file version="3.0">synthetic/semi-pitched.3.0.xml</file>
         <file version="3.1">synthetic/sfzp.3.1.xml</file>
         <file version="3.0">synthetic/shake.3.0.xml</file>
@@ -2851,7 +2867,7 @@
         <file version="3.0">synthetic/work-title.3.0.xml</file>
       </synthetic-files>
     </element>
-    <element name="type" total-files="417" wild-files="414" synthetic-files="3" min-synthetic-version="3.0">
+    <element name="type" total-files="421" wild-files="414" synthetic-files="7" min-synthetic-version="3.0">
       <attributes>
         <attribute name="size" wild-files="8" synthetic-files="0"/>
       </attributes>
@@ -2870,10 +2886,14 @@
         <file>foundsuite/Deutscher Tanz D.820.1.xml</file>
         <!-- 402 more -->
       </wild-files>
-      <synthetic-files count="3" min-version="3.0">
+      <synthetic-files count="7" min-version="3.0">
         <file version="3.0">synthetic/cancel.location.3.0.xml</file>
+        <file version="3.0">synthetic/coda.3.0.xml</file>
+        <file version="3.1">synthetic/coda.3.1.xml</file>
         <file version="3.0">synthetic/key-accidental.3.0.xml</file>
         <file version="3.1">synthetic/key-accidental.smufl.3.1.xml</file>
+        <file version="3.0">synthetic/segno.3.0.xml</file>
+        <file version="3.1">synthetic/segno.3.1.xml</file>
       </synthetic-files>
     </element>
     <element name="clef" total-files="417" wild-files="412" synthetic-files="5" min-synthetic-version="3.0">
@@ -3067,7 +3087,7 @@
         <file version="3.1">synthetic/time.3.1.xml</file>
       </synthetic-files>
     </element>
-    <element name="octave" total-files="624" wild-files="406" synthetic-files="218" min-synthetic-version="3.0">
+    <element name="octave" total-files="628" wild-files="406" synthetic-files="222" min-synthetic-version="3.0">
       <wild-files count="406">
         <file>custom/musescore-slur-start-stop.musicxml</file>
         <file>custom/segno_coda_roundtrip.3.0.xml</file>
@@ -3083,7 +3103,7 @@
         <file>foundsuite/Deutscher Tanz D.820.1.xml</file>
         <!-- 394 more -->
       </wild-files>
-      <synthetic-files count="218" min-version="3.0">
+      <synthetic-files count="222" min-version="3.0">
         <file version="3.0">synthetic/accent.3.0.xml</file>
         <file version="3.0">synthetic/accidental-mark.3.0.xml</file>
         <file version="3.1">synthetic/accidental-mark.3.1.xml</file>
@@ -3110,6 +3130,8 @@
         <file version="3.0">synthetic/caesura.3.0.xml</file>
         <file version="3.0">synthetic/cancel.location.3.0.xml</file>
         <file version="3.0">synthetic/circular-arrow.3.0.xml</file>
+        <file version="3.0">synthetic/coda.3.0.xml</file>
+        <file version="3.1">synthetic/coda.3.1.xml</file>
         <file version="4.0">synthetic/concert-score.4.0.xml</file>
         <file version="3.0">synthetic/creator.3.0.xml</file>
         <file version="3.0">synthetic/credit-image.3.0.xml</file>
@@ -3248,6 +3270,8 @@
         <file version="3.0">synthetic/schleifer.3.0.xml</file>
         <file version="3.0">synthetic/scoop.3.0.xml</file>
         <file version="3.1">synthetic/scoop.3.1.xml</file>
+        <file version="3.0">synthetic/segno.3.0.xml</file>
+        <file version="3.1">synthetic/segno.3.1.xml</file>
         <file version="3.0">synthetic/semi-pitched.3.0.xml</file>
         <file version="3.1">synthetic/sfzp.3.1.xml</file>
         <file version="3.0">synthetic/shake.3.0.xml</file>
@@ -3304,7 +3328,7 @@
         <file version="3.0">synthetic/work-title.3.0.xml</file>
       </synthetic-files>
     </element>
-    <element name="pitch" total-files="624" wild-files="406" synthetic-files="218" min-synthetic-version="3.0">
+    <element name="pitch" total-files="628" wild-files="406" synthetic-files="222" min-synthetic-version="3.0">
       <wild-files count="406">
         <file>custom/musescore-slur-start-stop.musicxml</file>
         <file>custom/segno_coda_roundtrip.3.0.xml</file>
@@ -3320,7 +3344,7 @@
         <file>foundsuite/Deutscher Tanz D.820.1.xml</file>
         <!-- 394 more -->
       </wild-files>
-      <synthetic-files count="218" min-version="3.0">
+      <synthetic-files count="222" min-version="3.0">
         <file version="3.0">synthetic/accent.3.0.xml</file>
         <file version="3.0">synthetic/accidental-mark.3.0.xml</file>
         <file version="3.1">synthetic/accidental-mark.3.1.xml</file>
@@ -3347,6 +3371,8 @@
         <file version="3.0">synthetic/caesura.3.0.xml</file>
         <file version="3.0">synthetic/cancel.location.3.0.xml</file>
         <file version="3.0">synthetic/circular-arrow.3.0.xml</file>
+        <file version="3.0">synthetic/coda.3.0.xml</file>
+        <file version="3.1">synthetic/coda.3.1.xml</file>
         <file version="4.0">synthetic/concert-score.4.0.xml</file>
         <file version="3.0">synthetic/creator.3.0.xml</file>
         <file version="3.0">synthetic/credit-image.3.0.xml</file>
@@ -3485,6 +3511,8 @@
         <file version="3.0">synthetic/schleifer.3.0.xml</file>
         <file version="3.0">synthetic/scoop.3.0.xml</file>
         <file version="3.1">synthetic/scoop.3.1.xml</file>
+        <file version="3.0">synthetic/segno.3.0.xml</file>
+        <file version="3.1">synthetic/segno.3.1.xml</file>
         <file version="3.0">synthetic/semi-pitched.3.0.xml</file>
         <file version="3.1">synthetic/sfzp.3.1.xml</file>
         <file version="3.0">synthetic/shake.3.0.xml</file>
@@ -3541,7 +3569,7 @@
         <file version="3.0">synthetic/work-title.3.0.xml</file>
       </synthetic-files>
     </element>
-    <element name="step" total-files="624" wild-files="406" synthetic-files="218" min-synthetic-version="3.0">
+    <element name="step" total-files="628" wild-files="406" synthetic-files="222" min-synthetic-version="3.0">
       <wild-files count="406">
         <file>custom/musescore-slur-start-stop.musicxml</file>
         <file>custom/segno_coda_roundtrip.3.0.xml</file>
@@ -3557,7 +3585,7 @@
         <file>foundsuite/Deutscher Tanz D.820.1.xml</file>
         <!-- 394 more -->
       </wild-files>
-      <synthetic-files count="218" min-version="3.0">
+      <synthetic-files count="222" min-version="3.0">
         <file version="3.0">synthetic/accent.3.0.xml</file>
         <file version="3.0">synthetic/accidental-mark.3.0.xml</file>
         <file version="3.1">synthetic/accidental-mark.3.1.xml</file>
@@ -3584,6 +3612,8 @@
         <file version="3.0">synthetic/caesura.3.0.xml</file>
         <file version="3.0">synthetic/cancel.location.3.0.xml</file>
         <file version="3.0">synthetic/circular-arrow.3.0.xml</file>
+        <file version="3.0">synthetic/coda.3.0.xml</file>
+        <file version="3.1">synthetic/coda.3.1.xml</file>
         <file version="4.0">synthetic/concert-score.4.0.xml</file>
         <file version="3.0">synthetic/creator.3.0.xml</file>
         <file version="3.0">synthetic/credit-image.3.0.xml</file>
@@ -3722,6 +3752,8 @@
         <file version="3.0">synthetic/schleifer.3.0.xml</file>
         <file version="3.0">synthetic/scoop.3.0.xml</file>
         <file version="3.1">synthetic/scoop.3.1.xml</file>
+        <file version="3.0">synthetic/segno.3.0.xml</file>
+        <file version="3.1">synthetic/segno.3.1.xml</file>
         <file version="3.0">synthetic/semi-pitched.3.0.xml</file>
         <file version="3.1">synthetic/sfzp.3.1.xml</file>
         <file version="3.0">synthetic/shake.3.0.xml</file>
@@ -12572,7 +12604,7 @@
         <file version="3.1">synthetic/flip.3.1.xml</file>
       </synthetic-files>
     </element>
-    <element name="footnote" total-files="386" wild-files="0" synthetic-files="386" min-synthetic-version="3.0">
+    <element name="footnote" total-files="382" wild-files="0" synthetic-files="382" min-synthetic-version="3.0">
       <attributes>
         <attribute name="color" wild-files="0" synthetic-files="1"/>
         <attribute name="default-x" wild-files="0" synthetic-files="1"/>
@@ -12599,7 +12631,7 @@
       </attributes>
       <wild-files count="0">
       </wild-files>
-      <synthetic-files count="386" min-version="3.0">
+      <synthetic-files count="382" min-version="3.0">
         <file version="3.0">synthetic/accent.3.0.xml</file>
         <file version="3.0">synthetic/accidental-mark.3.0.xml</file>
         <file version="3.1">synthetic/accidental-mark.3.1.xml</file>
@@ -12644,8 +12676,6 @@
         <file version="3.0">synthetic/circular-arrow.3.0.xml</file>
         <file version="3.0">synthetic/clef.3.0.xml</file>
         <file version="3.1">synthetic/clef.3.1.xml</file>
-        <file version="3.0">synthetic/coda.3.0.xml</file>
-        <file version="3.1">synthetic/coda.3.1.xml</file>
         <file version="4.0">synthetic/concert-score.4.0.xml</file>
         <file version="3.0">synthetic/creator.3.0.xml</file>
         <file version="3.0">synthetic/credit-image.3.0.xml</file>
@@ -12894,8 +12924,6 @@
         <file version="3.1">synthetic/scoop.3.1.xml</file>
         <file version="3.1">synthetic/scordatura.3.1.xml</file>
         <file version="4.0">synthetic/second.4.0.xml</file>
-        <file version="3.0">synthetic/segno.3.0.xml</file>
-        <file version="3.1">synthetic/segno.3.1.xml</file>
         <file version="3.0">synthetic/semi-pitched.3.0.xml</file>
         <file version="3.0">synthetic/senza-misura.3.0.xml</file>
         <file version="3.1">synthetic/sfzp.3.1.xml</file>
@@ -13264,7 +13292,7 @@
         <file version="3.0">synthetic/laughing.3.0.xml</file>
       </synthetic-files>
     </element>
-    <element name="level" total-files="386" wild-files="0" synthetic-files="386" min-synthetic-version="3.0">
+    <element name="level" total-files="382" wild-files="0" synthetic-files="382" min-synthetic-version="3.0">
       <attributes>
         <attribute name="bracket" wild-files="0" synthetic-files="2"/>
         <attribute name="parentheses" wild-files="0" synthetic-files="2"/>
@@ -13274,7 +13302,7 @@
       </attributes>
       <wild-files count="0">
       </wild-files>
-      <synthetic-files count="386" min-version="3.0">
+      <synthetic-files count="382" min-version="3.0">
         <file version="3.0">synthetic/accent.3.0.xml</file>
         <file version="3.0">synthetic/accidental-mark.3.0.xml</file>
         <file version="3.1">synthetic/accidental-mark.3.1.xml</file>
@@ -13319,8 +13347,6 @@
         <file version="3.0">synthetic/circular-arrow.3.0.xml</file>
         <file version="3.0">synthetic/clef.3.0.xml</file>
         <file version="3.1">synthetic/clef.3.1.xml</file>
-        <file version="3.0">synthetic/coda.3.0.xml</file>
-        <file version="3.1">synthetic/coda.3.1.xml</file>
         <file version="4.0">synthetic/concert-score.4.0.xml</file>
         <file version="3.0">synthetic/creator.3.0.xml</file>
         <file version="3.0">synthetic/credit-image.3.0.xml</file>
@@ -13569,8 +13595,6 @@
         <file version="3.1">synthetic/scoop.3.1.xml</file>
         <file version="3.1">synthetic/scordatura.3.1.xml</file>
         <file version="4.0">synthetic/second.4.0.xml</file>
-        <file version="3.0">synthetic/segno.3.0.xml</file>
-        <file version="3.1">synthetic/segno.3.1.xml</file>
         <file version="3.0">synthetic/semi-pitched.3.0.xml</file>
         <file version="3.0">synthetic/senza-misura.3.0.xml</file>
         <file version="3.1">synthetic/sfzp.3.1.xml</file>

--- a/data/synthetic/coda.3.0.features.xml
+++ b/data/synthetic/coda.3.0.features.xml
@@ -6,6 +6,9 @@
   <audited-version>3.0</audited-version>
   <features>
     <feature>
+      <name>attributes</name>
+    </feature>
+    <feature>
       <name>coda</name>
       <attributes>
         <attribute>color</attribute>
@@ -28,16 +31,22 @@
       <name>direction-type</name>
     </feature>
     <feature>
-      <name>footnote</name>
+      <name>divisions</name>
     </feature>
     <feature>
-      <name>level</name>
+      <name>duration</name>
     </feature>
     <feature>
       <name>measure</name>
       <attributes>
         <attribute>number</attribute>
       </attributes>
+    </feature>
+    <feature>
+      <name>note</name>
+    </feature>
+    <feature>
+      <name>octave</name>
     </feature>
     <feature>
       <name>part</name>
@@ -58,6 +67,9 @@
       <name>part-name</name>
     </feature>
     <feature>
+      <name>pitch</name>
+    </feature>
+    <feature>
       <name>score-part</name>
       <attributes>
         <attribute>id</attribute>
@@ -71,6 +83,12 @@
     </feature>
     <feature>
       <name>staff</name>
+    </feature>
+    <feature>
+      <name>step</name>
+    </feature>
+    <feature>
+      <name>type</name>
     </feature>
     <feature>
       <name>voice</name>

--- a/data/synthetic/coda.3.0.xml
+++ b/data/synthetic/coda.3.0.xml
@@ -1,29 +1,33 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <score-partwise version="3.0">
   <part-list>
-    <part-group type="start">
-      <footnote>x</footnote>
-      <level>x</level>
-    </part-group>
+    <part-group type="start" />
     <score-part id="id1">
       <part-name>x</part-name>
     </score-part>
-    <part-group type="stop">
-      <footnote>x</footnote>
-      <level>x</level>
-    </part-group>
+    <part-group type="stop" />
   </part-list>
   <part id="id1">
     <measure number="x">
+      <attributes>
+        <divisions>1</divisions>
+      </attributes>
       <direction>
         <direction-type>
           <coda default-x="1" default-y="1" relative-x="1" relative-y="1" font-family="x" font-style="normal" font-size="1" font-weight="normal" color="#FF000000" halign="left" valign="top" />
         </direction-type>
-        <footnote>x</footnote>
-        <level>x</level>
         <voice>1</voice>
         <staff>1</staff>
       </direction>
+      <note>
+        <pitch>
+          <step>C</step>
+          <octave>4</octave>
+        </pitch>
+        <duration>1</duration>
+        <voice>1</voice>
+        <type>quarter</type>
+      </note>
     </measure>
   </part>
 </score-partwise>

--- a/data/synthetic/coda.3.1.features.xml
+++ b/data/synthetic/coda.3.1.features.xml
@@ -6,6 +6,9 @@
   <audited-version>3.1</audited-version>
   <features>
     <feature>
+      <name>attributes</name>
+    </feature>
+    <feature>
       <name>coda</name>
       <attributes>
         <attribute>color</attribute>
@@ -30,16 +33,22 @@
       <name>direction-type</name>
     </feature>
     <feature>
-      <name>footnote</name>
+      <name>divisions</name>
     </feature>
     <feature>
-      <name>level</name>
+      <name>duration</name>
     </feature>
     <feature>
       <name>measure</name>
       <attributes>
         <attribute>number</attribute>
       </attributes>
+    </feature>
+    <feature>
+      <name>note</name>
+    </feature>
+    <feature>
+      <name>octave</name>
     </feature>
     <feature>
       <name>part</name>
@@ -60,6 +69,9 @@
       <name>part-name</name>
     </feature>
     <feature>
+      <name>pitch</name>
+    </feature>
+    <feature>
       <name>score-part</name>
       <attributes>
         <attribute>id</attribute>
@@ -73,6 +85,12 @@
     </feature>
     <feature>
       <name>staff</name>
+    </feature>
+    <feature>
+      <name>step</name>
+    </feature>
+    <feature>
+      <name>type</name>
     </feature>
     <feature>
       <name>voice</name>

--- a/data/synthetic/coda.3.1.xml
+++ b/data/synthetic/coda.3.1.xml
@@ -1,29 +1,33 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <score-partwise version="3.1">
   <part-list>
-    <part-group type="start">
-      <footnote>x</footnote>
-      <level>x</level>
-    </part-group>
+    <part-group type="start" />
     <score-part id="id1">
       <part-name>x</part-name>
     </score-part>
-    <part-group type="stop">
-      <footnote>x</footnote>
-      <level>x</level>
-    </part-group>
+    <part-group type="stop" />
   </part-list>
   <part id="id1">
     <measure number="x">
+      <attributes>
+        <divisions>1</divisions>
+      </attributes>
       <direction>
         <direction-type>
           <coda default-x="1" default-y="1" relative-x="1" relative-y="1" font-family="x" font-style="normal" font-size="1" font-weight="normal" color="#FF000000" halign="left" valign="top" id="id3" smufl="coda" />
         </direction-type>
-        <footnote>x</footnote>
-        <level>x</level>
         <voice>1</voice>
         <staff>1</staff>
       </direction>
+      <note>
+        <pitch>
+          <step>C</step>
+          <octave>4</octave>
+        </pitch>
+        <duration>1</duration>
+        <voice>1</voice>
+        <type>quarter</type>
+      </note>
     </measure>
   </part>
 </score-partwise>

--- a/data/synthetic/segno.3.0.features.xml
+++ b/data/synthetic/segno.3.0.features.xml
@@ -6,22 +6,31 @@
   <audited-version>3.0</audited-version>
   <features>
     <feature>
+      <name>attributes</name>
+    </feature>
+    <feature>
       <name>direction</name>
     </feature>
     <feature>
       <name>direction-type</name>
     </feature>
     <feature>
-      <name>footnote</name>
+      <name>divisions</name>
     </feature>
     <feature>
-      <name>level</name>
+      <name>duration</name>
     </feature>
     <feature>
       <name>measure</name>
       <attributes>
         <attribute>number</attribute>
       </attributes>
+    </feature>
+    <feature>
+      <name>note</name>
+    </feature>
+    <feature>
+      <name>octave</name>
     </feature>
     <feature>
       <name>part</name>
@@ -40,6 +49,9 @@
     </feature>
     <feature>
       <name>part-name</name>
+    </feature>
+    <feature>
+      <name>pitch</name>
     </feature>
     <feature>
       <name>score-part</name>
@@ -71,6 +83,12 @@
     </feature>
     <feature>
       <name>staff</name>
+    </feature>
+    <feature>
+      <name>step</name>
+    </feature>
+    <feature>
+      <name>type</name>
     </feature>
     <feature>
       <name>voice</name>

--- a/data/synthetic/segno.3.0.xml
+++ b/data/synthetic/segno.3.0.xml
@@ -1,29 +1,33 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <score-partwise version="3.0">
   <part-list>
-    <part-group type="start">
-      <footnote>x</footnote>
-      <level>x</level>
-    </part-group>
+    <part-group type="start" />
     <score-part id="id1">
       <part-name>x</part-name>
     </score-part>
-    <part-group type="stop">
-      <footnote>x</footnote>
-      <level>x</level>
-    </part-group>
+    <part-group type="stop" />
   </part-list>
   <part id="id1">
     <measure number="x">
+      <attributes>
+        <divisions>1</divisions>
+      </attributes>
       <direction>
         <direction-type>
           <segno default-x="1" default-y="1" relative-x="1" relative-y="1" font-family="x" font-style="normal" font-size="1" font-weight="normal" color="#FF000000" halign="left" valign="top" />
         </direction-type>
-        <footnote>x</footnote>
-        <level>x</level>
         <voice>1</voice>
         <staff>1</staff>
       </direction>
+      <note>
+        <pitch>
+          <step>C</step>
+          <octave>4</octave>
+        </pitch>
+        <duration>1</duration>
+        <voice>1</voice>
+        <type>quarter</type>
+      </note>
     </measure>
   </part>
 </score-partwise>

--- a/data/synthetic/segno.3.1.features.xml
+++ b/data/synthetic/segno.3.1.features.xml
@@ -6,22 +6,31 @@
   <audited-version>3.1</audited-version>
   <features>
     <feature>
+      <name>attributes</name>
+    </feature>
+    <feature>
       <name>direction</name>
     </feature>
     <feature>
       <name>direction-type</name>
     </feature>
     <feature>
-      <name>footnote</name>
+      <name>divisions</name>
     </feature>
     <feature>
-      <name>level</name>
+      <name>duration</name>
     </feature>
     <feature>
       <name>measure</name>
       <attributes>
         <attribute>number</attribute>
       </attributes>
+    </feature>
+    <feature>
+      <name>note</name>
+    </feature>
+    <feature>
+      <name>octave</name>
     </feature>
     <feature>
       <name>part</name>
@@ -40,6 +49,9 @@
     </feature>
     <feature>
       <name>part-name</name>
+    </feature>
+    <feature>
+      <name>pitch</name>
     </feature>
     <feature>
       <name>score-part</name>
@@ -73,6 +85,12 @@
     </feature>
     <feature>
       <name>staff</name>
+    </feature>
+    <feature>
+      <name>step</name>
+    </feature>
+    <feature>
+      <name>type</name>
     </feature>
     <feature>
       <name>voice</name>

--- a/data/synthetic/segno.3.1.xml
+++ b/data/synthetic/segno.3.1.xml
@@ -1,29 +1,33 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <score-partwise version="3.1">
   <part-list>
-    <part-group type="start">
-      <footnote>x</footnote>
-      <level>x</level>
-    </part-group>
+    <part-group type="start" />
     <score-part id="id1">
       <part-name>x</part-name>
     </score-part>
-    <part-group type="stop">
-      <footnote>x</footnote>
-      <level>x</level>
-    </part-group>
+    <part-group type="stop" />
   </part-list>
   <part id="id1">
     <measure number="x">
+      <attributes>
+        <divisions>1</divisions>
+      </attributes>
       <direction>
         <direction-type>
           <segno default-x="1" default-y="1" relative-x="1" relative-y="1" font-family="x" font-style="normal" font-size="1" font-weight="normal" color="#FF000000" halign="left" valign="top" id="id3" smufl="segno" />
         </direction-type>
-        <footnote>x</footnote>
-        <level>x</level>
         <voice>1</voice>
         <staff>1</staff>
       </direction>
+      <note>
+        <pitch>
+          <step>C</step>
+          <octave>4</octave>
+        </pitch>
+        <duration>1</duration>
+        <voice>1</voice>
+        <type>quarter</type>
+      </note>
     </measure>
   </part>
 </score-partwise>

--- a/src/private/mx/impl/DirectionReader.cpp
+++ b/src/private/mx/impl/DirectionReader.cpp
@@ -68,6 +68,7 @@
 #include "mx/impl/SoundFunctions.h"
 #include "mx/impl/SpannerFunctions.h"
 #include "mx/utility/Round.h"
+#include "mx/utility/StringToInt.h"
 #include "mx/utility/Unused.h"
 
 namespace mx
@@ -169,6 +170,17 @@ void DirectionReader::parseValues()
             {
                 myOutDirectionData.isSoundDataSpecified = true;
                 myOutDirectionData.soundData = std::move(soundData);
+            }
+        }
+
+        // The <direction>'s editorial-voice <voice> assigns the direction to a voice. A value of
+        // -1 on DirectionData::voice means none was present.
+        if (myDirection->editorialVoiceDirection().voice().has_value())
+        {
+            int parsedVoice = -1;
+            if (utility::stringToInt(myDirection->editorialVoiceDirection().voice()->c_str(), parsedVoice))
+            {
+                myOutDirectionData.voice = parsedVoice;
             }
         }
     }

--- a/src/private/mx/impl/DirectionWriter.cpp
+++ b/src/private/mx/impl/DirectionWriter.cpp
@@ -21,6 +21,7 @@
 #include "mx/core/generated/DirectionTypeChoiceChoice.h"
 #include "mx/core/generated/Divisions.h"
 #include "mx/core/generated/Dynamics.h"
+#include "mx/core/generated/EditorialVoiceDirectionGroup.h"
 #include "mx/core/generated/Empty.h"
 #include "mx/core/generated/Figure.h"
 #include "mx/core/generated/FiguredBass.h"
@@ -110,6 +111,17 @@ std::vector<core::MusicDataChoice> DirectionWriter::getDirectionLikeThings()
         coreOffset.setValue(core::Divisions{core::Decimal{static_cast<double>(offset)}});
         coreOffset.setSound(core::YesNo::yes());
         direction.setOffset(coreOffset);
+    }
+
+    // Assign the direction to a voice via the editorial-voice <voice>. Only emitted when this
+    // direction also writes direction-type content (guarded by myIsFirstDirectionTypeAdded below),
+    // so a voice carried in from a figured-bass or harmony element never produces an empty
+    // <direction>.
+    if (myDirectionData.voice >= 0)
+    {
+        core::EditorialVoiceDirectionGroup editorialVoice{};
+        editorialVoice.setVoice(std::to_string(myDirectionData.voice));
+        direction.setEditorialVoiceDirection(std::move(editorialVoice));
     }
 
     for (auto mark : myDirectionData.marks)

--- a/src/private/mxtest/api/roundtrip-baseline.txt
+++ b/src/private/mxtest/api/roundtrip-baseline.txt
@@ -65,3 +65,11 @@ lysuite/ly72b_TransposingInstruments_Full.xml
 # round-trips losslessly.
 custom/segno_coda_roundtrip.3.0.xml
 custom/segno_coda_roundtrip.3.1.xml
+
+# The audit's synthetic single-feature segno/coda fixtures. Each is a minimal score
+# with one part-group, a direction carrying the segno/coda plus a <voice> and <staff>,
+# and a single note; all round-trip losslessly.
+synthetic/segno.3.0.xml
+synthetic/segno.3.1.xml
+synthetic/coda.3.0.xml
+synthetic/coda.3.1.xml


### PR DESCRIPTION
Brings the audit's synthetic `segno`/`coda` fixtures onto the strict api read -> write -> read gate.

## What

1. **Round-trip the editorial-voice `<voice>` on a `<direction>`** (read from `editorialVoiceDirection().voice()`, written back). Today a direction's own `<voice>` is dropped. The write is emitted only when the direction has direction-type content, so a voice carried in from a figured-bass/harmony element never produces an empty `<direction>`. `<voice>` is common in the wild corpus, so this is real fidelity, not synthetic-only.

2. **Pin `synthetic/{segno,coda}.{3.0,3.1}.xml`** in `roundtrip-baseline.txt`. To make them round-trip losslessly the fixtures are tidied:
   - stripped the `<footnote>`/`<level>` editorial boilerplate the audit generator stamps onto every probe (editorial appears in **zero** real-world files, so the api does not model it — see #236, closed)
   - added a `<divisions>` + a `<note>` so the writer's first-measure `<divisions>` is legitimate instead of a spurious injection into a note-less measure

   They still isolate the segno/coda surface (3.0 base attributes; 3.1 adds id + smufl) and now also exercise a part-group and direction `<voice>`/`<staff>` through the public `DocumentManager` path.

## Why a real note instead of an impl fix for `<divisions>`

A note-less measure that the writer fills with a synthesized `<divisions>` is the #228 writer-policy issue. A naive "suppress divisions when the part has no notes" guard regresses `ksuite/k016a_Miscellaneous_Fields.xml`, which legitimately carries `<divisions>` in a note-less measure — distinguishing "source had it" from "api invented it" needs divisions-presence tracking in the public api, out of scope here. So the fixtures carry a real note; the writer-policy gap stays open under #228.

## Follow-up

A separate PR on top of this one strips the editorial boilerplate from every *other* synthetic file that isn't the dedicated `footnote`/`level` probe, so the synthetic corpus stops implying api features the wild corpus never uses.

## Testing

- [x] api round-trip regression gate: 38 passed, 0 failed (was 34; +4 synthetic)
- [x] discovery: no regressions
- [x] Full `mxtest`: 4268 assertions in 307 test cases, all pass
- [x] corert: 832 test cases pass, pinned corpus count unchanged
- [x] `clang-format` clean; audit `*.features.xml` sidecars + `corpus.xml` regenerated

## References

- Stacked on #235 / #204 (segno/coda api round-trip)
- Supersedes #236 (editorial dropped); resolves the direction-voice part of #237, with the `<divisions>` writer-policy part staying with #228
- Part of #208 (api round-trip coverage)