### PR TITLE
build: allow clients to provide their own pugixml

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -39,7 +39,7 @@ set(PUBLIC_DIR "${CMAKE_CURRENT_SOURCE_DIR}/src/include")
 # Client projects may provide a compatible pugixml target before adding mx.
 if(NOT TARGET pugixml)
     add_library(pugixml STATIC ${PRIVATE_DIR}/pugixml/pugixml.cpp)
-    target_include_directories(pugixml PUBLIC ${PRIVATE_DIR})
+    target_include_directories(pugixml PUBLIC ${PRIVATE_DIR}/pugixml)
 endif()
 
 # mx_core: the generated C++ typed model plus its hand-written runtime

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -36,8 +36,11 @@ set(PUBLIC_DIR "${CMAKE_CURRENT_SOURCE_DIR}/src/include")
 
 # pugixml: the XML layer the generated mx::core consumes directly (plan §2.1).
 # Vendored at src/private/pugixml (upstream 1.15, stock pugiconfig).
-add_library(pugixml STATIC ${PRIVATE_DIR}/pugixml/pugixml.cpp)
-target_include_directories(pugixml PUBLIC ${PRIVATE_DIR})
+# Client projects may provide a compatible pugixml target before adding mx.
+if(NOT TARGET pugixml)
+    add_library(pugixml STATIC ${PRIVATE_DIR}/pugixml/pugixml.cpp)
+    target_include_directories(pugixml PUBLIC ${PRIVATE_DIR})
+endif()
 
 # mx_core: the generated C++ typed model plus its hand-written runtime
 # (Decimal, Result, Error, Lexical, Token, NameToken, OneOrMore, Xml). The

--- a/Package.swift
+++ b/Package.swift
@@ -24,8 +24,9 @@ if useBinaryRelease {
     // `src/private`), minus the Catch2 runner, the test suites, and the example
     // programs -- the only files carrying their own main(). The public surface
     // is the mx::api headers under `src/include`; `src/private` is added to the
-    // internal header search path so the model can include `mx/core/...` and
-    // `pugixml/...`.
+    // internal header search path so the model can include `mx/core/...`; and
+    // `src/private/pugixml` is added so sources can use the canonical
+    // `#include "pugixml.hpp"` form that the CMake build also exposes.
     mxTarget = .target(
         name: "Mx",
         path: "src",
@@ -37,6 +38,7 @@ if useBinaryRelease {
         publicHeadersPath: "include",
         cxxSettings: [
             .headerSearchPath("private"),
+            .headerSearchPath("private/pugixml"),
         ]
     )
 }

--- a/README.md
+++ b/README.md
@@ -513,7 +513,8 @@ recorded in `docs/ai/design/mx-core-plan.md`.
 
 `mx::core` consumes the vendored [pugixml](http://pugixml.org/) (`src/private/pugixml/`) directly,
 in keeping with the build tenets [above](#build-tenets). The earlier `ezxml` abstraction layer is
-retired.
+retired. A client project may provide a compatible version by creating the CMake `pugixml` target
+before adding `mx`.
 
 ##### `mx::impl`
 

--- a/src/private/mx/api/DocumentManager.cpp
+++ b/src/private/mx/api/DocumentManager.cpp
@@ -11,7 +11,7 @@
 #include "mx/impl/ScoreWriter.h"
 #include "mx/impl/WriteRefusal.h"
 
-#include "pugixml/pugixml.hpp"
+#include "pugixml.hpp"
 
 #include <map>
 #include <mutex>

--- a/src/private/mx/core/Attribution.cpp
+++ b/src/private/mx/core/Attribution.cpp
@@ -13,7 +13,7 @@
 #include "mx/core/generated/ScorePartwise.h"
 #include "mx/core/generated/ScoreTimewise.h"
 
-#include "pugixml/pugixml.hpp"
+#include "pugixml.hpp"
 
 #include <utility>
 #include <vector>

--- a/src/private/mx/core/Xml.h
+++ b/src/private/mx/core/Xml.h
@@ -6,7 +6,7 @@
 
 #pragma once
 
-#include "pugixml/pugixml.hpp"
+#include "pugixml.hpp"
 
 #include <string>
 #include <string_view>

--- a/src/private/mxtest/api/ApiTester.cpp
+++ b/src/private/mxtest/api/ApiTester.cpp
@@ -2,7 +2,7 @@
 #include "mxtest/api/ApiTester.h"
 #include "mx/api/DocumentManager.h"
 #include "mxtest/file/StupidFileFunctions.h"
-#include "pugixml/pugixml.hpp"
+#include "pugixml.hpp"
 
 #include <sstream>
 

--- a/src/private/mxtest/api/CorpusRoundtripMain.cpp
+++ b/src/private/mxtest/api/CorpusRoundtripMain.cpp
@@ -24,7 +24,7 @@
 #include "mx/core/Attribution.h"
 #include "mxtest/corert/Compare.h"
 #include "mxtest/corert/Fixer.h"
-#include "pugixml/pugixml.hpp"
+#include "pugixml.hpp"
 
 #include <algorithm>
 #include <filesystem>

--- a/src/private/mxtest/api/PitchDataTest.cpp
+++ b/src/private/mxtest/api/PitchDataTest.cpp
@@ -7,7 +7,7 @@
 
 #include "cpul/cpulTestHarness.h"
 #include "mx/api/DocumentManager.h"
-#include "pugixml/pugixml.hpp"
+#include "pugixml.hpp"
 
 #include <sstream>
 #include <string>

--- a/src/private/mxtest/api/SlurTest.cpp
+++ b/src/private/mxtest/api/SlurTest.cpp
@@ -8,7 +8,7 @@
 #include "cpul/cpulTestHarness.h"
 #include "mxtest/api/TestHelpers.h"
 #include "mxtest/file/MxFileRepository.h"
-#include "pugixml/pugixml.hpp"
+#include "pugixml.hpp"
 
 #include <sstream>
 

--- a/src/private/mxtest/core/AttributionTest.cpp
+++ b/src/private/mxtest/core/AttributionTest.cpp
@@ -17,7 +17,7 @@
 #include "mx/core/generated/ScoreHeaderGroup.h"
 #include "mx/core/generated/ScorePartwise.h"
 
-#include "pugixml/pugixml.hpp"
+#include "pugixml.hpp"
 
 #include <string>
 #include <string_view>

--- a/src/private/mxtest/core/DocumentTest.cpp
+++ b/src/private/mxtest/core/DocumentTest.cpp
@@ -15,7 +15,7 @@
 #include "mx/core/generated/Document.h"
 #include "mx/core/generated/Version.h"
 
-#include "pugixml/pugixml.hpp"
+#include "pugixml.hpp"
 
 #include <string>
 

--- a/src/private/mxtest/core/ShapeTest.cpp
+++ b/src/private/mxtest/core/ShapeTest.cpp
@@ -24,7 +24,7 @@
 #include "mx/core/generated/Pitch.h"
 #include "mx/core/generated/Step.h"
 
-#include "pugixml/pugixml.hpp"
+#include "pugixml.hpp"
 
 #include <string>
 

--- a/src/private/mxtest/corert/Compare.h
+++ b/src/private/mxtest/corert/Compare.h
@@ -4,7 +4,7 @@
 
 #pragma once
 
-#include "pugixml/pugixml.hpp"
+#include "pugixml.hpp"
 
 #include <string>
 

--- a/src/private/mxtest/corert/CoreRoundtripImpl.cpp
+++ b/src/private/mxtest/corert/CoreRoundtripImpl.cpp
@@ -12,7 +12,7 @@
 #include "mxtest/file/PathRoot.h"
 #include "mxtest/import/Normalize.h"
 
-#include "pugixml/pugixml.hpp"
+#include "pugixml.hpp"
 
 #include <algorithm>
 #include <cmath>

--- a/src/private/mxtest/corert/Fixer.h
+++ b/src/private/mxtest/corert/Fixer.h
@@ -4,7 +4,7 @@
 
 #pragma once
 
-#include "pugixml/pugixml.hpp"
+#include "pugixml.hpp"
 
 #include <string>
 #include <vector>

--- a/src/private/mxtest/import/Normalize.h
+++ b/src/private/mxtest/import/Normalize.h
@@ -4,7 +4,7 @@
 
 #pragma once
 
-#include "pugixml/pugixml.hpp"
+#include "pugixml.hpp"
 
 namespace mxtest
 {

--- a/src/private/mxtest/validate/main.cpp
+++ b/src/private/mxtest/validate/main.cpp
@@ -13,7 +13,7 @@
 #include "mx/core/generated/Document.h"
 #include "mxtest/corert/CoreRoundtripImpl.h"
 
-#include "pugixml/pugixml.hpp"
+#include "pugixml.hpp"
 
 #include <cstdio>
 #include <filesystem>


### PR DESCRIPTION
This PR gates the inclusion of the local vendored `pugixml` on whether another already exists. It allows a client project that also uses `pugixml` to include `mx` without creating a conflict.

Resolves #242