### PR TITLE
gen: replace anonymous namespace with per-type name in enum impls

### DIFF
--- a/gen/cpp/templates/enum.cpp.tmpl
+++ b/gen/cpp/templates/enum.cpp.tmpl
@@ -8,16 +8,11 @@
 namespace {{vars.namespace}}
 {
 
-namespace
-{
-
-constexpr std::string_view kWire[] = {
+constexpr std::string_view k{{ident}}Wire[] = {
 {{#variants}}
     {{name.wire_q}},
 {{/variants}}
 };
-
-} // namespace
 
 {{#variants}}
 {{type.ident}} {{type.ident}}::{{ident}}() noexcept
@@ -28,14 +23,14 @@ constexpr std::string_view kWire[] = {
 {{/variants}}
 std::string_view {{ident}}::toString() const noexcept
 {
-    return kWire[static_cast<std::size_t>(m_tag)];
+    return k{{ident}}Wire[static_cast<std::size_t>(m_tag)];
 }
 
 bool {{ident}}::tryParse(std::string_view text, {{ident}} &out) noexcept
 {
-    for (std::size_t i = 0; i < std::size(kWire); ++i)
+    for (std::size_t i = 0; i < std::size(k{{ident}}Wire); ++i)
     {
-        if (kWire[i] == text)
+        if (k{{ident}}Wire[i] == text)
         {
             out = {{ident}}{static_cast<Tag>(i)};
             return true;

--- a/gen/cpp/templates/number.cpp.tmpl
+++ b/gen/cpp/templates/number.cpp.tmpl
@@ -9,10 +9,7 @@
 namespace {{vars.namespace}}
 {
 
-namespace
-{
-
-{{target_type}} clamped({{target_type}} v)
+{{target_type}} clamped{{ident}}({{target_type}} v)
 {
 {{#clamp}}
 {{#type.is_decimal}}
@@ -31,19 +28,17 @@ namespace
     return v;
 }
 
-} // namespace
-
-{{ident}}::{{ident}}() : m_value{clamped({{target_type}}{})}
+{{ident}}::{{ident}}() : m_value{clamped{{ident}}({{target_type}}{})}
 {
 }
 
-{{ident}}::{{ident}}({{target_type}} value) : m_value{clamped(std::move(value))}
+{{ident}}::{{ident}}({{target_type}} value) : m_value{clamped{{ident}}(std::move(value))}
 {
 }
 
 void {{ident}}::setValue({{target_type}} value)
 {
-    m_value = clamped(std::move(value));
+    m_value = clamped{{ident}}(std::move(value));
 }
 
 std::string {{ident}}::toString() const

--- a/gen/cpp/templates/smufl_prefixed.cpp.tmpl
+++ b/gen/cpp/templates/smufl_prefixed.cpp.tmpl
@@ -9,23 +9,18 @@
 namespace {{vars.namespace}}
 {
 
-namespace
-{
-
-constexpr std::string_view kPrefix[] = {
+constexpr std::string_view k{{ident}}Prefix[] = {
 {{#prefixes}}
     {{name.wire_q}},
 {{/prefixes}}
 };
 
 // The ASCII subset of XML name characters the schema's \c denotes.
-bool isNameChar(char c) noexcept
+bool isNameChar{{ident}}(char c) noexcept
 {
     return (c >= 'a' && c <= 'z') || (c >= 'A' && c <= 'Z') || (c >= '0' && c <= '9') || c == '-' ||
            c == '.' || c == ':' || c == '_';
 }
-
-} // namespace
 
 {{ident}}::{{ident}}()
 {
@@ -46,7 +41,7 @@ bool isNameChar(char c) noexcept
 void {{ident}}::setPrefix(Prefix value) noexcept
 {
     m_prefix = value;
-    if (static_cast<std::size_t>(m_prefix) >= std::size(kPrefix))
+    if (static_cast<std::size_t>(m_prefix) >= std::size(k{{ident}}Prefix))
     {
         m_prefix = Prefix::{{#prefixes}}{{#is_first}}{{ident}}{{/is_first}}{{/prefixes}};
     }
@@ -62,7 +57,7 @@ void {{ident}}::setSuffix(std::string value)
 void {{ident}}::repair()
 {
 {{#multi_prefix}}
-    if (static_cast<std::size_t>(m_prefix) >= std::size(kPrefix))
+    if (static_cast<std::size_t>(m_prefix) >= std::size(k{{ident}}Prefix))
     {
         m_prefix = Prefix::{{#prefixes}}{{#is_first}}{{ident}}{{/is_first}}{{/prefixes}};
     }
@@ -71,7 +66,7 @@ void {{ident}}::repair()
     cleaned.reserve(m_suffix.size());
     for (const char c : m_suffix)
     {
-        if (isNameChar(c))
+        if (isNameChar{{ident}}(c))
         {
             cleaned.push_back(c);
         }
@@ -88,10 +83,10 @@ void {{ident}}::repair()
 std::string {{ident}}::toString() const
 {
 {{#multi_prefix}}
-    std::string out{kPrefix[static_cast<std::size_t>(m_prefix)]};
+    std::string out{k{{ident}}Prefix[static_cast<std::size_t>(m_prefix)]};
 {{/multi_prefix}}
 {{^multi_prefix}}
-    std::string out{kPrefix[0]};
+    std::string out{k{{ident}}Prefix[0]};
 {{/multi_prefix}}
     out += m_suffix;
     return out;
@@ -99,9 +94,9 @@ std::string {{ident}}::toString() const
 
 bool {{ident}}::tryParse(std::string_view text, {{ident}} &out)
 {
-    for (std::size_t i = 0; i < std::size(kPrefix); ++i)
+    for (std::size_t i = 0; i < std::size(k{{ident}}Prefix); ++i)
     {
-        const std::string_view prefix = kPrefix[i];
+        const std::string_view prefix = k{{ident}}Prefix[i];
         if (text.size() < prefix.size() || text.substr(0, prefix.size()) != prefix)
         {
             continue;
@@ -116,7 +111,7 @@ bool {{ident}}::tryParse(std::string_view text, {{ident}} &out)
         bool valid = true;
         for (const char c : suffix)
         {
-            if (!isNameChar(c))
+            if (!isNameChar{{ident}}(c))
             {
                 valid = false;
                 break;

--- a/gen/cpp/templates/string.cpp.tmpl
+++ b/gen/cpp/templates/string.cpp.tmpl
@@ -7,10 +7,7 @@
 namespace {{vars.namespace}}
 {
 
-namespace
-{
-
-std::string repaired(std::string v)
+std::string repaired{{ident}}(std::string v)
 {
 {{#min_length}}
     // Deterministic repair to the schema's minLength (plan §2.2.2): pad
@@ -23,21 +20,19 @@ std::string repaired(std::string v)
     return v;
 }
 
-} // namespace
-
 {{#min_length}}
-{{ident}}::{{ident}}() : m_value{repaired(std::string{})}
+{{ident}}::{{ident}}() : m_value{repaired{{ident}}(std::string{})}
 {
 }
 
 {{/min_length}}
-{{ident}}::{{ident}}(std::string value) : m_value{repaired(std::move(value))}
+{{ident}}::{{ident}}(std::string value) : m_value{repaired{{ident}}(std::move(value))}
 {
 }
 
 void {{ident}}::setValue(std::string value)
 {
-    m_value = repaired(std::move(value));
+    m_value = repaired{{ident}}(std::move(value));
 }
 
 bool {{ident}}::tryParse(std::string_view text, {{ident}} &out)

--- a/src/private/mx/core/generated/AboveBelow.cpp
+++ b/src/private/mx/core/generated/AboveBelow.cpp
@@ -8,15 +8,10 @@
 namespace mx::core
 {
 
-namespace
-{
-
-constexpr std::string_view kWire[] = {
+constexpr std::string_view kAboveBelowWire[] = {
     "above",
     "below",
 };
-
-} // namespace
 
 AboveBelow AboveBelow::above() noexcept
 {
@@ -30,14 +25,14 @@ AboveBelow AboveBelow::below() noexcept
 
 std::string_view AboveBelow::toString() const noexcept
 {
-    return kWire[static_cast<std::size_t>(m_tag)];
+    return kAboveBelowWire[static_cast<std::size_t>(m_tag)];
 }
 
 bool AboveBelow::tryParse(std::string_view text, AboveBelow &out) noexcept
 {
-    for (std::size_t i = 0; i < std::size(kWire); ++i)
+    for (std::size_t i = 0; i < std::size(kAboveBelowWire); ++i)
     {
-        if (kWire[i] == text)
+        if (kAboveBelowWire[i] == text)
         {
             out = AboveBelow{static_cast<Tag>(i)};
             return true;

--- a/src/private/mx/core/generated/AccidentalValue.cpp
+++ b/src/private/mx/core/generated/AccidentalValue.cpp
@@ -8,10 +8,7 @@
 namespace mx::core
 {
 
-namespace
-{
-
-constexpr std::string_view kWire[] = {
+constexpr std::string_view kAccidentalValueWire[] = {
     "sharp",
     "natural",
     "flat",
@@ -54,8 +51,6 @@ constexpr std::string_view kWire[] = {
     "koron",
     "other",
 };
-
-} // namespace
 
 AccidentalValue AccidentalValue::sharp() noexcept
 {
@@ -264,14 +259,14 @@ AccidentalValue AccidentalValue::other() noexcept
 
 std::string_view AccidentalValue::toString() const noexcept
 {
-    return kWire[static_cast<std::size_t>(m_tag)];
+    return kAccidentalValueWire[static_cast<std::size_t>(m_tag)];
 }
 
 bool AccidentalValue::tryParse(std::string_view text, AccidentalValue &out) noexcept
 {
-    for (std::size_t i = 0; i < std::size(kWire); ++i)
+    for (std::size_t i = 0; i < std::size(kAccidentalValueWire); ++i)
     {
-        if (kWire[i] == text)
+        if (kAccidentalValueWire[i] == text)
         {
             out = AccidentalValue{static_cast<Tag>(i)};
             return true;

--- a/src/private/mx/core/generated/AccordionMiddle.cpp
+++ b/src/private/mx/core/generated/AccordionMiddle.cpp
@@ -9,10 +9,7 @@
 namespace mx::core
 {
 
-namespace
-{
-
-int clamped(int v)
+int clampedAccordionMiddle(int v)
 {
     if (v < 1)
     {
@@ -25,19 +22,17 @@ int clamped(int v)
     return v;
 }
 
-} // namespace
-
-AccordionMiddle::AccordionMiddle() : m_value{clamped(int{})}
+AccordionMiddle::AccordionMiddle() : m_value{clampedAccordionMiddle(int{})}
 {
 }
 
-AccordionMiddle::AccordionMiddle(int value) : m_value{clamped(std::move(value))}
+AccordionMiddle::AccordionMiddle(int value) : m_value{clampedAccordionMiddle(std::move(value))}
 {
 }
 
 void AccordionMiddle::setValue(int value)
 {
-    m_value = clamped(std::move(value));
+    m_value = clampedAccordionMiddle(std::move(value));
 }
 
 std::string AccordionMiddle::toString() const

--- a/src/private/mx/core/generated/ArrowDirection.cpp
+++ b/src/private/mx/core/generated/ArrowDirection.cpp
@@ -8,16 +8,11 @@
 namespace mx::core
 {
 
-namespace
-{
-
-constexpr std::string_view kWire[] = {
+constexpr std::string_view kArrowDirectionWire[] = {
     "left",      "up",        "right",      "down",    "northwest",           "northeast",
     "southeast", "southwest", "left right", "up down", "northwest southeast", "northeast southwest",
     "other",
 };
-
-} // namespace
 
 ArrowDirection ArrowDirection::left() noexcept
 {
@@ -86,14 +81,14 @@ ArrowDirection ArrowDirection::other() noexcept
 
 std::string_view ArrowDirection::toString() const noexcept
 {
-    return kWire[static_cast<std::size_t>(m_tag)];
+    return kArrowDirectionWire[static_cast<std::size_t>(m_tag)];
 }
 
 bool ArrowDirection::tryParse(std::string_view text, ArrowDirection &out) noexcept
 {
-    for (std::size_t i = 0; i < std::size(kWire); ++i)
+    for (std::size_t i = 0; i < std::size(kArrowDirectionWire); ++i)
     {
-        if (kWire[i] == text)
+        if (kArrowDirectionWire[i] == text)
         {
             out = ArrowDirection{static_cast<Tag>(i)};
             return true;

--- a/src/private/mx/core/generated/ArrowStyle.cpp
+++ b/src/private/mx/core/generated/ArrowStyle.cpp
@@ -8,14 +8,9 @@
 namespace mx::core
 {
 
-namespace
-{
-
-constexpr std::string_view kWire[] = {
+constexpr std::string_view kArrowStyleWire[] = {
     "single", "double", "filled", "hollow", "paired", "combined", "other",
 };
-
-} // namespace
 
 ArrowStyle ArrowStyle::single() noexcept
 {
@@ -54,14 +49,14 @@ ArrowStyle ArrowStyle::other() noexcept
 
 std::string_view ArrowStyle::toString() const noexcept
 {
-    return kWire[static_cast<std::size_t>(m_tag)];
+    return kArrowStyleWire[static_cast<std::size_t>(m_tag)];
 }
 
 bool ArrowStyle::tryParse(std::string_view text, ArrowStyle &out) noexcept
 {
-    for (std::size_t i = 0; i < std::size(kWire); ++i)
+    for (std::size_t i = 0; i < std::size(kArrowStyleWire); ++i)
     {
-        if (kWire[i] == text)
+        if (kArrowStyleWire[i] == text)
         {
             out = ArrowStyle{static_cast<Tag>(i)};
             return true;

--- a/src/private/mx/core/generated/BackwardForward.cpp
+++ b/src/private/mx/core/generated/BackwardForward.cpp
@@ -8,15 +8,10 @@
 namespace mx::core
 {
 
-namespace
-{
-
-constexpr std::string_view kWire[] = {
+constexpr std::string_view kBackwardForwardWire[] = {
     "backward",
     "forward",
 };
-
-} // namespace
 
 BackwardForward BackwardForward::backward() noexcept
 {
@@ -30,14 +25,14 @@ BackwardForward BackwardForward::forward() noexcept
 
 std::string_view BackwardForward::toString() const noexcept
 {
-    return kWire[static_cast<std::size_t>(m_tag)];
+    return kBackwardForwardWire[static_cast<std::size_t>(m_tag)];
 }
 
 bool BackwardForward::tryParse(std::string_view text, BackwardForward &out) noexcept
 {
-    for (std::size_t i = 0; i < std::size(kWire); ++i)
+    for (std::size_t i = 0; i < std::size(kBackwardForwardWire); ++i)
     {
-        if (kWire[i] == text)
+        if (kBackwardForwardWire[i] == text)
         {
             out = BackwardForward{static_cast<Tag>(i)};
             return true;

--- a/src/private/mx/core/generated/BarStyle.cpp
+++ b/src/private/mx/core/generated/BarStyle.cpp
@@ -8,15 +8,10 @@
 namespace mx::core
 {
 
-namespace
-{
-
-constexpr std::string_view kWire[] = {
+constexpr std::string_view kBarStyleWire[] = {
     "regular",     "dotted",      "dashed", "heavy", "light-light", "light-heavy",
     "heavy-light", "heavy-heavy", "tick",   "short", "none",
 };
-
-} // namespace
 
 BarStyle BarStyle::regular() noexcept
 {
@@ -75,14 +70,14 @@ BarStyle BarStyle::none() noexcept
 
 std::string_view BarStyle::toString() const noexcept
 {
-    return kWire[static_cast<std::size_t>(m_tag)];
+    return kBarStyleWire[static_cast<std::size_t>(m_tag)];
 }
 
 bool BarStyle::tryParse(std::string_view text, BarStyle &out) noexcept
 {
-    for (std::size_t i = 0; i < std::size(kWire); ++i)
+    for (std::size_t i = 0; i < std::size(kBarStyleWire); ++i)
     {
-        if (kWire[i] == text)
+        if (kBarStyleWire[i] == text)
         {
             out = BarStyle{static_cast<Tag>(i)};
             return true;

--- a/src/private/mx/core/generated/BeamLevel.cpp
+++ b/src/private/mx/core/generated/BeamLevel.cpp
@@ -9,10 +9,7 @@
 namespace mx::core
 {
 
-namespace
-{
-
-int clamped(int v)
+int clampedBeamLevel(int v)
 {
     if (v < 1)
     {
@@ -25,19 +22,17 @@ int clamped(int v)
     return v;
 }
 
-} // namespace
-
-BeamLevel::BeamLevel() : m_value{clamped(int{})}
+BeamLevel::BeamLevel() : m_value{clampedBeamLevel(int{})}
 {
 }
 
-BeamLevel::BeamLevel(int value) : m_value{clamped(std::move(value))}
+BeamLevel::BeamLevel(int value) : m_value{clampedBeamLevel(std::move(value))}
 {
 }
 
 void BeamLevel::setValue(int value)
 {
-    m_value = clamped(std::move(value));
+    m_value = clampedBeamLevel(std::move(value));
 }
 
 std::string BeamLevel::toString() const

--- a/src/private/mx/core/generated/BeamValue.cpp
+++ b/src/private/mx/core/generated/BeamValue.cpp
@@ -8,14 +8,9 @@
 namespace mx::core
 {
 
-namespace
-{
-
-constexpr std::string_view kWire[] = {
+constexpr std::string_view kBeamValueWire[] = {
     "begin", "continue", "end", "forward hook", "backward hook",
 };
-
-} // namespace
 
 BeamValue BeamValue::begin() noexcept
 {
@@ -44,14 +39,14 @@ BeamValue BeamValue::backwardHook() noexcept
 
 std::string_view BeamValue::toString() const noexcept
 {
-    return kWire[static_cast<std::size_t>(m_tag)];
+    return kBeamValueWire[static_cast<std::size_t>(m_tag)];
 }
 
 bool BeamValue::tryParse(std::string_view text, BeamValue &out) noexcept
 {
-    for (std::size_t i = 0; i < std::size(kWire); ++i)
+    for (std::size_t i = 0; i < std::size(kBeamValueWire); ++i)
     {
-        if (kWire[i] == text)
+        if (kBeamValueWire[i] == text)
         {
             out = BeamValue{static_cast<Tag>(i)};
             return true;

--- a/src/private/mx/core/generated/BeaterValue.cpp
+++ b/src/private/mx/core/generated/BeaterValue.cpp
@@ -8,10 +8,7 @@
 namespace mx::core
 {
 
-namespace
-{
-
-constexpr std::string_view kWire[] = {
+constexpr std::string_view kBeaterValueWire[] = {
     "bow",
     "chime hammer",
     "coin",
@@ -33,8 +30,6 @@ constexpr std::string_view kWire[] = {
     "triangle beater plain",
     "wire brush",
 };
-
-} // namespace
 
 BeaterValue BeaterValue::bow() noexcept
 {
@@ -138,14 +133,14 @@ BeaterValue BeaterValue::wireBrush() noexcept
 
 std::string_view BeaterValue::toString() const noexcept
 {
-    return kWire[static_cast<std::size_t>(m_tag)];
+    return kBeaterValueWire[static_cast<std::size_t>(m_tag)];
 }
 
 bool BeaterValue::tryParse(std::string_view text, BeaterValue &out) noexcept
 {
-    for (std::size_t i = 0; i < std::size(kWire); ++i)
+    for (std::size_t i = 0; i < std::size(kBeaterValueWire); ++i)
     {
-        if (kWire[i] == text)
+        if (kBeaterValueWire[i] == text)
         {
             out = BeaterValue{static_cast<Tag>(i)};
             return true;

--- a/src/private/mx/core/generated/BendShape.cpp
+++ b/src/private/mx/core/generated/BendShape.cpp
@@ -8,15 +8,10 @@
 namespace mx::core
 {
 
-namespace
-{
-
-constexpr std::string_view kWire[] = {
+constexpr std::string_view kBendShapeWire[] = {
     "angled",
     "curved",
 };
-
-} // namespace
 
 BendShape BendShape::angled() noexcept
 {
@@ -30,14 +25,14 @@ BendShape BendShape::curved() noexcept
 
 std::string_view BendShape::toString() const noexcept
 {
-    return kWire[static_cast<std::size_t>(m_tag)];
+    return kBendShapeWire[static_cast<std::size_t>(m_tag)];
 }
 
 bool BendShape::tryParse(std::string_view text, BendShape &out) noexcept
 {
-    for (std::size_t i = 0; i < std::size(kWire); ++i)
+    for (std::size_t i = 0; i < std::size(kBendShapeWire); ++i)
     {
-        if (kWire[i] == text)
+        if (kBendShapeWire[i] == text)
         {
             out = BendShape{static_cast<Tag>(i)};
             return true;

--- a/src/private/mx/core/generated/BreathMarkValue.cpp
+++ b/src/private/mx/core/generated/BreathMarkValue.cpp
@@ -8,14 +8,9 @@
 namespace mx::core
 {
 
-namespace
-{
-
-constexpr std::string_view kWire[] = {
+constexpr std::string_view kBreathMarkValueWire[] = {
     "", "comma", "tick", "upbow", "salzedo",
 };
-
-} // namespace
 
 BreathMarkValue BreathMarkValue::empty() noexcept
 {
@@ -44,14 +39,14 @@ BreathMarkValue BreathMarkValue::salzedo() noexcept
 
 std::string_view BreathMarkValue::toString() const noexcept
 {
-    return kWire[static_cast<std::size_t>(m_tag)];
+    return kBreathMarkValueWire[static_cast<std::size_t>(m_tag)];
 }
 
 bool BreathMarkValue::tryParse(std::string_view text, BreathMarkValue &out) noexcept
 {
-    for (std::size_t i = 0; i < std::size(kWire); ++i)
+    for (std::size_t i = 0; i < std::size(kBreathMarkValueWire); ++i)
     {
-        if (kWire[i] == text)
+        if (kBreathMarkValueWire[i] == text)
         {
             out = BreathMarkValue{static_cast<Tag>(i)};
             return true;

--- a/src/private/mx/core/generated/CSSFontSize.cpp
+++ b/src/private/mx/core/generated/CSSFontSize.cpp
@@ -8,14 +8,9 @@
 namespace mx::core
 {
 
-namespace
-{
-
-constexpr std::string_view kWire[] = {
+constexpr std::string_view kCSSFontSizeWire[] = {
     "xx-small", "x-small", "small", "medium", "large", "x-large", "xx-large",
 };
-
-} // namespace
 
 CSSFontSize CSSFontSize::xxSmall() noexcept
 {
@@ -54,14 +49,14 @@ CSSFontSize CSSFontSize::xxLarge() noexcept
 
 std::string_view CSSFontSize::toString() const noexcept
 {
-    return kWire[static_cast<std::size_t>(m_tag)];
+    return kCSSFontSizeWire[static_cast<std::size_t>(m_tag)];
 }
 
 bool CSSFontSize::tryParse(std::string_view text, CSSFontSize &out) noexcept
 {
-    for (std::size_t i = 0; i < std::size(kWire); ++i)
+    for (std::size_t i = 0; i < std::size(kCSSFontSizeWire); ++i)
     {
-        if (kWire[i] == text)
+        if (kCSSFontSizeWire[i] == text)
         {
             out = CSSFontSize{static_cast<Tag>(i)};
             return true;

--- a/src/private/mx/core/generated/CaesuraValue.cpp
+++ b/src/private/mx/core/generated/CaesuraValue.cpp
@@ -8,14 +8,9 @@
 namespace mx::core
 {
 
-namespace
-{
-
-constexpr std::string_view kWire[] = {
+constexpr std::string_view kCaesuraValueWire[] = {
     "normal", "thick", "short", "curved", "single", "",
 };
-
-} // namespace
 
 CaesuraValue CaesuraValue::normal() noexcept
 {
@@ -49,14 +44,14 @@ CaesuraValue CaesuraValue::empty() noexcept
 
 std::string_view CaesuraValue::toString() const noexcept
 {
-    return kWire[static_cast<std::size_t>(m_tag)];
+    return kCaesuraValueWire[static_cast<std::size_t>(m_tag)];
 }
 
 bool CaesuraValue::tryParse(std::string_view text, CaesuraValue &out) noexcept
 {
-    for (std::size_t i = 0; i < std::size(kWire); ++i)
+    for (std::size_t i = 0; i < std::size(kCaesuraValueWire); ++i)
     {
-        if (kWire[i] == text)
+        if (kCaesuraValueWire[i] == text)
         {
             out = CaesuraValue{static_cast<Tag>(i)};
             return true;

--- a/src/private/mx/core/generated/CancelLocation.cpp
+++ b/src/private/mx/core/generated/CancelLocation.cpp
@@ -8,16 +8,11 @@
 namespace mx::core
 {
 
-namespace
-{
-
-constexpr std::string_view kWire[] = {
+constexpr std::string_view kCancelLocationWire[] = {
     "left",
     "right",
     "before-barline",
 };
-
-} // namespace
 
 CancelLocation CancelLocation::left() noexcept
 {
@@ -36,14 +31,14 @@ CancelLocation CancelLocation::beforeBarline() noexcept
 
 std::string_view CancelLocation::toString() const noexcept
 {
-    return kWire[static_cast<std::size_t>(m_tag)];
+    return kCancelLocationWire[static_cast<std::size_t>(m_tag)];
 }
 
 bool CancelLocation::tryParse(std::string_view text, CancelLocation &out) noexcept
 {
-    for (std::size_t i = 0; i < std::size(kWire); ++i)
+    for (std::size_t i = 0; i < std::size(kCancelLocationWire); ++i)
     {
-        if (kWire[i] == text)
+        if (kCancelLocationWire[i] == text)
         {
             out = CancelLocation{static_cast<Tag>(i)};
             return true;

--- a/src/private/mx/core/generated/CircularArrow.cpp
+++ b/src/private/mx/core/generated/CircularArrow.cpp
@@ -8,15 +8,10 @@
 namespace mx::core
 {
 
-namespace
-{
-
-constexpr std::string_view kWire[] = {
+constexpr std::string_view kCircularArrowWire[] = {
     "clockwise",
     "anticlockwise",
 };
-
-} // namespace
 
 CircularArrow CircularArrow::clockwise() noexcept
 {
@@ -30,14 +25,14 @@ CircularArrow CircularArrow::anticlockwise() noexcept
 
 std::string_view CircularArrow::toString() const noexcept
 {
-    return kWire[static_cast<std::size_t>(m_tag)];
+    return kCircularArrowWire[static_cast<std::size_t>(m_tag)];
 }
 
 bool CircularArrow::tryParse(std::string_view text, CircularArrow &out) noexcept
 {
-    for (std::size_t i = 0; i < std::size(kWire); ++i)
+    for (std::size_t i = 0; i < std::size(kCircularArrowWire); ++i)
     {
-        if (kWire[i] == text)
+        if (kCircularArrowWire[i] == text)
         {
             out = CircularArrow{static_cast<Tag>(i)};
             return true;

--- a/src/private/mx/core/generated/ClefSign.cpp
+++ b/src/private/mx/core/generated/ClefSign.cpp
@@ -8,14 +8,9 @@
 namespace mx::core
 {
 
-namespace
-{
-
-constexpr std::string_view kWire[] = {
+constexpr std::string_view kClefSignWire[] = {
     "G", "F", "C", "percussion", "TAB", "jianpu", "none",
 };
-
-} // namespace
 
 ClefSign ClefSign::g() noexcept
 {
@@ -54,14 +49,14 @@ ClefSign ClefSign::none() noexcept
 
 std::string_view ClefSign::toString() const noexcept
 {
-    return kWire[static_cast<std::size_t>(m_tag)];
+    return kClefSignWire[static_cast<std::size_t>(m_tag)];
 }
 
 bool ClefSign::tryParse(std::string_view text, ClefSign &out) noexcept
 {
-    for (std::size_t i = 0; i < std::size(kWire); ++i)
+    for (std::size_t i = 0; i < std::size(kClefSignWire); ++i)
     {
-        if (kWire[i] == text)
+        if (kClefSignWire[i] == text)
         {
             out = ClefSign{static_cast<Tag>(i)};
             return true;

--- a/src/private/mx/core/generated/DegreeSymbolValue.cpp
+++ b/src/private/mx/core/generated/DegreeSymbolValue.cpp
@@ -8,14 +8,9 @@
 namespace mx::core
 {
 
-namespace
-{
-
-constexpr std::string_view kWire[] = {
+constexpr std::string_view kDegreeSymbolValueWire[] = {
     "major", "minor", "augmented", "diminished", "half-diminished",
 };
-
-} // namespace
 
 DegreeSymbolValue DegreeSymbolValue::major() noexcept
 {
@@ -44,14 +39,14 @@ DegreeSymbolValue DegreeSymbolValue::halfDiminished() noexcept
 
 std::string_view DegreeSymbolValue::toString() const noexcept
 {
-    return kWire[static_cast<std::size_t>(m_tag)];
+    return kDegreeSymbolValueWire[static_cast<std::size_t>(m_tag)];
 }
 
 bool DegreeSymbolValue::tryParse(std::string_view text, DegreeSymbolValue &out) noexcept
 {
-    for (std::size_t i = 0; i < std::size(kWire); ++i)
+    for (std::size_t i = 0; i < std::size(kDegreeSymbolValueWire); ++i)
     {
-        if (kWire[i] == text)
+        if (kDegreeSymbolValueWire[i] == text)
         {
             out = DegreeSymbolValue{static_cast<Tag>(i)};
             return true;

--- a/src/private/mx/core/generated/DegreeTypeValue.cpp
+++ b/src/private/mx/core/generated/DegreeTypeValue.cpp
@@ -8,16 +8,11 @@
 namespace mx::core
 {
 
-namespace
-{
-
-constexpr std::string_view kWire[] = {
+constexpr std::string_view kDegreeTypeValueWire[] = {
     "add",
     "alter",
     "subtract",
 };
-
-} // namespace
 
 DegreeTypeValue DegreeTypeValue::add() noexcept
 {
@@ -36,14 +31,14 @@ DegreeTypeValue DegreeTypeValue::subtract() noexcept
 
 std::string_view DegreeTypeValue::toString() const noexcept
 {
-    return kWire[static_cast<std::size_t>(m_tag)];
+    return kDegreeTypeValueWire[static_cast<std::size_t>(m_tag)];
 }
 
 bool DegreeTypeValue::tryParse(std::string_view text, DegreeTypeValue &out) noexcept
 {
-    for (std::size_t i = 0; i < std::size(kWire); ++i)
+    for (std::size_t i = 0; i < std::size(kDegreeTypeValueWire); ++i)
     {
-        if (kWire[i] == text)
+        if (kDegreeTypeValueWire[i] == text)
         {
             out = DegreeTypeValue{static_cast<Tag>(i)};
             return true;

--- a/src/private/mx/core/generated/DistanceType.cpp
+++ b/src/private/mx/core/generated/DistanceType.cpp
@@ -7,23 +7,18 @@
 namespace mx::core
 {
 
-namespace
-{
-
-std::string repaired(std::string v)
+std::string repairedDistanceType(std::string v)
 {
     return v;
 }
 
-} // namespace
-
-DistanceType::DistanceType(std::string value) : m_value{repaired(std::move(value))}
+DistanceType::DistanceType(std::string value) : m_value{repairedDistanceType(std::move(value))}
 {
 }
 
 void DistanceType::setValue(std::string value)
 {
-    m_value = repaired(std::move(value));
+    m_value = repairedDistanceType(std::move(value));
 }
 
 bool DistanceType::tryParse(std::string_view text, DistanceType &out)

--- a/src/private/mx/core/generated/Divisions.cpp
+++ b/src/private/mx/core/generated/Divisions.cpp
@@ -9,27 +9,22 @@
 namespace mx::core
 {
 
-namespace
-{
-
-Decimal clamped(Decimal v)
+Decimal clampedDivisions(Decimal v)
 {
     return v;
 }
 
-} // namespace
-
-Divisions::Divisions() : m_value{clamped(Decimal{})}
+Divisions::Divisions() : m_value{clampedDivisions(Decimal{})}
 {
 }
 
-Divisions::Divisions(Decimal value) : m_value{clamped(std::move(value))}
+Divisions::Divisions(Decimal value) : m_value{clampedDivisions(std::move(value))}
 {
 }
 
 void Divisions::setValue(Decimal value)
 {
-    m_value = clamped(std::move(value));
+    m_value = clampedDivisions(std::move(value));
 }
 
 std::string Divisions::toString() const

--- a/src/private/mx/core/generated/EffectValue.cpp
+++ b/src/private/mx/core/generated/EffectValue.cpp
@@ -8,16 +8,11 @@
 namespace mx::core
 {
 
-namespace
-{
-
-constexpr std::string_view kWire[] = {
+constexpr std::string_view kEffectValueWire[] = {
     "anvil",         "auto horn",     "bird whistle", "cannon",       "duck call",      "gun shot",
     "klaxon horn",   "lions roar",    "lotus flute",  "megaphone",    "police whistle", "siren",
     "slide whistle", "thunder sheet", "wind machine", "wind whistle",
 };
-
-} // namespace
 
 EffectValue EffectValue::anvil() noexcept
 {
@@ -101,14 +96,14 @@ EffectValue EffectValue::windWhistle() noexcept
 
 std::string_view EffectValue::toString() const noexcept
 {
-    return kWire[static_cast<std::size_t>(m_tag)];
+    return kEffectValueWire[static_cast<std::size_t>(m_tag)];
 }
 
 bool EffectValue::tryParse(std::string_view text, EffectValue &out) noexcept
 {
-    for (std::size_t i = 0; i < std::size(kWire); ++i)
+    for (std::size_t i = 0; i < std::size(kEffectValueWire); ++i)
     {
-        if (kWire[i] == text)
+        if (kEffectValueWire[i] == text)
         {
             out = EffectValue{static_cast<Tag>(i)};
             return true;

--- a/src/private/mx/core/generated/EnclosureShape.cpp
+++ b/src/private/mx/core/generated/EnclosureShape.cpp
@@ -8,15 +8,10 @@
 namespace mx::core
 {
 
-namespace
-{
-
-constexpr std::string_view kWire[] = {
+constexpr std::string_view kEnclosureShapeWire[] = {
     "rectangle", "square",  "oval",     "circle",  "bracket", "inverted-bracket", "triangle", "diamond",
     "pentagon",  "hexagon", "heptagon", "octagon", "nonagon", "decagon",          "none",
 };
-
-} // namespace
 
 EnclosureShape EnclosureShape::rectangle() noexcept
 {
@@ -95,14 +90,14 @@ EnclosureShape EnclosureShape::none() noexcept
 
 std::string_view EnclosureShape::toString() const noexcept
 {
-    return kWire[static_cast<std::size_t>(m_tag)];
+    return kEnclosureShapeWire[static_cast<std::size_t>(m_tag)];
 }
 
 bool EnclosureShape::tryParse(std::string_view text, EnclosureShape &out) noexcept
 {
-    for (std::size_t i = 0; i < std::size(kWire); ++i)
+    for (std::size_t i = 0; i < std::size(kEnclosureShapeWire); ++i)
     {
-        if (kWire[i] == text)
+        if (kEnclosureShapeWire[i] == text)
         {
             out = EnclosureShape{static_cast<Tag>(i)};
             return true;

--- a/src/private/mx/core/generated/Fan.cpp
+++ b/src/private/mx/core/generated/Fan.cpp
@@ -8,16 +8,11 @@
 namespace mx::core
 {
 
-namespace
-{
-
-constexpr std::string_view kWire[] = {
+constexpr std::string_view kFanWire[] = {
     "accel",
     "rit",
     "none",
 };
-
-} // namespace
 
 Fan Fan::accel() noexcept
 {
@@ -36,14 +31,14 @@ Fan Fan::none() noexcept
 
 std::string_view Fan::toString() const noexcept
 {
-    return kWire[static_cast<std::size_t>(m_tag)];
+    return kFanWire[static_cast<std::size_t>(m_tag)];
 }
 
 bool Fan::tryParse(std::string_view text, Fan &out) noexcept
 {
-    for (std::size_t i = 0; i < std::size(kWire); ++i)
+    for (std::size_t i = 0; i < std::size(kFanWire); ++i)
     {
-        if (kWire[i] == text)
+        if (kFanWire[i] == text)
         {
             out = Fan{static_cast<Tag>(i)};
             return true;

--- a/src/private/mx/core/generated/FermataShape.cpp
+++ b/src/private/mx/core/generated/FermataShape.cpp
@@ -8,14 +8,9 @@
 namespace mx::core
 {
 
-namespace
-{
-
-constexpr std::string_view kWire[] = {
+constexpr std::string_view kFermataShapeWire[] = {
     "normal", "angled", "square", "double-angled", "double-square", "double-dot", "half-curve", "curlew", "",
 };
-
-} // namespace
 
 FermataShape FermataShape::normal() noexcept
 {
@@ -64,14 +59,14 @@ FermataShape FermataShape::empty() noexcept
 
 std::string_view FermataShape::toString() const noexcept
 {
-    return kWire[static_cast<std::size_t>(m_tag)];
+    return kFermataShapeWire[static_cast<std::size_t>(m_tag)];
 }
 
 bool FermataShape::tryParse(std::string_view text, FermataShape &out) noexcept
 {
-    for (std::size_t i = 0; i < std::size(kWire); ++i)
+    for (std::size_t i = 0; i < std::size(kFermataShapeWire); ++i)
     {
-        if (kWire[i] == text)
+        if (kFermataShapeWire[i] == text)
         {
             out = FermataShape{static_cast<Tag>(i)};
             return true;

--- a/src/private/mx/core/generated/Fifths.cpp
+++ b/src/private/mx/core/generated/Fifths.cpp
@@ -9,27 +9,22 @@
 namespace mx::core
 {
 
-namespace
-{
-
-int clamped(int v)
+int clampedFifths(int v)
 {
     return v;
 }
 
-} // namespace
-
-Fifths::Fifths() : m_value{clamped(int{})}
+Fifths::Fifths() : m_value{clampedFifths(int{})}
 {
 }
 
-Fifths::Fifths(int value) : m_value{clamped(std::move(value))}
+Fifths::Fifths(int value) : m_value{clampedFifths(std::move(value))}
 {
 }
 
 void Fifths::setValue(int value)
 {
-    m_value = clamped(std::move(value));
+    m_value = clampedFifths(std::move(value));
 }
 
 std::string Fifths::toString() const

--- a/src/private/mx/core/generated/FontStyle.cpp
+++ b/src/private/mx/core/generated/FontStyle.cpp
@@ -8,15 +8,10 @@
 namespace mx::core
 {
 
-namespace
-{
-
-constexpr std::string_view kWire[] = {
+constexpr std::string_view kFontStyleWire[] = {
     "normal",
     "italic",
 };
-
-} // namespace
 
 FontStyle FontStyle::normal() noexcept
 {
@@ -30,14 +25,14 @@ FontStyle FontStyle::italic() noexcept
 
 std::string_view FontStyle::toString() const noexcept
 {
-    return kWire[static_cast<std::size_t>(m_tag)];
+    return kFontStyleWire[static_cast<std::size_t>(m_tag)];
 }
 
 bool FontStyle::tryParse(std::string_view text, FontStyle &out) noexcept
 {
-    for (std::size_t i = 0; i < std::size(kWire); ++i)
+    for (std::size_t i = 0; i < std::size(kFontStyleWire); ++i)
     {
-        if (kWire[i] == text)
+        if (kFontStyleWire[i] == text)
         {
             out = FontStyle{static_cast<Tag>(i)};
             return true;

--- a/src/private/mx/core/generated/FontWeight.cpp
+++ b/src/private/mx/core/generated/FontWeight.cpp
@@ -8,15 +8,10 @@
 namespace mx::core
 {
 
-namespace
-{
-
-constexpr std::string_view kWire[] = {
+constexpr std::string_view kFontWeightWire[] = {
     "normal",
     "bold",
 };
-
-} // namespace
 
 FontWeight FontWeight::normal() noexcept
 {
@@ -30,14 +25,14 @@ FontWeight FontWeight::bold() noexcept
 
 std::string_view FontWeight::toString() const noexcept
 {
-    return kWire[static_cast<std::size_t>(m_tag)];
+    return kFontWeightWire[static_cast<std::size_t>(m_tag)];
 }
 
 bool FontWeight::tryParse(std::string_view text, FontWeight &out) noexcept
 {
-    for (std::size_t i = 0; i < std::size(kWire); ++i)
+    for (std::size_t i = 0; i < std::size(kFontWeightWire); ++i)
     {
-        if (kWire[i] == text)
+        if (kFontWeightWire[i] == text)
         {
             out = FontWeight{static_cast<Tag>(i)};
             return true;

--- a/src/private/mx/core/generated/GlassValue.cpp
+++ b/src/private/mx/core/generated/GlassValue.cpp
@@ -8,16 +8,11 @@
 namespace mx::core
 {
 
-namespace
-{
-
-constexpr std::string_view kWire[] = {
+constexpr std::string_view kGlassValueWire[] = {
     "glass harmonica",
     "glass harp",
     "wind chimes",
 };
-
-} // namespace
 
 GlassValue GlassValue::glassHarmonica() noexcept
 {
@@ -36,14 +31,14 @@ GlassValue GlassValue::windChimes() noexcept
 
 std::string_view GlassValue::toString() const noexcept
 {
-    return kWire[static_cast<std::size_t>(m_tag)];
+    return kGlassValueWire[static_cast<std::size_t>(m_tag)];
 }
 
 bool GlassValue::tryParse(std::string_view text, GlassValue &out) noexcept
 {
-    for (std::size_t i = 0; i < std::size(kWire); ++i)
+    for (std::size_t i = 0; i < std::size(kGlassValueWire); ++i)
     {
-        if (kWire[i] == text)
+        if (kGlassValueWire[i] == text)
         {
             out = GlassValue{static_cast<Tag>(i)};
             return true;

--- a/src/private/mx/core/generated/GlyphType.cpp
+++ b/src/private/mx/core/generated/GlyphType.cpp
@@ -7,23 +7,18 @@
 namespace mx::core
 {
 
-namespace
-{
-
-std::string repaired(std::string v)
+std::string repairedGlyphType(std::string v)
 {
     return v;
 }
 
-} // namespace
-
-GlyphType::GlyphType(std::string value) : m_value{repaired(std::move(value))}
+GlyphType::GlyphType(std::string value) : m_value{repairedGlyphType(std::move(value))}
 {
 }
 
 void GlyphType::setValue(std::string value)
 {
-    m_value = repaired(std::move(value));
+    m_value = repairedGlyphType(std::move(value));
 }
 
 bool GlyphType::tryParse(std::string_view text, GlyphType &out)

--- a/src/private/mx/core/generated/GroupBarlineValue.cpp
+++ b/src/private/mx/core/generated/GroupBarlineValue.cpp
@@ -8,16 +8,11 @@
 namespace mx::core
 {
 
-namespace
-{
-
-constexpr std::string_view kWire[] = {
+constexpr std::string_view kGroupBarlineValueWire[] = {
     "yes",
     "no",
     "Mensurstrich",
 };
-
-} // namespace
 
 GroupBarlineValue GroupBarlineValue::yes() noexcept
 {
@@ -36,14 +31,14 @@ GroupBarlineValue GroupBarlineValue::mensurstrich() noexcept
 
 std::string_view GroupBarlineValue::toString() const noexcept
 {
-    return kWire[static_cast<std::size_t>(m_tag)];
+    return kGroupBarlineValueWire[static_cast<std::size_t>(m_tag)];
 }
 
 bool GroupBarlineValue::tryParse(std::string_view text, GroupBarlineValue &out) noexcept
 {
-    for (std::size_t i = 0; i < std::size(kWire); ++i)
+    for (std::size_t i = 0; i < std::size(kGroupBarlineValueWire); ++i)
     {
-        if (kWire[i] == text)
+        if (kGroupBarlineValueWire[i] == text)
         {
             out = GroupBarlineValue{static_cast<Tag>(i)};
             return true;

--- a/src/private/mx/core/generated/GroupSymbolValue.cpp
+++ b/src/private/mx/core/generated/GroupSymbolValue.cpp
@@ -8,14 +8,9 @@
 namespace mx::core
 {
 
-namespace
-{
-
-constexpr std::string_view kWire[] = {
+constexpr std::string_view kGroupSymbolValueWire[] = {
     "none", "brace", "line", "bracket", "square",
 };
-
-} // namespace
 
 GroupSymbolValue GroupSymbolValue::none() noexcept
 {
@@ -44,14 +39,14 @@ GroupSymbolValue GroupSymbolValue::square() noexcept
 
 std::string_view GroupSymbolValue::toString() const noexcept
 {
-    return kWire[static_cast<std::size_t>(m_tag)];
+    return kGroupSymbolValueWire[static_cast<std::size_t>(m_tag)];
 }
 
 bool GroupSymbolValue::tryParse(std::string_view text, GroupSymbolValue &out) noexcept
 {
-    for (std::size_t i = 0; i < std::size(kWire); ++i)
+    for (std::size_t i = 0; i < std::size(kGroupSymbolValueWire); ++i)
     {
-        if (kWire[i] == text)
+        if (kGroupSymbolValueWire[i] == text)
         {
             out = GroupSymbolValue{static_cast<Tag>(i)};
             return true;

--- a/src/private/mx/core/generated/HandbellValue.cpp
+++ b/src/private/mx/core/generated/HandbellValue.cpp
@@ -8,10 +8,7 @@
 namespace mx::core
 {
 
-namespace
-{
-
-constexpr std::string_view kWire[] = {
+constexpr std::string_view kHandbellValueWire[] = {
     "belltree",
     "damp",
     "echo",
@@ -25,8 +22,6 @@ constexpr std::string_view kWire[] = {
     "pluck lift",
     "swing",
 };
-
-} // namespace
 
 HandbellValue HandbellValue::belltree() noexcept
 {
@@ -90,14 +85,14 @@ HandbellValue HandbellValue::swing() noexcept
 
 std::string_view HandbellValue::toString() const noexcept
 {
-    return kWire[static_cast<std::size_t>(m_tag)];
+    return kHandbellValueWire[static_cast<std::size_t>(m_tag)];
 }
 
 bool HandbellValue::tryParse(std::string_view text, HandbellValue &out) noexcept
 {
-    for (std::size_t i = 0; i < std::size(kWire); ++i)
+    for (std::size_t i = 0; i < std::size(kHandbellValueWire); ++i)
     {
-        if (kWire[i] == text)
+        if (kHandbellValueWire[i] == text)
         {
             out = HandbellValue{static_cast<Tag>(i)};
             return true;

--- a/src/private/mx/core/generated/HarmonClosedLocation.cpp
+++ b/src/private/mx/core/generated/HarmonClosedLocation.cpp
@@ -8,17 +8,12 @@
 namespace mx::core
 {
 
-namespace
-{
-
-constexpr std::string_view kWire[] = {
+constexpr std::string_view kHarmonClosedLocationWire[] = {
     "right",
     "bottom",
     "left",
     "top",
 };
-
-} // namespace
 
 HarmonClosedLocation HarmonClosedLocation::right() noexcept
 {
@@ -42,14 +37,14 @@ HarmonClosedLocation HarmonClosedLocation::top() noexcept
 
 std::string_view HarmonClosedLocation::toString() const noexcept
 {
-    return kWire[static_cast<std::size_t>(m_tag)];
+    return kHarmonClosedLocationWire[static_cast<std::size_t>(m_tag)];
 }
 
 bool HarmonClosedLocation::tryParse(std::string_view text, HarmonClosedLocation &out) noexcept
 {
-    for (std::size_t i = 0; i < std::size(kWire); ++i)
+    for (std::size_t i = 0; i < std::size(kHarmonClosedLocationWire); ++i)
     {
-        if (kWire[i] == text)
+        if (kHarmonClosedLocationWire[i] == text)
         {
             out = HarmonClosedLocation{static_cast<Tag>(i)};
             return true;

--- a/src/private/mx/core/generated/HarmonClosedValue.cpp
+++ b/src/private/mx/core/generated/HarmonClosedValue.cpp
@@ -8,16 +8,11 @@
 namespace mx::core
 {
 
-namespace
-{
-
-constexpr std::string_view kWire[] = {
+constexpr std::string_view kHarmonClosedValueWire[] = {
     "yes",
     "no",
     "half",
 };
-
-} // namespace
 
 HarmonClosedValue HarmonClosedValue::yes() noexcept
 {
@@ -36,14 +31,14 @@ HarmonClosedValue HarmonClosedValue::half() noexcept
 
 std::string_view HarmonClosedValue::toString() const noexcept
 {
-    return kWire[static_cast<std::size_t>(m_tag)];
+    return kHarmonClosedValueWire[static_cast<std::size_t>(m_tag)];
 }
 
 bool HarmonClosedValue::tryParse(std::string_view text, HarmonClosedValue &out) noexcept
 {
-    for (std::size_t i = 0; i < std::size(kWire); ++i)
+    for (std::size_t i = 0; i < std::size(kHarmonClosedValueWire); ++i)
     {
-        if (kWire[i] == text)
+        if (kHarmonClosedValueWire[i] == text)
         {
             out = HarmonClosedValue{static_cast<Tag>(i)};
             return true;

--- a/src/private/mx/core/generated/HarmonyArrangement.cpp
+++ b/src/private/mx/core/generated/HarmonyArrangement.cpp
@@ -8,16 +8,11 @@
 namespace mx::core
 {
 
-namespace
-{
-
-constexpr std::string_view kWire[] = {
+constexpr std::string_view kHarmonyArrangementWire[] = {
     "vertical",
     "horizontal",
     "diagonal",
 };
-
-} // namespace
 
 HarmonyArrangement HarmonyArrangement::vertical() noexcept
 {
@@ -36,14 +31,14 @@ HarmonyArrangement HarmonyArrangement::diagonal() noexcept
 
 std::string_view HarmonyArrangement::toString() const noexcept
 {
-    return kWire[static_cast<std::size_t>(m_tag)];
+    return kHarmonyArrangementWire[static_cast<std::size_t>(m_tag)];
 }
 
 bool HarmonyArrangement::tryParse(std::string_view text, HarmonyArrangement &out) noexcept
 {
-    for (std::size_t i = 0; i < std::size(kWire); ++i)
+    for (std::size_t i = 0; i < std::size(kHarmonyArrangementWire); ++i)
     {
-        if (kWire[i] == text)
+        if (kHarmonyArrangementWire[i] == text)
         {
             out = HarmonyArrangement{static_cast<Tag>(i)};
             return true;

--- a/src/private/mx/core/generated/HarmonyType.cpp
+++ b/src/private/mx/core/generated/HarmonyType.cpp
@@ -8,16 +8,11 @@
 namespace mx::core
 {
 
-namespace
-{
-
-constexpr std::string_view kWire[] = {
+constexpr std::string_view kHarmonyTypeWire[] = {
     "explicit",
     "implied",
     "alternate",
 };
-
-} // namespace
 
 HarmonyType HarmonyType::explicit_() noexcept
 {
@@ -36,14 +31,14 @@ HarmonyType HarmonyType::alternate() noexcept
 
 std::string_view HarmonyType::toString() const noexcept
 {
-    return kWire[static_cast<std::size_t>(m_tag)];
+    return kHarmonyTypeWire[static_cast<std::size_t>(m_tag)];
 }
 
 bool HarmonyType::tryParse(std::string_view text, HarmonyType &out) noexcept
 {
-    for (std::size_t i = 0; i < std::size(kWire); ++i)
+    for (std::size_t i = 0; i < std::size(kHarmonyTypeWire); ++i)
     {
-        if (kWire[i] == text)
+        if (kHarmonyTypeWire[i] == text)
         {
             out = HarmonyType{static_cast<Tag>(i)};
             return true;

--- a/src/private/mx/core/generated/HoleClosedLocation.cpp
+++ b/src/private/mx/core/generated/HoleClosedLocation.cpp
@@ -8,17 +8,12 @@
 namespace mx::core
 {
 
-namespace
-{
-
-constexpr std::string_view kWire[] = {
+constexpr std::string_view kHoleClosedLocationWire[] = {
     "right",
     "bottom",
     "left",
     "top",
 };
-
-} // namespace
 
 HoleClosedLocation HoleClosedLocation::right() noexcept
 {
@@ -42,14 +37,14 @@ HoleClosedLocation HoleClosedLocation::top() noexcept
 
 std::string_view HoleClosedLocation::toString() const noexcept
 {
-    return kWire[static_cast<std::size_t>(m_tag)];
+    return kHoleClosedLocationWire[static_cast<std::size_t>(m_tag)];
 }
 
 bool HoleClosedLocation::tryParse(std::string_view text, HoleClosedLocation &out) noexcept
 {
-    for (std::size_t i = 0; i < std::size(kWire); ++i)
+    for (std::size_t i = 0; i < std::size(kHoleClosedLocationWire); ++i)
     {
-        if (kWire[i] == text)
+        if (kHoleClosedLocationWire[i] == text)
         {
             out = HoleClosedLocation{static_cast<Tag>(i)};
             return true;

--- a/src/private/mx/core/generated/HoleClosedValue.cpp
+++ b/src/private/mx/core/generated/HoleClosedValue.cpp
@@ -8,16 +8,11 @@
 namespace mx::core
 {
 
-namespace
-{
-
-constexpr std::string_view kWire[] = {
+constexpr std::string_view kHoleClosedValueWire[] = {
     "yes",
     "no",
     "half",
 };
-
-} // namespace
 
 HoleClosedValue HoleClosedValue::yes() noexcept
 {
@@ -36,14 +31,14 @@ HoleClosedValue HoleClosedValue::half() noexcept
 
 std::string_view HoleClosedValue::toString() const noexcept
 {
-    return kWire[static_cast<std::size_t>(m_tag)];
+    return kHoleClosedValueWire[static_cast<std::size_t>(m_tag)];
 }
 
 bool HoleClosedValue::tryParse(std::string_view text, HoleClosedValue &out) noexcept
 {
-    for (std::size_t i = 0; i < std::size(kWire); ++i)
+    for (std::size_t i = 0; i < std::size(kHoleClosedValueWire); ++i)
     {
-        if (kWire[i] == text)
+        if (kHoleClosedValueWire[i] == text)
         {
             out = HoleClosedValue{static_cast<Tag>(i)};
             return true;

--- a/src/private/mx/core/generated/KindValue.cpp
+++ b/src/private/mx/core/generated/KindValue.cpp
@@ -8,10 +8,7 @@
 namespace mx::core
 {
 
-namespace
-{
-
-constexpr std::string_view kWire[] = {
+constexpr std::string_view kKindValueWire[] = {
     "major",
     "minor",
     "augmented",
@@ -46,8 +43,6 @@ constexpr std::string_view kWire[] = {
     "other",
     "none",
 };
-
-} // namespace
 
 KindValue KindValue::major() noexcept
 {
@@ -216,14 +211,14 @@ KindValue KindValue::none() noexcept
 
 std::string_view KindValue::toString() const noexcept
 {
-    return kWire[static_cast<std::size_t>(m_tag)];
+    return kKindValueWire[static_cast<std::size_t>(m_tag)];
 }
 
 bool KindValue::tryParse(std::string_view text, KindValue &out) noexcept
 {
-    for (std::size_t i = 0; i < std::size(kWire); ++i)
+    for (std::size_t i = 0; i < std::size(kKindValueWire); ++i)
     {
-        if (kWire[i] == text)
+        if (kKindValueWire[i] == text)
         {
             out = KindValue{static_cast<Tag>(i)};
             return true;

--- a/src/private/mx/core/generated/LeftCenterRight.cpp
+++ b/src/private/mx/core/generated/LeftCenterRight.cpp
@@ -8,16 +8,11 @@
 namespace mx::core
 {
 
-namespace
-{
-
-constexpr std::string_view kWire[] = {
+constexpr std::string_view kLeftCenterRightWire[] = {
     "left",
     "center",
     "right",
 };
-
-} // namespace
 
 LeftCenterRight LeftCenterRight::left() noexcept
 {
@@ -36,14 +31,14 @@ LeftCenterRight LeftCenterRight::right() noexcept
 
 std::string_view LeftCenterRight::toString() const noexcept
 {
-    return kWire[static_cast<std::size_t>(m_tag)];
+    return kLeftCenterRightWire[static_cast<std::size_t>(m_tag)];
 }
 
 bool LeftCenterRight::tryParse(std::string_view text, LeftCenterRight &out) noexcept
 {
-    for (std::size_t i = 0; i < std::size(kWire); ++i)
+    for (std::size_t i = 0; i < std::size(kLeftCenterRightWire); ++i)
     {
-        if (kWire[i] == text)
+        if (kLeftCenterRightWire[i] == text)
         {
             out = LeftCenterRight{static_cast<Tag>(i)};
             return true;

--- a/src/private/mx/core/generated/LeftRight.cpp
+++ b/src/private/mx/core/generated/LeftRight.cpp
@@ -8,15 +8,10 @@
 namespace mx::core
 {
 
-namespace
-{
-
-constexpr std::string_view kWire[] = {
+constexpr std::string_view kLeftRightWire[] = {
     "left",
     "right",
 };
-
-} // namespace
 
 LeftRight LeftRight::left() noexcept
 {
@@ -30,14 +25,14 @@ LeftRight LeftRight::right() noexcept
 
 std::string_view LeftRight::toString() const noexcept
 {
-    return kWire[static_cast<std::size_t>(m_tag)];
+    return kLeftRightWire[static_cast<std::size_t>(m_tag)];
 }
 
 bool LeftRight::tryParse(std::string_view text, LeftRight &out) noexcept
 {
-    for (std::size_t i = 0; i < std::size(kWire); ++i)
+    for (std::size_t i = 0; i < std::size(kLeftRightWire); ++i)
     {
-        if (kWire[i] == text)
+        if (kLeftRightWire[i] == text)
         {
             out = LeftRight{static_cast<Tag>(i)};
             return true;

--- a/src/private/mx/core/generated/LineEnd.cpp
+++ b/src/private/mx/core/generated/LineEnd.cpp
@@ -8,14 +8,9 @@
 namespace mx::core
 {
 
-namespace
-{
-
-constexpr std::string_view kWire[] = {
+constexpr std::string_view kLineEndWire[] = {
     "up", "down", "both", "arrow", "none",
 };
-
-} // namespace
 
 LineEnd LineEnd::up() noexcept
 {
@@ -44,14 +39,14 @@ LineEnd LineEnd::none() noexcept
 
 std::string_view LineEnd::toString() const noexcept
 {
-    return kWire[static_cast<std::size_t>(m_tag)];
+    return kLineEndWire[static_cast<std::size_t>(m_tag)];
 }
 
 bool LineEnd::tryParse(std::string_view text, LineEnd &out) noexcept
 {
-    for (std::size_t i = 0; i < std::size(kWire); ++i)
+    for (std::size_t i = 0; i < std::size(kLineEndWire); ++i)
     {
-        if (kWire[i] == text)
+        if (kLineEndWire[i] == text)
         {
             out = LineEnd{static_cast<Tag>(i)};
             return true;

--- a/src/private/mx/core/generated/LineLength.cpp
+++ b/src/private/mx/core/generated/LineLength.cpp
@@ -8,16 +8,11 @@
 namespace mx::core
 {
 
-namespace
-{
-
-constexpr std::string_view kWire[] = {
+constexpr std::string_view kLineLengthWire[] = {
     "short",
     "medium",
     "long",
 };
-
-} // namespace
 
 LineLength LineLength::short_() noexcept
 {
@@ -36,14 +31,14 @@ LineLength LineLength::long_() noexcept
 
 std::string_view LineLength::toString() const noexcept
 {
-    return kWire[static_cast<std::size_t>(m_tag)];
+    return kLineLengthWire[static_cast<std::size_t>(m_tag)];
 }
 
 bool LineLength::tryParse(std::string_view text, LineLength &out) noexcept
 {
-    for (std::size_t i = 0; i < std::size(kWire); ++i)
+    for (std::size_t i = 0; i < std::size(kLineLengthWire); ++i)
     {
-        if (kWire[i] == text)
+        if (kLineLengthWire[i] == text)
         {
             out = LineLength{static_cast<Tag>(i)};
             return true;

--- a/src/private/mx/core/generated/LineShape.cpp
+++ b/src/private/mx/core/generated/LineShape.cpp
@@ -8,15 +8,10 @@
 namespace mx::core
 {
 
-namespace
-{
-
-constexpr std::string_view kWire[] = {
+constexpr std::string_view kLineShapeWire[] = {
     "straight",
     "curved",
 };
-
-} // namespace
 
 LineShape LineShape::straight() noexcept
 {
@@ -30,14 +25,14 @@ LineShape LineShape::curved() noexcept
 
 std::string_view LineShape::toString() const noexcept
 {
-    return kWire[static_cast<std::size_t>(m_tag)];
+    return kLineShapeWire[static_cast<std::size_t>(m_tag)];
 }
 
 bool LineShape::tryParse(std::string_view text, LineShape &out) noexcept
 {
-    for (std::size_t i = 0; i < std::size(kWire); ++i)
+    for (std::size_t i = 0; i < std::size(kLineShapeWire); ++i)
     {
-        if (kWire[i] == text)
+        if (kLineShapeWire[i] == text)
         {
             out = LineShape{static_cast<Tag>(i)};
             return true;

--- a/src/private/mx/core/generated/LineType.cpp
+++ b/src/private/mx/core/generated/LineType.cpp
@@ -8,17 +8,12 @@
 namespace mx::core
 {
 
-namespace
-{
-
-constexpr std::string_view kWire[] = {
+constexpr std::string_view kLineTypeWire[] = {
     "solid",
     "dashed",
     "dotted",
     "wavy",
 };
-
-} // namespace
 
 LineType LineType::solid() noexcept
 {
@@ -42,14 +37,14 @@ LineType LineType::wavy() noexcept
 
 std::string_view LineType::toString() const noexcept
 {
-    return kWire[static_cast<std::size_t>(m_tag)];
+    return kLineTypeWire[static_cast<std::size_t>(m_tag)];
 }
 
 bool LineType::tryParse(std::string_view text, LineType &out) noexcept
 {
-    for (std::size_t i = 0; i < std::size(kWire); ++i)
+    for (std::size_t i = 0; i < std::size(kLineTypeWire); ++i)
     {
-        if (kWire[i] == text)
+        if (kLineTypeWire[i] == text)
         {
             out = LineType{static_cast<Tag>(i)};
             return true;

--- a/src/private/mx/core/generated/LineWidthType.cpp
+++ b/src/private/mx/core/generated/LineWidthType.cpp
@@ -7,23 +7,18 @@
 namespace mx::core
 {
 
-namespace
-{
-
-std::string repaired(std::string v)
+std::string repairedLineWidthType(std::string v)
 {
     return v;
 }
 
-} // namespace
-
-LineWidthType::LineWidthType(std::string value) : m_value{repaired(std::move(value))}
+LineWidthType::LineWidthType(std::string value) : m_value{repairedLineWidthType(std::move(value))}
 {
 }
 
 void LineWidthType::setValue(std::string value)
 {
-    m_value = repaired(std::move(value));
+    m_value = repairedLineWidthType(std::move(value));
 }
 
 bool LineWidthType::tryParse(std::string_view text, LineWidthType &out)

--- a/src/private/mx/core/generated/MIDI128.cpp
+++ b/src/private/mx/core/generated/MIDI128.cpp
@@ -9,10 +9,7 @@
 namespace mx::core
 {
 
-namespace
-{
-
-int clamped(int v)
+int clampedMIDI128(int v)
 {
     if (v < 1)
     {
@@ -25,19 +22,17 @@ int clamped(int v)
     return v;
 }
 
-} // namespace
-
-MIDI128::MIDI128() : m_value{clamped(int{})}
+MIDI128::MIDI128() : m_value{clampedMIDI128(int{})}
 {
 }
 
-MIDI128::MIDI128(int value) : m_value{clamped(std::move(value))}
+MIDI128::MIDI128(int value) : m_value{clampedMIDI128(std::move(value))}
 {
 }
 
 void MIDI128::setValue(int value)
 {
-    m_value = clamped(std::move(value));
+    m_value = clampedMIDI128(std::move(value));
 }
 
 std::string MIDI128::toString() const

--- a/src/private/mx/core/generated/MIDI16.cpp
+++ b/src/private/mx/core/generated/MIDI16.cpp
@@ -9,10 +9,7 @@
 namespace mx::core
 {
 
-namespace
-{
-
-int clamped(int v)
+int clampedMIDI16(int v)
 {
     if (v < 1)
     {
@@ -25,19 +22,17 @@ int clamped(int v)
     return v;
 }
 
-} // namespace
-
-MIDI16::MIDI16() : m_value{clamped(int{})}
+MIDI16::MIDI16() : m_value{clampedMIDI16(int{})}
 {
 }
 
-MIDI16::MIDI16(int value) : m_value{clamped(std::move(value))}
+MIDI16::MIDI16(int value) : m_value{clampedMIDI16(std::move(value))}
 {
 }
 
 void MIDI16::setValue(int value)
 {
-    m_value = clamped(std::move(value));
+    m_value = clampedMIDI16(std::move(value));
 }
 
 std::string MIDI16::toString() const

--- a/src/private/mx/core/generated/MIDI16384.cpp
+++ b/src/private/mx/core/generated/MIDI16384.cpp
@@ -9,10 +9,7 @@
 namespace mx::core
 {
 
-namespace
-{
-
-int clamped(int v)
+int clampedMIDI16384(int v)
 {
     if (v < 1)
     {
@@ -25,19 +22,17 @@ int clamped(int v)
     return v;
 }
 
-} // namespace
-
-MIDI16384::MIDI16384() : m_value{clamped(int{})}
+MIDI16384::MIDI16384() : m_value{clampedMIDI16384(int{})}
 {
 }
 
-MIDI16384::MIDI16384(int value) : m_value{clamped(std::move(value))}
+MIDI16384::MIDI16384(int value) : m_value{clampedMIDI16384(std::move(value))}
 {
 }
 
 void MIDI16384::setValue(int value)
 {
-    m_value = clamped(std::move(value));
+    m_value = clampedMIDI16384(std::move(value));
 }
 
 std::string MIDI16384::toString() const

--- a/src/private/mx/core/generated/MarginType.cpp
+++ b/src/private/mx/core/generated/MarginType.cpp
@@ -8,16 +8,11 @@
 namespace mx::core
 {
 
-namespace
-{
-
-constexpr std::string_view kWire[] = {
+constexpr std::string_view kMarginTypeWire[] = {
     "odd",
     "even",
     "both",
 };
-
-} // namespace
 
 MarginType MarginType::odd() noexcept
 {
@@ -36,14 +31,14 @@ MarginType MarginType::both() noexcept
 
 std::string_view MarginType::toString() const noexcept
 {
-    return kWire[static_cast<std::size_t>(m_tag)];
+    return kMarginTypeWire[static_cast<std::size_t>(m_tag)];
 }
 
 bool MarginType::tryParse(std::string_view text, MarginType &out) noexcept
 {
-    for (std::size_t i = 0; i < std::size(kWire); ++i)
+    for (std::size_t i = 0; i < std::size(kMarginTypeWire); ++i)
     {
-        if (kWire[i] == text)
+        if (kMarginTypeWire[i] == text)
         {
             out = MarginType{static_cast<Tag>(i)};
             return true;

--- a/src/private/mx/core/generated/MeasureNumberingValue.cpp
+++ b/src/private/mx/core/generated/MeasureNumberingValue.cpp
@@ -8,16 +8,11 @@
 namespace mx::core
 {
 
-namespace
-{
-
-constexpr std::string_view kWire[] = {
+constexpr std::string_view kMeasureNumberingValueWire[] = {
     "none",
     "measure",
     "system",
 };
-
-} // namespace
 
 MeasureNumberingValue MeasureNumberingValue::none() noexcept
 {
@@ -36,14 +31,14 @@ MeasureNumberingValue MeasureNumberingValue::system() noexcept
 
 std::string_view MeasureNumberingValue::toString() const noexcept
 {
-    return kWire[static_cast<std::size_t>(m_tag)];
+    return kMeasureNumberingValueWire[static_cast<std::size_t>(m_tag)];
 }
 
 bool MeasureNumberingValue::tryParse(std::string_view text, MeasureNumberingValue &out) noexcept
 {
-    for (std::size_t i = 0; i < std::size(kWire); ++i)
+    for (std::size_t i = 0; i < std::size(kMeasureNumberingValueWire); ++i)
     {
-        if (kWire[i] == text)
+        if (kMeasureNumberingValueWire[i] == text)
         {
             out = MeasureNumberingValue{static_cast<Tag>(i)};
             return true;

--- a/src/private/mx/core/generated/MeasureText.cpp
+++ b/src/private/mx/core/generated/MeasureText.cpp
@@ -7,10 +7,7 @@
 namespace mx::core
 {
 
-namespace
-{
-
-std::string repaired(std::string v)
+std::string repairedMeasureText(std::string v)
 {
     // Deterministic repair to the schema's minLength (plan §2.2.2): pad
     // with '-' so a too-short value is unrepresentable.
@@ -21,19 +18,17 @@ std::string repaired(std::string v)
     return v;
 }
 
-} // namespace
-
-MeasureText::MeasureText() : m_value{repaired(std::string{})}
+MeasureText::MeasureText() : m_value{repairedMeasureText(std::string{})}
 {
 }
 
-MeasureText::MeasureText(std::string value) : m_value{repaired(std::move(value))}
+MeasureText::MeasureText(std::string value) : m_value{repairedMeasureText(std::move(value))}
 {
 }
 
 void MeasureText::setValue(std::string value)
 {
-    m_value = repaired(std::move(value));
+    m_value = repairedMeasureText(std::move(value));
 }
 
 bool MeasureText::tryParse(std::string_view text, MeasureText &out)

--- a/src/private/mx/core/generated/MembraneValue.cpp
+++ b/src/private/mx/core/generated/MembraneValue.cpp
@@ -8,16 +8,11 @@
 namespace mx::core
 {
 
-namespace
-{
-
-constexpr std::string_view kWire[] = {
+constexpr std::string_view kMembraneValueWire[] = {
     "bass drum",   "bass drum on side",    "bongos",          "Chinese tomtom", "conga drum", "cuica",
     "goblet drum", "Indo-American tomtom", "Japanese tomtom", "military drum",  "snare drum", "snare drum snares off",
     "tabla",       "tambourine",           "tenor drum",      "timbales",       "tomtom",
 };
-
-} // namespace
 
 MembraneValue MembraneValue::bassDrum() noexcept
 {
@@ -106,14 +101,14 @@ MembraneValue MembraneValue::tomtom() noexcept
 
 std::string_view MembraneValue::toString() const noexcept
 {
-    return kWire[static_cast<std::size_t>(m_tag)];
+    return kMembraneValueWire[static_cast<std::size_t>(m_tag)];
 }
 
 bool MembraneValue::tryParse(std::string_view text, MembraneValue &out) noexcept
 {
-    for (std::size_t i = 0; i < std::size(kWire); ++i)
+    for (std::size_t i = 0; i < std::size(kMembraneValueWire); ++i)
     {
-        if (kWire[i] == text)
+        if (kMembraneValueWire[i] == text)
         {
             out = MembraneValue{static_cast<Tag>(i)};
             return true;

--- a/src/private/mx/core/generated/MetalValue.cpp
+++ b/src/private/mx/core/generated/MetalValue.cpp
@@ -8,10 +8,7 @@
 namespace mx::core
 {
 
-namespace
-{
-
-constexpr std::string_view kWire[] = {
+constexpr std::string_view kMetalValueWire[] = {
     "agogo",
     "almglocken",
     "bell",
@@ -45,8 +42,6 @@ constexpr std::string_view kWire[] = {
     "triangle",
     "Vietnamese hat",
 };
-
-} // namespace
 
 MetalValue MetalValue::agogo() noexcept
 {
@@ -210,14 +205,14 @@ MetalValue MetalValue::vietnameseHat() noexcept
 
 std::string_view MetalValue::toString() const noexcept
 {
-    return kWire[static_cast<std::size_t>(m_tag)];
+    return kMetalValueWire[static_cast<std::size_t>(m_tag)];
 }
 
 bool MetalValue::tryParse(std::string_view text, MetalValue &out) noexcept
 {
-    for (std::size_t i = 0; i < std::size(kWire); ++i)
+    for (std::size_t i = 0; i < std::size(kMetalValueWire); ++i)
     {
-        if (kWire[i] == text)
+        if (kMetalValueWire[i] == text)
         {
             out = MetalValue{static_cast<Tag>(i)};
             return true;

--- a/src/private/mx/core/generated/Millimeters.cpp
+++ b/src/private/mx/core/generated/Millimeters.cpp
@@ -9,27 +9,22 @@
 namespace mx::core
 {
 
-namespace
-{
-
-Decimal clamped(Decimal v)
+Decimal clampedMillimeters(Decimal v)
 {
     return v;
 }
 
-} // namespace
-
-Millimeters::Millimeters() : m_value{clamped(Decimal{})}
+Millimeters::Millimeters() : m_value{clampedMillimeters(Decimal{})}
 {
 }
 
-Millimeters::Millimeters(Decimal value) : m_value{clamped(std::move(value))}
+Millimeters::Millimeters(Decimal value) : m_value{clampedMillimeters(std::move(value))}
 {
 }
 
 void Millimeters::setValue(Decimal value)
 {
-    m_value = clamped(std::move(value));
+    m_value = clampedMillimeters(std::move(value));
 }
 
 std::string Millimeters::toString() const

--- a/src/private/mx/core/generated/Milliseconds.cpp
+++ b/src/private/mx/core/generated/Milliseconds.cpp
@@ -9,10 +9,7 @@
 namespace mx::core
 {
 
-namespace
-{
-
-int clamped(int v)
+int clampedMilliseconds(int v)
 {
     if (v < 0)
     {
@@ -21,19 +18,17 @@ int clamped(int v)
     return v;
 }
 
-} // namespace
-
-Milliseconds::Milliseconds() : m_value{clamped(int{})}
+Milliseconds::Milliseconds() : m_value{clampedMilliseconds(int{})}
 {
 }
 
-Milliseconds::Milliseconds(int value) : m_value{clamped(std::move(value))}
+Milliseconds::Milliseconds(int value) : m_value{clampedMilliseconds(std::move(value))}
 {
 }
 
 void Milliseconds::setValue(int value)
 {
-    m_value = clamped(std::move(value));
+    m_value = clampedMilliseconds(std::move(value));
 }
 
 std::string Milliseconds::toString() const

--- a/src/private/mx/core/generated/Mode.cpp
+++ b/src/private/mx/core/generated/Mode.cpp
@@ -7,23 +7,18 @@
 namespace mx::core
 {
 
-namespace
-{
-
-std::string repaired(std::string v)
+std::string repairedMode(std::string v)
 {
     return v;
 }
 
-} // namespace
-
-Mode::Mode(std::string value) : m_value{repaired(std::move(value))}
+Mode::Mode(std::string value) : m_value{repairedMode(std::move(value))}
 {
 }
 
 void Mode::setValue(std::string value)
 {
-    m_value = repaired(std::move(value));
+    m_value = repairedMode(std::move(value));
 }
 
 bool Mode::tryParse(std::string_view text, Mode &out)

--- a/src/private/mx/core/generated/Mute.cpp
+++ b/src/private/mx/core/generated/Mute.cpp
@@ -8,15 +8,10 @@
 namespace mx::core
 {
 
-namespace
-{
-
-constexpr std::string_view kWire[] = {
+constexpr std::string_view kMuteWire[] = {
     "on",  "off",      "straight", "cup",       "harmon-no-stem", "harmon-stem", "bucket", "plunger",
     "hat", "solotone", "practice", "stop-mute", "stop-hand",      "echo",        "palm",
 };
-
-} // namespace
 
 Mute Mute::on() noexcept
 {
@@ -95,14 +90,14 @@ Mute Mute::palm() noexcept
 
 std::string_view Mute::toString() const noexcept
 {
-    return kWire[static_cast<std::size_t>(m_tag)];
+    return kMuteWire[static_cast<std::size_t>(m_tag)];
 }
 
 bool Mute::tryParse(std::string_view text, Mute &out) noexcept
 {
-    for (std::size_t i = 0; i < std::size(kWire); ++i)
+    for (std::size_t i = 0; i < std::size(kMuteWire); ++i)
     {
-        if (kWire[i] == text)
+        if (kMuteWire[i] == text)
         {
             out = Mute{static_cast<Tag>(i)};
             return true;

--- a/src/private/mx/core/generated/NonNegativeDecimal.cpp
+++ b/src/private/mx/core/generated/NonNegativeDecimal.cpp
@@ -9,10 +9,7 @@
 namespace mx::core
 {
 
-namespace
-{
-
-Decimal clamped(Decimal v)
+Decimal clampedNonNegativeDecimal(Decimal v)
 {
     if (v.value() < 0.0)
     {
@@ -21,19 +18,17 @@ Decimal clamped(Decimal v)
     return v;
 }
 
-} // namespace
-
-NonNegativeDecimal::NonNegativeDecimal() : m_value{clamped(Decimal{})}
+NonNegativeDecimal::NonNegativeDecimal() : m_value{clampedNonNegativeDecimal(Decimal{})}
 {
 }
 
-NonNegativeDecimal::NonNegativeDecimal(Decimal value) : m_value{clamped(std::move(value))}
+NonNegativeDecimal::NonNegativeDecimal(Decimal value) : m_value{clampedNonNegativeDecimal(std::move(value))}
 {
 }
 
 void NonNegativeDecimal::setValue(Decimal value)
 {
-    m_value = clamped(std::move(value));
+    m_value = clampedNonNegativeDecimal(std::move(value));
 }
 
 std::string NonNegativeDecimal::toString() const

--- a/src/private/mx/core/generated/NoteSizeType.cpp
+++ b/src/private/mx/core/generated/NoteSizeType.cpp
@@ -8,17 +8,12 @@
 namespace mx::core
 {
 
-namespace
-{
-
-constexpr std::string_view kWire[] = {
+constexpr std::string_view kNoteSizeTypeWire[] = {
     "cue",
     "grace",
     "grace-cue",
     "large",
 };
-
-} // namespace
 
 NoteSizeType NoteSizeType::cue() noexcept
 {
@@ -42,14 +37,14 @@ NoteSizeType NoteSizeType::large() noexcept
 
 std::string_view NoteSizeType::toString() const noexcept
 {
-    return kWire[static_cast<std::size_t>(m_tag)];
+    return kNoteSizeTypeWire[static_cast<std::size_t>(m_tag)];
 }
 
 bool NoteSizeType::tryParse(std::string_view text, NoteSizeType &out) noexcept
 {
-    for (std::size_t i = 0; i < std::size(kWire); ++i)
+    for (std::size_t i = 0; i < std::size(kNoteSizeTypeWire); ++i)
     {
-        if (kWire[i] == text)
+        if (kNoteSizeTypeWire[i] == text)
         {
             out = NoteSizeType{static_cast<Tag>(i)};
             return true;

--- a/src/private/mx/core/generated/NoteTypeValue.cpp
+++ b/src/private/mx/core/generated/NoteTypeValue.cpp
@@ -8,15 +8,10 @@
 namespace mx::core
 {
 
-namespace
-{
-
-constexpr std::string_view kWire[] = {
+constexpr std::string_view kNoteTypeValueWire[] = {
     "1024th", "512th",   "256th", "128th", "64th",  "32nd", "16th",
     "eighth", "quarter", "half",  "whole", "breve", "long", "maxima",
 };
-
-} // namespace
 
 NoteTypeValue NoteTypeValue::_1024th() noexcept
 {
@@ -90,14 +85,14 @@ NoteTypeValue NoteTypeValue::maxima() noexcept
 
 std::string_view NoteTypeValue::toString() const noexcept
 {
-    return kWire[static_cast<std::size_t>(m_tag)];
+    return kNoteTypeValueWire[static_cast<std::size_t>(m_tag)];
 }
 
 bool NoteTypeValue::tryParse(std::string_view text, NoteTypeValue &out) noexcept
 {
-    for (std::size_t i = 0; i < std::size(kWire); ++i)
+    for (std::size_t i = 0; i < std::size(kNoteTypeValueWire); ++i)
     {
-        if (kWire[i] == text)
+        if (kNoteTypeValueWire[i] == text)
         {
             out = NoteTypeValue{static_cast<Tag>(i)};
             return true;

--- a/src/private/mx/core/generated/NoteheadValue.cpp
+++ b/src/private/mx/core/generated/NoteheadValue.cpp
@@ -8,10 +8,7 @@
 namespace mx::core
 {
 
-namespace
-{
-
-constexpr std::string_view kWire[] = {
+constexpr std::string_view kNoteheadValueWire[] = {
     "slash",
     "triangle",
     "diamond",
@@ -41,8 +38,6 @@ constexpr std::string_view kWire[] = {
     "ti",
     "other",
 };
-
-} // namespace
 
 NoteheadValue NoteheadValue::slash() noexcept
 {
@@ -186,14 +181,14 @@ NoteheadValue NoteheadValue::other() noexcept
 
 std::string_view NoteheadValue::toString() const noexcept
 {
-    return kWire[static_cast<std::size_t>(m_tag)];
+    return kNoteheadValueWire[static_cast<std::size_t>(m_tag)];
 }
 
 bool NoteheadValue::tryParse(std::string_view text, NoteheadValue &out) noexcept
 {
-    for (std::size_t i = 0; i < std::size(kWire); ++i)
+    for (std::size_t i = 0; i < std::size(kNoteheadValueWire); ++i)
     {
-        if (kWire[i] == text)
+        if (kNoteheadValueWire[i] == text)
         {
             out = NoteheadValue{static_cast<Tag>(i)};
             return true;

--- a/src/private/mx/core/generated/NumberLevel.cpp
+++ b/src/private/mx/core/generated/NumberLevel.cpp
@@ -9,10 +9,7 @@
 namespace mx::core
 {
 
-namespace
-{
-
-int clamped(int v)
+int clampedNumberLevel(int v)
 {
     if (v < 1)
     {
@@ -25,19 +22,17 @@ int clamped(int v)
     return v;
 }
 
-} // namespace
-
-NumberLevel::NumberLevel() : m_value{clamped(int{})}
+NumberLevel::NumberLevel() : m_value{clampedNumberLevel(int{})}
 {
 }
 
-NumberLevel::NumberLevel(int value) : m_value{clamped(std::move(value))}
+NumberLevel::NumberLevel(int value) : m_value{clampedNumberLevel(std::move(value))}
 {
 }
 
 void NumberLevel::setValue(int value)
 {
-    m_value = clamped(std::move(value));
+    m_value = clampedNumberLevel(std::move(value));
 }
 
 std::string NumberLevel::toString() const

--- a/src/private/mx/core/generated/NumberOfLines.cpp
+++ b/src/private/mx/core/generated/NumberOfLines.cpp
@@ -9,10 +9,7 @@
 namespace mx::core
 {
 
-namespace
-{
-
-int clamped(int v)
+int clampedNumberOfLines(int v)
 {
     if (v < 0)
     {
@@ -25,19 +22,17 @@ int clamped(int v)
     return v;
 }
 
-} // namespace
-
-NumberOfLines::NumberOfLines() : m_value{clamped(int{})}
+NumberOfLines::NumberOfLines() : m_value{clampedNumberOfLines(int{})}
 {
 }
 
-NumberOfLines::NumberOfLines(int value) : m_value{clamped(std::move(value))}
+NumberOfLines::NumberOfLines(int value) : m_value{clampedNumberOfLines(std::move(value))}
 {
 }
 
 void NumberOfLines::setValue(int value)
 {
-    m_value = clamped(std::move(value));
+    m_value = clampedNumberOfLines(std::move(value));
 }
 
 std::string NumberOfLines::toString() const

--- a/src/private/mx/core/generated/NumeralMode.cpp
+++ b/src/private/mx/core/generated/NumeralMode.cpp
@@ -8,14 +8,9 @@
 namespace mx::core
 {
 
-namespace
-{
-
-constexpr std::string_view kWire[] = {
+constexpr std::string_view kNumeralModeWire[] = {
     "major", "minor", "natural minor", "melodic minor", "harmonic minor",
 };
-
-} // namespace
 
 NumeralMode NumeralMode::major() noexcept
 {
@@ -44,14 +39,14 @@ NumeralMode NumeralMode::harmonicMinor() noexcept
 
 std::string_view NumeralMode::toString() const noexcept
 {
-    return kWire[static_cast<std::size_t>(m_tag)];
+    return kNumeralModeWire[static_cast<std::size_t>(m_tag)];
 }
 
 bool NumeralMode::tryParse(std::string_view text, NumeralMode &out) noexcept
 {
-    for (std::size_t i = 0; i < std::size(kWire); ++i)
+    for (std::size_t i = 0; i < std::size(kNumeralModeWire); ++i)
     {
-        if (kWire[i] == text)
+        if (kNumeralModeWire[i] == text)
         {
             out = NumeralMode{static_cast<Tag>(i)};
             return true;

--- a/src/private/mx/core/generated/NumeralValue.cpp
+++ b/src/private/mx/core/generated/NumeralValue.cpp
@@ -9,10 +9,7 @@
 namespace mx::core
 {
 
-namespace
-{
-
-int clamped(int v)
+int clampedNumeralValue(int v)
 {
     if (v < 1)
     {
@@ -25,19 +22,17 @@ int clamped(int v)
     return v;
 }
 
-} // namespace
-
-NumeralValue::NumeralValue() : m_value{clamped(int{})}
+NumeralValue::NumeralValue() : m_value{clampedNumeralValue(int{})}
 {
 }
 
-NumeralValue::NumeralValue(int value) : m_value{clamped(std::move(value))}
+NumeralValue::NumeralValue(int value) : m_value{clampedNumeralValue(std::move(value))}
 {
 }
 
 void NumeralValue::setValue(int value)
 {
-    m_value = clamped(std::move(value));
+    m_value = clampedNumeralValue(std::move(value));
 }
 
 std::string NumeralValue::toString() const

--- a/src/private/mx/core/generated/Octave.cpp
+++ b/src/private/mx/core/generated/Octave.cpp
@@ -9,10 +9,7 @@
 namespace mx::core
 {
 
-namespace
-{
-
-int clamped(int v)
+int clampedOctave(int v)
 {
     if (v < 0)
     {
@@ -25,19 +22,17 @@ int clamped(int v)
     return v;
 }
 
-} // namespace
-
-Octave::Octave() : m_value{clamped(int{})}
+Octave::Octave() : m_value{clampedOctave(int{})}
 {
 }
 
-Octave::Octave(int value) : m_value{clamped(std::move(value))}
+Octave::Octave(int value) : m_value{clampedOctave(std::move(value))}
 {
 }
 
 void Octave::setValue(int value)
 {
-    m_value = clamped(std::move(value));
+    m_value = clampedOctave(std::move(value));
 }
 
 std::string Octave::toString() const

--- a/src/private/mx/core/generated/OnOff.cpp
+++ b/src/private/mx/core/generated/OnOff.cpp
@@ -8,15 +8,10 @@
 namespace mx::core
 {
 
-namespace
-{
-
-constexpr std::string_view kWire[] = {
+constexpr std::string_view kOnOffWire[] = {
     "on",
     "off",
 };
-
-} // namespace
 
 OnOff OnOff::on() noexcept
 {
@@ -30,14 +25,14 @@ OnOff OnOff::off() noexcept
 
 std::string_view OnOff::toString() const noexcept
 {
-    return kWire[static_cast<std::size_t>(m_tag)];
+    return kOnOffWire[static_cast<std::size_t>(m_tag)];
 }
 
 bool OnOff::tryParse(std::string_view text, OnOff &out) noexcept
 {
-    for (std::size_t i = 0; i < std::size(kWire); ++i)
+    for (std::size_t i = 0; i < std::size(kOnOffWire); ++i)
     {
-        if (kWire[i] == text)
+        if (kOnOffWire[i] == text)
         {
             out = OnOff{static_cast<Tag>(i)};
             return true;

--- a/src/private/mx/core/generated/OverUnder.cpp
+++ b/src/private/mx/core/generated/OverUnder.cpp
@@ -8,15 +8,10 @@
 namespace mx::core
 {
 
-namespace
-{
-
-constexpr std::string_view kWire[] = {
+constexpr std::string_view kOverUnderWire[] = {
     "over",
     "under",
 };
-
-} // namespace
 
 OverUnder OverUnder::over() noexcept
 {
@@ -30,14 +25,14 @@ OverUnder OverUnder::under() noexcept
 
 std::string_view OverUnder::toString() const noexcept
 {
-    return kWire[static_cast<std::size_t>(m_tag)];
+    return kOverUnderWire[static_cast<std::size_t>(m_tag)];
 }
 
 bool OverUnder::tryParse(std::string_view text, OverUnder &out) noexcept
 {
-    for (std::size_t i = 0; i < std::size(kWire); ++i)
+    for (std::size_t i = 0; i < std::size(kOverUnderWire); ++i)
     {
-        if (kWire[i] == text)
+        if (kOverUnderWire[i] == text)
         {
             out = OverUnder{static_cast<Tag>(i)};
             return true;

--- a/src/private/mx/core/generated/PedalType.cpp
+++ b/src/private/mx/core/generated/PedalType.cpp
@@ -8,14 +8,9 @@
 namespace mx::core
 {
 
-namespace
-{
-
-constexpr std::string_view kWire[] = {
+constexpr std::string_view kPedalTypeWire[] = {
     "start", "stop", "sostenuto", "change", "continue", "discontinue", "resume",
 };
-
-} // namespace
 
 PedalType PedalType::start() noexcept
 {
@@ -54,14 +49,14 @@ PedalType PedalType::resume() noexcept
 
 std::string_view PedalType::toString() const noexcept
 {
-    return kWire[static_cast<std::size_t>(m_tag)];
+    return kPedalTypeWire[static_cast<std::size_t>(m_tag)];
 }
 
 bool PedalType::tryParse(std::string_view text, PedalType &out) noexcept
 {
-    for (std::size_t i = 0; i < std::size(kWire); ++i)
+    for (std::size_t i = 0; i < std::size(kPedalTypeWire); ++i)
     {
-        if (kWire[i] == text)
+        if (kPedalTypeWire[i] == text)
         {
             out = PedalType{static_cast<Tag>(i)};
             return true;

--- a/src/private/mx/core/generated/Percent.cpp
+++ b/src/private/mx/core/generated/Percent.cpp
@@ -9,10 +9,7 @@
 namespace mx::core
 {
 
-namespace
-{
-
-Decimal clamped(Decimal v)
+Decimal clampedPercent(Decimal v)
 {
     if (v.value() < 0.0)
     {
@@ -25,19 +22,17 @@ Decimal clamped(Decimal v)
     return v;
 }
 
-} // namespace
-
-Percent::Percent() : m_value{clamped(Decimal{})}
+Percent::Percent() : m_value{clampedPercent(Decimal{})}
 {
 }
 
-Percent::Percent(Decimal value) : m_value{clamped(std::move(value))}
+Percent::Percent(Decimal value) : m_value{clampedPercent(std::move(value))}
 {
 }
 
 void Percent::setValue(Decimal value)
 {
-    m_value = clamped(std::move(value));
+    m_value = clampedPercent(std::move(value));
 }
 
 std::string Percent::toString() const

--- a/src/private/mx/core/generated/PitchedValue.cpp
+++ b/src/private/mx/core/generated/PitchedValue.cpp
@@ -8,15 +8,10 @@
 namespace mx::core
 {
 
-namespace
-{
-
-constexpr std::string_view kWire[] = {
+constexpr std::string_view kPitchedValueWire[] = {
     "celesta",     "chimes",    "glockenspiel",   "lithophone", "mallet",    "marimba",
     "steel drums", "tubaphone", "tubular chimes", "vibraphone", "xylophone",
 };
-
-} // namespace
 
 PitchedValue PitchedValue::celesta() noexcept
 {
@@ -75,14 +70,14 @@ PitchedValue PitchedValue::xylophone() noexcept
 
 std::string_view PitchedValue::toString() const noexcept
 {
-    return kWire[static_cast<std::size_t>(m_tag)];
+    return kPitchedValueWire[static_cast<std::size_t>(m_tag)];
 }
 
 bool PitchedValue::tryParse(std::string_view text, PitchedValue &out) noexcept
 {
-    for (std::size_t i = 0; i < std::size(kWire); ++i)
+    for (std::size_t i = 0; i < std::size(kPitchedValueWire); ++i)
     {
-        if (kWire[i] == text)
+        if (kPitchedValueWire[i] == text)
         {
             out = PitchedValue{static_cast<Tag>(i)};
             return true;

--- a/src/private/mx/core/generated/PositiveDivisions.cpp
+++ b/src/private/mx/core/generated/PositiveDivisions.cpp
@@ -9,10 +9,7 @@
 namespace mx::core
 {
 
-namespace
-{
-
-Decimal clamped(Decimal v)
+Decimal clampedPositiveDivisions(Decimal v)
 {
     if (v.value() <= 0.0)
     {
@@ -21,19 +18,17 @@ Decimal clamped(Decimal v)
     return v;
 }
 
-} // namespace
-
-PositiveDivisions::PositiveDivisions() : m_value{clamped(Decimal{})}
+PositiveDivisions::PositiveDivisions() : m_value{clampedPositiveDivisions(Decimal{})}
 {
 }
 
-PositiveDivisions::PositiveDivisions(Decimal value) : m_value{clamped(std::move(value))}
+PositiveDivisions::PositiveDivisions(Decimal value) : m_value{clampedPositiveDivisions(std::move(value))}
 {
 }
 
 void PositiveDivisions::setValue(Decimal value)
 {
-    m_value = clamped(std::move(value));
+    m_value = clampedPositiveDivisions(std::move(value));
 }
 
 std::string PositiveDivisions::toString() const

--- a/src/private/mx/core/generated/PrincipalVoiceSymbol.cpp
+++ b/src/private/mx/core/generated/PrincipalVoiceSymbol.cpp
@@ -8,17 +8,12 @@
 namespace mx::core
 {
 
-namespace
-{
-
-constexpr std::string_view kWire[] = {
+constexpr std::string_view kPrincipalVoiceSymbolWire[] = {
     "Hauptstimme",
     "Nebenstimme",
     "plain",
     "none",
 };
-
-} // namespace
 
 PrincipalVoiceSymbol PrincipalVoiceSymbol::hauptstimme() noexcept
 {
@@ -42,14 +37,14 @@ PrincipalVoiceSymbol PrincipalVoiceSymbol::none() noexcept
 
 std::string_view PrincipalVoiceSymbol::toString() const noexcept
 {
-    return kWire[static_cast<std::size_t>(m_tag)];
+    return kPrincipalVoiceSymbolWire[static_cast<std::size_t>(m_tag)];
 }
 
 bool PrincipalVoiceSymbol::tryParse(std::string_view text, PrincipalVoiceSymbol &out) noexcept
 {
-    for (std::size_t i = 0; i < std::size(kWire); ++i)
+    for (std::size_t i = 0; i < std::size(kPrincipalVoiceSymbolWire); ++i)
     {
-        if (kWire[i] == text)
+        if (kPrincipalVoiceSymbolWire[i] == text)
         {
             out = PrincipalVoiceSymbol{static_cast<Tag>(i)};
             return true;

--- a/src/private/mx/core/generated/RightLeftMiddle.cpp
+++ b/src/private/mx/core/generated/RightLeftMiddle.cpp
@@ -8,16 +8,11 @@
 namespace mx::core
 {
 
-namespace
-{
-
-constexpr std::string_view kWire[] = {
+constexpr std::string_view kRightLeftMiddleWire[] = {
     "right",
     "left",
     "middle",
 };
-
-} // namespace
 
 RightLeftMiddle RightLeftMiddle::right() noexcept
 {
@@ -36,14 +31,14 @@ RightLeftMiddle RightLeftMiddle::middle() noexcept
 
 std::string_view RightLeftMiddle::toString() const noexcept
 {
-    return kWire[static_cast<std::size_t>(m_tag)];
+    return kRightLeftMiddleWire[static_cast<std::size_t>(m_tag)];
 }
 
 bool RightLeftMiddle::tryParse(std::string_view text, RightLeftMiddle &out) noexcept
 {
-    for (std::size_t i = 0; i < std::size(kWire); ++i)
+    for (std::size_t i = 0; i < std::size(kRightLeftMiddleWire); ++i)
     {
-        if (kWire[i] == text)
+        if (kRightLeftMiddleWire[i] == text)
         {
             out = RightLeftMiddle{static_cast<Tag>(i)};
             return true;

--- a/src/private/mx/core/generated/RotationDegrees.cpp
+++ b/src/private/mx/core/generated/RotationDegrees.cpp
@@ -9,10 +9,7 @@
 namespace mx::core
 {
 
-namespace
-{
-
-Decimal clamped(Decimal v)
+Decimal clampedRotationDegrees(Decimal v)
 {
     if (v.value() < -180.0)
     {
@@ -25,19 +22,17 @@ Decimal clamped(Decimal v)
     return v;
 }
 
-} // namespace
-
-RotationDegrees::RotationDegrees() : m_value{clamped(Decimal{})}
+RotationDegrees::RotationDegrees() : m_value{clampedRotationDegrees(Decimal{})}
 {
 }
 
-RotationDegrees::RotationDegrees(Decimal value) : m_value{clamped(std::move(value))}
+RotationDegrees::RotationDegrees(Decimal value) : m_value{clampedRotationDegrees(std::move(value))}
 {
 }
 
 void RotationDegrees::setValue(Decimal value)
 {
-    m_value = clamped(std::move(value));
+    m_value = clampedRotationDegrees(std::move(value));
 }
 
 std::string RotationDegrees::toString() const

--- a/src/private/mx/core/generated/SemiPitched.cpp
+++ b/src/private/mx/core/generated/SemiPitched.cpp
@@ -8,14 +8,9 @@
 namespace mx::core
 {
 
-namespace
-{
-
-constexpr std::string_view kWire[] = {
+constexpr std::string_view kSemiPitchedWire[] = {
     "high", "medium-high", "medium", "medium-low", "low", "very-low",
 };
-
-} // namespace
 
 SemiPitched SemiPitched::high() noexcept
 {
@@ -49,14 +44,14 @@ SemiPitched SemiPitched::veryLow() noexcept
 
 std::string_view SemiPitched::toString() const noexcept
 {
-    return kWire[static_cast<std::size_t>(m_tag)];
+    return kSemiPitchedWire[static_cast<std::size_t>(m_tag)];
 }
 
 bool SemiPitched::tryParse(std::string_view text, SemiPitched &out) noexcept
 {
-    for (std::size_t i = 0; i < std::size(kWire); ++i)
+    for (std::size_t i = 0; i < std::size(kSemiPitchedWire); ++i)
     {
-        if (kWire[i] == text)
+        if (kSemiPitchedWire[i] == text)
         {
             out = SemiPitched{static_cast<Tag>(i)};
             return true;

--- a/src/private/mx/core/generated/Semitones.cpp
+++ b/src/private/mx/core/generated/Semitones.cpp
@@ -9,27 +9,22 @@
 namespace mx::core
 {
 
-namespace
-{
-
-Decimal clamped(Decimal v)
+Decimal clampedSemitones(Decimal v)
 {
     return v;
 }
 
-} // namespace
-
-Semitones::Semitones() : m_value{clamped(Decimal{})}
+Semitones::Semitones() : m_value{clampedSemitones(Decimal{})}
 {
 }
 
-Semitones::Semitones(Decimal value) : m_value{clamped(std::move(value))}
+Semitones::Semitones(Decimal value) : m_value{clampedSemitones(std::move(value))}
 {
 }
 
 void Semitones::setValue(Decimal value)
 {
-    m_value = clamped(std::move(value));
+    m_value = clampedSemitones(std::move(value));
 }
 
 std::string Semitones::toString() const

--- a/src/private/mx/core/generated/ShowFrets.cpp
+++ b/src/private/mx/core/generated/ShowFrets.cpp
@@ -8,15 +8,10 @@
 namespace mx::core
 {
 
-namespace
-{
-
-constexpr std::string_view kWire[] = {
+constexpr std::string_view kShowFretsWire[] = {
     "numbers",
     "letters",
 };
-
-} // namespace
 
 ShowFrets ShowFrets::numbers() noexcept
 {
@@ -30,14 +25,14 @@ ShowFrets ShowFrets::letters() noexcept
 
 std::string_view ShowFrets::toString() const noexcept
 {
-    return kWire[static_cast<std::size_t>(m_tag)];
+    return kShowFretsWire[static_cast<std::size_t>(m_tag)];
 }
 
 bool ShowFrets::tryParse(std::string_view text, ShowFrets &out) noexcept
 {
-    for (std::size_t i = 0; i < std::size(kWire); ++i)
+    for (std::size_t i = 0; i < std::size(kShowFretsWire); ++i)
     {
-        if (kWire[i] == text)
+        if (kShowFretsWire[i] == text)
         {
             out = ShowFrets{static_cast<Tag>(i)};
             return true;

--- a/src/private/mx/core/generated/ShowTuplet.cpp
+++ b/src/private/mx/core/generated/ShowTuplet.cpp
@@ -8,16 +8,11 @@
 namespace mx::core
 {
 
-namespace
-{
-
-constexpr std::string_view kWire[] = {
+constexpr std::string_view kShowTupletWire[] = {
     "actual",
     "both",
     "none",
 };
-
-} // namespace
 
 ShowTuplet ShowTuplet::actual() noexcept
 {
@@ -36,14 +31,14 @@ ShowTuplet ShowTuplet::none() noexcept
 
 std::string_view ShowTuplet::toString() const noexcept
 {
-    return kWire[static_cast<std::size_t>(m_tag)];
+    return kShowTupletWire[static_cast<std::size_t>(m_tag)];
 }
 
 bool ShowTuplet::tryParse(std::string_view text, ShowTuplet &out) noexcept
 {
-    for (std::size_t i = 0; i < std::size(kWire); ++i)
+    for (std::size_t i = 0; i < std::size(kShowTupletWire); ++i)
     {
-        if (kWire[i] == text)
+        if (kShowTupletWire[i] == text)
         {
             out = ShowTuplet{static_cast<Tag>(i)};
             return true;

--- a/src/private/mx/core/generated/SmuflAccidentalGlyphName.cpp
+++ b/src/private/mx/core/generated/SmuflAccidentalGlyphName.cpp
@@ -9,21 +9,16 @@
 namespace mx::core
 {
 
-namespace
-{
-
-constexpr std::string_view kPrefix[] = {
+constexpr std::string_view kSmuflAccidentalGlyphNamePrefix[] = {
     "acc", "medRenFla", "medRenNatura", "medRenShar", "kievanAccidental",
 };
 
 // The ASCII subset of XML name characters the schema's \c denotes.
-bool isNameChar(char c) noexcept
+bool isNameCharSmuflAccidentalGlyphName(char c) noexcept
 {
     return (c >= 'a' && c <= 'z') || (c >= 'A' && c <= 'Z') || (c >= '0' && c <= '9') || c == '-' || c == '.' ||
            c == ':' || c == '_';
 }
-
-} // namespace
 
 SmuflAccidentalGlyphName::SmuflAccidentalGlyphName()
 {
@@ -44,7 +39,7 @@ SmuflAccidentalGlyphName::SmuflAccidentalGlyphName(Prefix prefix, std::string su
 void SmuflAccidentalGlyphName::setPrefix(Prefix value) noexcept
 {
     m_prefix = value;
-    if (static_cast<std::size_t>(m_prefix) >= std::size(kPrefix))
+    if (static_cast<std::size_t>(m_prefix) >= std::size(kSmuflAccidentalGlyphNamePrefix))
     {
         m_prefix = Prefix::acc;
     }
@@ -58,7 +53,7 @@ void SmuflAccidentalGlyphName::setSuffix(std::string value)
 
 void SmuflAccidentalGlyphName::repair()
 {
-    if (static_cast<std::size_t>(m_prefix) >= std::size(kPrefix))
+    if (static_cast<std::size_t>(m_prefix) >= std::size(kSmuflAccidentalGlyphNamePrefix))
     {
         m_prefix = Prefix::acc;
     }
@@ -66,7 +61,7 @@ void SmuflAccidentalGlyphName::repair()
     cleaned.reserve(m_suffix.size());
     for (const char c : m_suffix)
     {
-        if (isNameChar(c))
+        if (isNameCharSmuflAccidentalGlyphName(c))
         {
             cleaned.push_back(c);
         }
@@ -80,16 +75,16 @@ void SmuflAccidentalGlyphName::repair()
 
 std::string SmuflAccidentalGlyphName::toString() const
 {
-    std::string out{kPrefix[static_cast<std::size_t>(m_prefix)]};
+    std::string out{kSmuflAccidentalGlyphNamePrefix[static_cast<std::size_t>(m_prefix)]};
     out += m_suffix;
     return out;
 }
 
 bool SmuflAccidentalGlyphName::tryParse(std::string_view text, SmuflAccidentalGlyphName &out)
 {
-    for (std::size_t i = 0; i < std::size(kPrefix); ++i)
+    for (std::size_t i = 0; i < std::size(kSmuflAccidentalGlyphNamePrefix); ++i)
     {
-        const std::string_view prefix = kPrefix[i];
+        const std::string_view prefix = kSmuflAccidentalGlyphNamePrefix[i];
         if (text.size() < prefix.size() || text.substr(0, prefix.size()) != prefix)
         {
             continue;
@@ -102,7 +97,7 @@ bool SmuflAccidentalGlyphName::tryParse(std::string_view text, SmuflAccidentalGl
         bool valid = true;
         for (const char c : suffix)
         {
-            if (!isNameChar(c))
+            if (!isNameCharSmuflAccidentalGlyphName(c))
             {
                 valid = false;
                 break;

--- a/src/private/mx/core/generated/SmuflCodaGlyphName.cpp
+++ b/src/private/mx/core/generated/SmuflCodaGlyphName.cpp
@@ -9,21 +9,16 @@
 namespace mx::core
 {
 
-namespace
-{
-
-constexpr std::string_view kPrefix[] = {
+constexpr std::string_view kSmuflCodaGlyphNamePrefix[] = {
     "coda",
 };
 
 // The ASCII subset of XML name characters the schema's \c denotes.
-bool isNameChar(char c) noexcept
+bool isNameCharSmuflCodaGlyphName(char c) noexcept
 {
     return (c >= 'a' && c <= 'z') || (c >= 'A' && c <= 'Z') || (c >= '0' && c <= '9') || c == '-' || c == '.' ||
            c == ':' || c == '_';
 }
-
-} // namespace
 
 SmuflCodaGlyphName::SmuflCodaGlyphName()
 {
@@ -47,7 +42,7 @@ void SmuflCodaGlyphName::repair()
     cleaned.reserve(m_suffix.size());
     for (const char c : m_suffix)
     {
-        if (isNameChar(c))
+        if (isNameCharSmuflCodaGlyphName(c))
         {
             cleaned.push_back(c);
         }
@@ -57,16 +52,16 @@ void SmuflCodaGlyphName::repair()
 
 std::string SmuflCodaGlyphName::toString() const
 {
-    std::string out{kPrefix[0]};
+    std::string out{kSmuflCodaGlyphNamePrefix[0]};
     out += m_suffix;
     return out;
 }
 
 bool SmuflCodaGlyphName::tryParse(std::string_view text, SmuflCodaGlyphName &out)
 {
-    for (std::size_t i = 0; i < std::size(kPrefix); ++i)
+    for (std::size_t i = 0; i < std::size(kSmuflCodaGlyphNamePrefix); ++i)
     {
-        const std::string_view prefix = kPrefix[i];
+        const std::string_view prefix = kSmuflCodaGlyphNamePrefix[i];
         if (text.size() < prefix.size() || text.substr(0, prefix.size()) != prefix)
         {
             continue;
@@ -75,7 +70,7 @@ bool SmuflCodaGlyphName::tryParse(std::string_view text, SmuflCodaGlyphName &out
         bool valid = true;
         for (const char c : suffix)
         {
-            if (!isNameChar(c))
+            if (!isNameCharSmuflCodaGlyphName(c))
             {
                 valid = false;
                 break;

--- a/src/private/mx/core/generated/SmuflLyricsGlyphName.cpp
+++ b/src/private/mx/core/generated/SmuflLyricsGlyphName.cpp
@@ -9,21 +9,16 @@
 namespace mx::core
 {
 
-namespace
-{
-
-constexpr std::string_view kPrefix[] = {
+constexpr std::string_view kSmuflLyricsGlyphNamePrefix[] = {
     "lyrics",
 };
 
 // The ASCII subset of XML name characters the schema's \c denotes.
-bool isNameChar(char c) noexcept
+bool isNameCharSmuflLyricsGlyphName(char c) noexcept
 {
     return (c >= 'a' && c <= 'z') || (c >= 'A' && c <= 'Z') || (c >= '0' && c <= '9') || c == '-' || c == '.' ||
            c == ':' || c == '_';
 }
-
-} // namespace
 
 SmuflLyricsGlyphName::SmuflLyricsGlyphName()
 {
@@ -47,7 +42,7 @@ void SmuflLyricsGlyphName::repair()
     cleaned.reserve(m_suffix.size());
     for (const char c : m_suffix)
     {
-        if (isNameChar(c))
+        if (isNameCharSmuflLyricsGlyphName(c))
         {
             cleaned.push_back(c);
         }
@@ -61,16 +56,16 @@ void SmuflLyricsGlyphName::repair()
 
 std::string SmuflLyricsGlyphName::toString() const
 {
-    std::string out{kPrefix[0]};
+    std::string out{kSmuflLyricsGlyphNamePrefix[0]};
     out += m_suffix;
     return out;
 }
 
 bool SmuflLyricsGlyphName::tryParse(std::string_view text, SmuflLyricsGlyphName &out)
 {
-    for (std::size_t i = 0; i < std::size(kPrefix); ++i)
+    for (std::size_t i = 0; i < std::size(kSmuflLyricsGlyphNamePrefix); ++i)
     {
-        const std::string_view prefix = kPrefix[i];
+        const std::string_view prefix = kSmuflLyricsGlyphNamePrefix[i];
         if (text.size() < prefix.size() || text.substr(0, prefix.size()) != prefix)
         {
             continue;
@@ -83,7 +78,7 @@ bool SmuflLyricsGlyphName::tryParse(std::string_view text, SmuflLyricsGlyphName 
         bool valid = true;
         for (const char c : suffix)
         {
-            if (!isNameChar(c))
+            if (!isNameCharSmuflLyricsGlyphName(c))
             {
                 valid = false;
                 break;

--- a/src/private/mx/core/generated/SmuflPictogramGlyphName.cpp
+++ b/src/private/mx/core/generated/SmuflPictogramGlyphName.cpp
@@ -9,21 +9,16 @@
 namespace mx::core
 {
 
-namespace
-{
-
-constexpr std::string_view kPrefix[] = {
+constexpr std::string_view kSmuflPictogramGlyphNamePrefix[] = {
     "pict",
 };
 
 // The ASCII subset of XML name characters the schema's \c denotes.
-bool isNameChar(char c) noexcept
+bool isNameCharSmuflPictogramGlyphName(char c) noexcept
 {
     return (c >= 'a' && c <= 'z') || (c >= 'A' && c <= 'Z') || (c >= '0' && c <= '9') || c == '-' || c == '.' ||
            c == ':' || c == '_';
 }
-
-} // namespace
 
 SmuflPictogramGlyphName::SmuflPictogramGlyphName()
 {
@@ -47,7 +42,7 @@ void SmuflPictogramGlyphName::repair()
     cleaned.reserve(m_suffix.size());
     for (const char c : m_suffix)
     {
-        if (isNameChar(c))
+        if (isNameCharSmuflPictogramGlyphName(c))
         {
             cleaned.push_back(c);
         }
@@ -61,16 +56,16 @@ void SmuflPictogramGlyphName::repair()
 
 std::string SmuflPictogramGlyphName::toString() const
 {
-    std::string out{kPrefix[0]};
+    std::string out{kSmuflPictogramGlyphNamePrefix[0]};
     out += m_suffix;
     return out;
 }
 
 bool SmuflPictogramGlyphName::tryParse(std::string_view text, SmuflPictogramGlyphName &out)
 {
-    for (std::size_t i = 0; i < std::size(kPrefix); ++i)
+    for (std::size_t i = 0; i < std::size(kSmuflPictogramGlyphNamePrefix); ++i)
     {
-        const std::string_view prefix = kPrefix[i];
+        const std::string_view prefix = kSmuflPictogramGlyphNamePrefix[i];
         if (text.size() < prefix.size() || text.substr(0, prefix.size()) != prefix)
         {
             continue;
@@ -83,7 +78,7 @@ bool SmuflPictogramGlyphName::tryParse(std::string_view text, SmuflPictogramGlyp
         bool valid = true;
         for (const char c : suffix)
         {
-            if (!isNameChar(c))
+            if (!isNameCharSmuflPictogramGlyphName(c))
             {
                 valid = false;
                 break;

--- a/src/private/mx/core/generated/SmuflSegnoGlyphName.cpp
+++ b/src/private/mx/core/generated/SmuflSegnoGlyphName.cpp
@@ -9,21 +9,16 @@
 namespace mx::core
 {
 
-namespace
-{
-
-constexpr std::string_view kPrefix[] = {
+constexpr std::string_view kSmuflSegnoGlyphNamePrefix[] = {
     "segno",
 };
 
 // The ASCII subset of XML name characters the schema's \c denotes.
-bool isNameChar(char c) noexcept
+bool isNameCharSmuflSegnoGlyphName(char c) noexcept
 {
     return (c >= 'a' && c <= 'z') || (c >= 'A' && c <= 'Z') || (c >= '0' && c <= '9') || c == '-' || c == '.' ||
            c == ':' || c == '_';
 }
-
-} // namespace
 
 SmuflSegnoGlyphName::SmuflSegnoGlyphName()
 {
@@ -47,7 +42,7 @@ void SmuflSegnoGlyphName::repair()
     cleaned.reserve(m_suffix.size());
     for (const char c : m_suffix)
     {
-        if (isNameChar(c))
+        if (isNameCharSmuflSegnoGlyphName(c))
         {
             cleaned.push_back(c);
         }
@@ -57,16 +52,16 @@ void SmuflSegnoGlyphName::repair()
 
 std::string SmuflSegnoGlyphName::toString() const
 {
-    std::string out{kPrefix[0]};
+    std::string out{kSmuflSegnoGlyphNamePrefix[0]};
     out += m_suffix;
     return out;
 }
 
 bool SmuflSegnoGlyphName::tryParse(std::string_view text, SmuflSegnoGlyphName &out)
 {
-    for (std::size_t i = 0; i < std::size(kPrefix); ++i)
+    for (std::size_t i = 0; i < std::size(kSmuflSegnoGlyphNamePrefix); ++i)
     {
-        const std::string_view prefix = kPrefix[i];
+        const std::string_view prefix = kSmuflSegnoGlyphNamePrefix[i];
         if (text.size() < prefix.size() || text.substr(0, prefix.size()) != prefix)
         {
             continue;
@@ -75,7 +70,7 @@ bool SmuflSegnoGlyphName::tryParse(std::string_view text, SmuflSegnoGlyphName &o
         bool valid = true;
         for (const char c : suffix)
         {
-            if (!isNameChar(c))
+            if (!isNameCharSmuflSegnoGlyphName(c))
             {
                 valid = false;
                 break;

--- a/src/private/mx/core/generated/SoundID.cpp
+++ b/src/private/mx/core/generated/SoundID.cpp
@@ -8,10 +8,7 @@
 namespace mx::core
 {
 
-namespace
-{
-
-constexpr std::string_view kWire[] = {
+constexpr std::string_view kSoundIDWire[] = {
     "brass.alphorn",
     "brass.alto-horn",
     "brass.baritone-horn",
@@ -907,8 +904,6 @@ constexpr std::string_view kWire[] = {
     "wood.tonetang",
     "wood.wood-block",
 };
-
-} // namespace
 
 SoundID SoundID::brassAlphorn() noexcept
 {
@@ -5382,14 +5377,14 @@ SoundID SoundID::woodWoodBlock() noexcept
 
 std::string_view SoundID::toString() const noexcept
 {
-    return kWire[static_cast<std::size_t>(m_tag)];
+    return kSoundIDWire[static_cast<std::size_t>(m_tag)];
 }
 
 bool SoundID::tryParse(std::string_view text, SoundID &out) noexcept
 {
-    for (std::size_t i = 0; i < std::size(kWire); ++i)
+    for (std::size_t i = 0; i < std::size(kSoundIDWire); ++i)
     {
-        if (kWire[i] == text)
+        if (kSoundIDWire[i] == text)
         {
             out = SoundID{static_cast<Tag>(i)};
             return true;

--- a/src/private/mx/core/generated/StaffDivideSymbol.cpp
+++ b/src/private/mx/core/generated/StaffDivideSymbol.cpp
@@ -8,16 +8,11 @@
 namespace mx::core
 {
 
-namespace
-{
-
-constexpr std::string_view kWire[] = {
+constexpr std::string_view kStaffDivideSymbolWire[] = {
     "down",
     "up",
     "up-down",
 };
-
-} // namespace
 
 StaffDivideSymbol StaffDivideSymbol::down() noexcept
 {
@@ -36,14 +31,14 @@ StaffDivideSymbol StaffDivideSymbol::upDown() noexcept
 
 std::string_view StaffDivideSymbol::toString() const noexcept
 {
-    return kWire[static_cast<std::size_t>(m_tag)];
+    return kStaffDivideSymbolWire[static_cast<std::size_t>(m_tag)];
 }
 
 bool StaffDivideSymbol::tryParse(std::string_view text, StaffDivideSymbol &out) noexcept
 {
-    for (std::size_t i = 0; i < std::size(kWire); ++i)
+    for (std::size_t i = 0; i < std::size(kStaffDivideSymbolWire); ++i)
     {
-        if (kWire[i] == text)
+        if (kStaffDivideSymbolWire[i] == text)
         {
             out = StaffDivideSymbol{static_cast<Tag>(i)};
             return true;

--- a/src/private/mx/core/generated/StaffLine.cpp
+++ b/src/private/mx/core/generated/StaffLine.cpp
@@ -9,10 +9,7 @@
 namespace mx::core
 {
 
-namespace
-{
-
-int clamped(int v)
+int clampedStaffLine(int v)
 {
     if (v < 1)
     {
@@ -21,19 +18,17 @@ int clamped(int v)
     return v;
 }
 
-} // namespace
-
-StaffLine::StaffLine() : m_value{clamped(int{})}
+StaffLine::StaffLine() : m_value{clampedStaffLine(int{})}
 {
 }
 
-StaffLine::StaffLine(int value) : m_value{clamped(std::move(value))}
+StaffLine::StaffLine(int value) : m_value{clampedStaffLine(std::move(value))}
 {
 }
 
 void StaffLine::setValue(int value)
 {
-    m_value = clamped(std::move(value));
+    m_value = clampedStaffLine(std::move(value));
 }
 
 std::string StaffLine::toString() const

--- a/src/private/mx/core/generated/StaffLinePosition.cpp
+++ b/src/private/mx/core/generated/StaffLinePosition.cpp
@@ -9,27 +9,22 @@
 namespace mx::core
 {
 
-namespace
-{
-
-int clamped(int v)
+int clampedStaffLinePosition(int v)
 {
     return v;
 }
 
-} // namespace
-
-StaffLinePosition::StaffLinePosition() : m_value{clamped(int{})}
+StaffLinePosition::StaffLinePosition() : m_value{clampedStaffLinePosition(int{})}
 {
 }
 
-StaffLinePosition::StaffLinePosition(int value) : m_value{clamped(std::move(value))}
+StaffLinePosition::StaffLinePosition(int value) : m_value{clampedStaffLinePosition(std::move(value))}
 {
 }
 
 void StaffLinePosition::setValue(int value)
 {
-    m_value = clamped(std::move(value));
+    m_value = clampedStaffLinePosition(std::move(value));
 }
 
 std::string StaffLinePosition::toString() const

--- a/src/private/mx/core/generated/StaffNumber.cpp
+++ b/src/private/mx/core/generated/StaffNumber.cpp
@@ -9,10 +9,7 @@
 namespace mx::core
 {
 
-namespace
-{
-
-int clamped(int v)
+int clampedStaffNumber(int v)
 {
     if (v < 1)
     {
@@ -21,19 +18,17 @@ int clamped(int v)
     return v;
 }
 
-} // namespace
-
-StaffNumber::StaffNumber() : m_value{clamped(int{})}
+StaffNumber::StaffNumber() : m_value{clampedStaffNumber(int{})}
 {
 }
 
-StaffNumber::StaffNumber(int value) : m_value{clamped(std::move(value))}
+StaffNumber::StaffNumber(int value) : m_value{clampedStaffNumber(std::move(value))}
 {
 }
 
 void StaffNumber::setValue(int value)
 {
-    m_value = clamped(std::move(value));
+    m_value = clampedStaffNumber(std::move(value));
 }
 
 std::string StaffNumber::toString() const

--- a/src/private/mx/core/generated/StaffType.cpp
+++ b/src/private/mx/core/generated/StaffType.cpp
@@ -8,14 +8,9 @@
 namespace mx::core
 {
 
-namespace
-{
-
-constexpr std::string_view kWire[] = {
+constexpr std::string_view kStaffTypeWire[] = {
     "ossia", "editorial", "cue", "alternate", "regular",
 };
-
-} // namespace
 
 StaffType StaffType::ossia() noexcept
 {
@@ -44,14 +39,14 @@ StaffType StaffType::regular() noexcept
 
 std::string_view StaffType::toString() const noexcept
 {
-    return kWire[static_cast<std::size_t>(m_tag)];
+    return kStaffTypeWire[static_cast<std::size_t>(m_tag)];
 }
 
 bool StaffType::tryParse(std::string_view text, StaffType &out) noexcept
 {
-    for (std::size_t i = 0; i < std::size(kWire); ++i)
+    for (std::size_t i = 0; i < std::size(kStaffTypeWire); ++i)
     {
-        if (kWire[i] == text)
+        if (kStaffTypeWire[i] == text)
         {
             out = StaffType{static_cast<Tag>(i)};
             return true;

--- a/src/private/mx/core/generated/StartNote.cpp
+++ b/src/private/mx/core/generated/StartNote.cpp
@@ -8,16 +8,11 @@
 namespace mx::core
 {
 
-namespace
-{
-
-constexpr std::string_view kWire[] = {
+constexpr std::string_view kStartNoteWire[] = {
     "upper",
     "main",
     "below",
 };
-
-} // namespace
 
 StartNote StartNote::upper() noexcept
 {
@@ -36,14 +31,14 @@ StartNote StartNote::below() noexcept
 
 std::string_view StartNote::toString() const noexcept
 {
-    return kWire[static_cast<std::size_t>(m_tag)];
+    return kStartNoteWire[static_cast<std::size_t>(m_tag)];
 }
 
 bool StartNote::tryParse(std::string_view text, StartNote &out) noexcept
 {
-    for (std::size_t i = 0; i < std::size(kWire); ++i)
+    for (std::size_t i = 0; i < std::size(kStartNoteWire); ++i)
     {
-        if (kWire[i] == text)
+        if (kStartNoteWire[i] == text)
         {
             out = StartNote{static_cast<Tag>(i)};
             return true;

--- a/src/private/mx/core/generated/StartStop.cpp
+++ b/src/private/mx/core/generated/StartStop.cpp
@@ -8,15 +8,10 @@
 namespace mx::core
 {
 
-namespace
-{
-
-constexpr std::string_view kWire[] = {
+constexpr std::string_view kStartStopWire[] = {
     "start",
     "stop",
 };
-
-} // namespace
 
 StartStop StartStop::start() noexcept
 {
@@ -30,14 +25,14 @@ StartStop StartStop::stop() noexcept
 
 std::string_view StartStop::toString() const noexcept
 {
-    return kWire[static_cast<std::size_t>(m_tag)];
+    return kStartStopWire[static_cast<std::size_t>(m_tag)];
 }
 
 bool StartStop::tryParse(std::string_view text, StartStop &out) noexcept
 {
-    for (std::size_t i = 0; i < std::size(kWire); ++i)
+    for (std::size_t i = 0; i < std::size(kStartStopWire); ++i)
     {
-        if (kWire[i] == text)
+        if (kStartStopWire[i] == text)
         {
             out = StartStop{static_cast<Tag>(i)};
             return true;

--- a/src/private/mx/core/generated/StartStopContinue.cpp
+++ b/src/private/mx/core/generated/StartStopContinue.cpp
@@ -8,16 +8,11 @@
 namespace mx::core
 {
 
-namespace
-{
-
-constexpr std::string_view kWire[] = {
+constexpr std::string_view kStartStopContinueWire[] = {
     "start",
     "stop",
     "continue",
 };
-
-} // namespace
 
 StartStopContinue StartStopContinue::start() noexcept
 {
@@ -36,14 +31,14 @@ StartStopContinue StartStopContinue::continue_() noexcept
 
 std::string_view StartStopContinue::toString() const noexcept
 {
-    return kWire[static_cast<std::size_t>(m_tag)];
+    return kStartStopContinueWire[static_cast<std::size_t>(m_tag)];
 }
 
 bool StartStopContinue::tryParse(std::string_view text, StartStopContinue &out) noexcept
 {
-    for (std::size_t i = 0; i < std::size(kWire); ++i)
+    for (std::size_t i = 0; i < std::size(kStartStopContinueWire); ++i)
     {
-        if (kWire[i] == text)
+        if (kStartStopContinueWire[i] == text)
         {
             out = StartStopContinue{static_cast<Tag>(i)};
             return true;

--- a/src/private/mx/core/generated/StartStopDiscontinue.cpp
+++ b/src/private/mx/core/generated/StartStopDiscontinue.cpp
@@ -8,16 +8,11 @@
 namespace mx::core
 {
 
-namespace
-{
-
-constexpr std::string_view kWire[] = {
+constexpr std::string_view kStartStopDiscontinueWire[] = {
     "start",
     "stop",
     "discontinue",
 };
-
-} // namespace
 
 StartStopDiscontinue StartStopDiscontinue::start() noexcept
 {
@@ -36,14 +31,14 @@ StartStopDiscontinue StartStopDiscontinue::discontinue() noexcept
 
 std::string_view StartStopDiscontinue::toString() const noexcept
 {
-    return kWire[static_cast<std::size_t>(m_tag)];
+    return kStartStopDiscontinueWire[static_cast<std::size_t>(m_tag)];
 }
 
 bool StartStopDiscontinue::tryParse(std::string_view text, StartStopDiscontinue &out) noexcept
 {
-    for (std::size_t i = 0; i < std::size(kWire); ++i)
+    for (std::size_t i = 0; i < std::size(kStartStopDiscontinueWire); ++i)
     {
-        if (kWire[i] == text)
+        if (kStartStopDiscontinueWire[i] == text)
         {
             out = StartStopDiscontinue{static_cast<Tag>(i)};
             return true;

--- a/src/private/mx/core/generated/StartStopSingle.cpp
+++ b/src/private/mx/core/generated/StartStopSingle.cpp
@@ -8,16 +8,11 @@
 namespace mx::core
 {
 
-namespace
-{
-
-constexpr std::string_view kWire[] = {
+constexpr std::string_view kStartStopSingleWire[] = {
     "start",
     "stop",
     "single",
 };
-
-} // namespace
 
 StartStopSingle StartStopSingle::start() noexcept
 {
@@ -36,14 +31,14 @@ StartStopSingle StartStopSingle::single() noexcept
 
 std::string_view StartStopSingle::toString() const noexcept
 {
-    return kWire[static_cast<std::size_t>(m_tag)];
+    return kStartStopSingleWire[static_cast<std::size_t>(m_tag)];
 }
 
 bool StartStopSingle::tryParse(std::string_view text, StartStopSingle &out) noexcept
 {
-    for (std::size_t i = 0; i < std::size(kWire); ++i)
+    for (std::size_t i = 0; i < std::size(kStartStopSingleWire); ++i)
     {
-        if (kWire[i] == text)
+        if (kStartStopSingleWire[i] == text)
         {
             out = StartStopSingle{static_cast<Tag>(i)};
             return true;

--- a/src/private/mx/core/generated/StemValue.cpp
+++ b/src/private/mx/core/generated/StemValue.cpp
@@ -8,17 +8,12 @@
 namespace mx::core
 {
 
-namespace
-{
-
-constexpr std::string_view kWire[] = {
+constexpr std::string_view kStemValueWire[] = {
     "down",
     "up",
     "double",
     "none",
 };
-
-} // namespace
 
 StemValue StemValue::down() noexcept
 {
@@ -42,14 +37,14 @@ StemValue StemValue::none() noexcept
 
 std::string_view StemValue::toString() const noexcept
 {
-    return kWire[static_cast<std::size_t>(m_tag)];
+    return kStemValueWire[static_cast<std::size_t>(m_tag)];
 }
 
 bool StemValue::tryParse(std::string_view text, StemValue &out) noexcept
 {
-    for (std::size_t i = 0; i < std::size(kWire); ++i)
+    for (std::size_t i = 0; i < std::size(kStemValueWire); ++i)
     {
-        if (kWire[i] == text)
+        if (kStemValueWire[i] == text)
         {
             out = StemValue{static_cast<Tag>(i)};
             return true;

--- a/src/private/mx/core/generated/Step.cpp
+++ b/src/private/mx/core/generated/Step.cpp
@@ -8,14 +8,9 @@
 namespace mx::core
 {
 
-namespace
-{
-
-constexpr std::string_view kWire[] = {
+constexpr std::string_view kStepWire[] = {
     "A", "B", "C", "D", "E", "F", "G",
 };
-
-} // namespace
 
 Step Step::a() noexcept
 {
@@ -54,14 +49,14 @@ Step Step::g() noexcept
 
 std::string_view Step::toString() const noexcept
 {
-    return kWire[static_cast<std::size_t>(m_tag)];
+    return kStepWire[static_cast<std::size_t>(m_tag)];
 }
 
 bool Step::tryParse(std::string_view text, Step &out) noexcept
 {
-    for (std::size_t i = 0; i < std::size(kWire); ++i)
+    for (std::size_t i = 0; i < std::size(kStepWire); ++i)
     {
-        if (kWire[i] == text)
+        if (kStepWire[i] == text)
         {
             out = Step{static_cast<Tag>(i)};
             return true;

--- a/src/private/mx/core/generated/StickLocation.cpp
+++ b/src/private/mx/core/generated/StickLocation.cpp
@@ -8,17 +8,12 @@
 namespace mx::core
 {
 
-namespace
-{
-
-constexpr std::string_view kWire[] = {
+constexpr std::string_view kStickLocationWire[] = {
     "center",
     "rim",
     "cymbal bell",
     "cymbal edge",
 };
-
-} // namespace
 
 StickLocation StickLocation::center() noexcept
 {
@@ -42,14 +37,14 @@ StickLocation StickLocation::cymbalEdge() noexcept
 
 std::string_view StickLocation::toString() const noexcept
 {
-    return kWire[static_cast<std::size_t>(m_tag)];
+    return kStickLocationWire[static_cast<std::size_t>(m_tag)];
 }
 
 bool StickLocation::tryParse(std::string_view text, StickLocation &out) noexcept
 {
-    for (std::size_t i = 0; i < std::size(kWire); ++i)
+    for (std::size_t i = 0; i < std::size(kStickLocationWire); ++i)
     {
-        if (kWire[i] == text)
+        if (kStickLocationWire[i] == text)
         {
             out = StickLocation{static_cast<Tag>(i)};
             return true;

--- a/src/private/mx/core/generated/StickMaterial.cpp
+++ b/src/private/mx/core/generated/StickMaterial.cpp
@@ -8,14 +8,9 @@
 namespace mx::core
 {
 
-namespace
-{
-
-constexpr std::string_view kWire[] = {
+constexpr std::string_view kStickMaterialWire[] = {
     "soft", "medium", "hard", "shaded", "x",
 };
-
-} // namespace
 
 StickMaterial StickMaterial::soft() noexcept
 {
@@ -44,14 +39,14 @@ StickMaterial StickMaterial::x() noexcept
 
 std::string_view StickMaterial::toString() const noexcept
 {
-    return kWire[static_cast<std::size_t>(m_tag)];
+    return kStickMaterialWire[static_cast<std::size_t>(m_tag)];
 }
 
 bool StickMaterial::tryParse(std::string_view text, StickMaterial &out) noexcept
 {
-    for (std::size_t i = 0; i < std::size(kWire); ++i)
+    for (std::size_t i = 0; i < std::size(kStickMaterialWire); ++i)
     {
-        if (kWire[i] == text)
+        if (kStickMaterialWire[i] == text)
         {
             out = StickMaterial{static_cast<Tag>(i)};
             return true;

--- a/src/private/mx/core/generated/StickType.cpp
+++ b/src/private/mx/core/generated/StickType.cpp
@@ -8,15 +8,10 @@
 namespace mx::core
 {
 
-namespace
-{
-
-constexpr std::string_view kWire[] = {
+constexpr std::string_view kStickTypeWire[] = {
     "bass drum", "double bass drum", "glockenspiel", "gum",       "hammer",
     "superball", "timpani",          "wound",        "xylophone", "yarn",
 };
-
-} // namespace
 
 StickType StickType::bassDrum() noexcept
 {
@@ -70,14 +65,14 @@ StickType StickType::yarn() noexcept
 
 std::string_view StickType::toString() const noexcept
 {
-    return kWire[static_cast<std::size_t>(m_tag)];
+    return kStickTypeWire[static_cast<std::size_t>(m_tag)];
 }
 
 bool StickType::tryParse(std::string_view text, StickType &out) noexcept
 {
-    for (std::size_t i = 0; i < std::size(kWire); ++i)
+    for (std::size_t i = 0; i < std::size(kStickTypeWire); ++i)
     {
-        if (kWire[i] == text)
+        if (kStickTypeWire[i] == text)
         {
             out = StickType{static_cast<Tag>(i)};
             return true;

--- a/src/private/mx/core/generated/StringNumber.cpp
+++ b/src/private/mx/core/generated/StringNumber.cpp
@@ -9,10 +9,7 @@
 namespace mx::core
 {
 
-namespace
-{
-
-int clamped(int v)
+int clampedStringNumber(int v)
 {
     if (v < 1)
     {
@@ -21,19 +18,17 @@ int clamped(int v)
     return v;
 }
 
-} // namespace
-
-StringNumber::StringNumber() : m_value{clamped(int{})}
+StringNumber::StringNumber() : m_value{clampedStringNumber(int{})}
 {
 }
 
-StringNumber::StringNumber(int value) : m_value{clamped(std::move(value))}
+StringNumber::StringNumber(int value) : m_value{clampedStringNumber(std::move(value))}
 {
 }
 
 void StringNumber::setValue(int value)
 {
-    m_value = clamped(std::move(value));
+    m_value = clampedStringNumber(std::move(value));
 }
 
 std::string StringNumber::toString() const

--- a/src/private/mx/core/generated/SwingTypeValue.cpp
+++ b/src/private/mx/core/generated/SwingTypeValue.cpp
@@ -8,15 +8,10 @@
 namespace mx::core
 {
 
-namespace
-{
-
-constexpr std::string_view kWire[] = {
+constexpr std::string_view kSwingTypeValueWire[] = {
     "16th",
     "eighth",
 };
-
-} // namespace
 
 SwingTypeValue SwingTypeValue::_16th() noexcept
 {
@@ -30,14 +25,14 @@ SwingTypeValue SwingTypeValue::eighth() noexcept
 
 std::string_view SwingTypeValue::toString() const noexcept
 {
-    return kWire[static_cast<std::size_t>(m_tag)];
+    return kSwingTypeValueWire[static_cast<std::size_t>(m_tag)];
 }
 
 bool SwingTypeValue::tryParse(std::string_view text, SwingTypeValue &out) noexcept
 {
-    for (std::size_t i = 0; i < std::size(kWire); ++i)
+    for (std::size_t i = 0; i < std::size(kSwingTypeValueWire); ++i)
     {
-        if (kWire[i] == text)
+        if (kSwingTypeValueWire[i] == text)
         {
             out = SwingTypeValue{static_cast<Tag>(i)};
             return true;

--- a/src/private/mx/core/generated/Syllabic.cpp
+++ b/src/private/mx/core/generated/Syllabic.cpp
@@ -8,17 +8,12 @@
 namespace mx::core
 {
 
-namespace
-{
-
-constexpr std::string_view kWire[] = {
+constexpr std::string_view kSyllabicWire[] = {
     "single",
     "begin",
     "end",
     "middle",
 };
-
-} // namespace
 
 Syllabic Syllabic::single() noexcept
 {
@@ -42,14 +37,14 @@ Syllabic Syllabic::middle() noexcept
 
 std::string_view Syllabic::toString() const noexcept
 {
-    return kWire[static_cast<std::size_t>(m_tag)];
+    return kSyllabicWire[static_cast<std::size_t>(m_tag)];
 }
 
 bool Syllabic::tryParse(std::string_view text, Syllabic &out) noexcept
 {
-    for (std::size_t i = 0; i < std::size(kWire); ++i)
+    for (std::size_t i = 0; i < std::size(kSyllabicWire); ++i)
     {
-        if (kWire[i] == text)
+        if (kSyllabicWire[i] == text)
         {
             out = Syllabic{static_cast<Tag>(i)};
             return true;

--- a/src/private/mx/core/generated/SymbolSize.cpp
+++ b/src/private/mx/core/generated/SymbolSize.cpp
@@ -8,17 +8,12 @@
 namespace mx::core
 {
 
-namespace
-{
-
-constexpr std::string_view kWire[] = {
+constexpr std::string_view kSymbolSizeWire[] = {
     "full",
     "cue",
     "grace-cue",
     "large",
 };
-
-} // namespace
 
 SymbolSize SymbolSize::full() noexcept
 {
@@ -42,14 +37,14 @@ SymbolSize SymbolSize::large() noexcept
 
 std::string_view SymbolSize::toString() const noexcept
 {
-    return kWire[static_cast<std::size_t>(m_tag)];
+    return kSymbolSizeWire[static_cast<std::size_t>(m_tag)];
 }
 
 bool SymbolSize::tryParse(std::string_view text, SymbolSize &out) noexcept
 {
-    for (std::size_t i = 0; i < std::size(kWire); ++i)
+    for (std::size_t i = 0; i < std::size(kSymbolSizeWire); ++i)
     {
-        if (kWire[i] == text)
+        if (kSymbolSizeWire[i] == text)
         {
             out = SymbolSize{static_cast<Tag>(i)};
             return true;

--- a/src/private/mx/core/generated/SyncType.cpp
+++ b/src/private/mx/core/generated/SyncType.cpp
@@ -8,14 +8,9 @@
 namespace mx::core
 {
 
-namespace
-{
-
-constexpr std::string_view kWire[] = {
+constexpr std::string_view kSyncTypeWire[] = {
     "none", "tempo", "mostly-tempo", "mostly-event", "event", "always-event",
 };
-
-} // namespace
 
 SyncType SyncType::none() noexcept
 {
@@ -49,14 +44,14 @@ SyncType SyncType::alwaysEvent() noexcept
 
 std::string_view SyncType::toString() const noexcept
 {
-    return kWire[static_cast<std::size_t>(m_tag)];
+    return kSyncTypeWire[static_cast<std::size_t>(m_tag)];
 }
 
 bool SyncType::tryParse(std::string_view text, SyncType &out) noexcept
 {
-    for (std::size_t i = 0; i < std::size(kWire); ++i)
+    for (std::size_t i = 0; i < std::size(kSyncTypeWire); ++i)
     {
-        if (kWire[i] == text)
+        if (kSyncTypeWire[i] == text)
         {
             out = SyncType{static_cast<Tag>(i)};
             return true;

--- a/src/private/mx/core/generated/SystemRelation.cpp
+++ b/src/private/mx/core/generated/SystemRelation.cpp
@@ -8,16 +8,11 @@
 namespace mx::core
 {
 
-namespace
-{
-
-constexpr std::string_view kWire[] = {
+constexpr std::string_view kSystemRelationWire[] = {
     "only-top",
     "also-top",
     "none",
 };
-
-} // namespace
 
 SystemRelation SystemRelation::onlyTop() noexcept
 {
@@ -36,14 +31,14 @@ SystemRelation SystemRelation::none() noexcept
 
 std::string_view SystemRelation::toString() const noexcept
 {
-    return kWire[static_cast<std::size_t>(m_tag)];
+    return kSystemRelationWire[static_cast<std::size_t>(m_tag)];
 }
 
 bool SystemRelation::tryParse(std::string_view text, SystemRelation &out) noexcept
 {
-    for (std::size_t i = 0; i < std::size(kWire); ++i)
+    for (std::size_t i = 0; i < std::size(kSystemRelationWire); ++i)
     {
-        if (kWire[i] == text)
+        if (kSystemRelationWire[i] == text)
         {
             out = SystemRelation{static_cast<Tag>(i)};
             return true;

--- a/src/private/mx/core/generated/SystemRelationNumber.cpp
+++ b/src/private/mx/core/generated/SystemRelationNumber.cpp
@@ -8,14 +8,9 @@
 namespace mx::core
 {
 
-namespace
-{
-
-constexpr std::string_view kWire[] = {
+constexpr std::string_view kSystemRelationNumberWire[] = {
     "only-top", "only-bottom", "also-top", "also-bottom", "none",
 };
-
-} // namespace
 
 SystemRelationNumber SystemRelationNumber::onlyTop() noexcept
 {
@@ -44,14 +39,14 @@ SystemRelationNumber SystemRelationNumber::none() noexcept
 
 std::string_view SystemRelationNumber::toString() const noexcept
 {
-    return kWire[static_cast<std::size_t>(m_tag)];
+    return kSystemRelationNumberWire[static_cast<std::size_t>(m_tag)];
 }
 
 bool SystemRelationNumber::tryParse(std::string_view text, SystemRelationNumber &out) noexcept
 {
-    for (std::size_t i = 0; i < std::size(kWire); ++i)
+    for (std::size_t i = 0; i < std::size(kSystemRelationNumberWire); ++i)
     {
-        if (kWire[i] == text)
+        if (kSystemRelationNumberWire[i] == text)
         {
             out = SystemRelationNumber{static_cast<Tag>(i)};
             return true;

--- a/src/private/mx/core/generated/TapHand.cpp
+++ b/src/private/mx/core/generated/TapHand.cpp
@@ -8,15 +8,10 @@
 namespace mx::core
 {
 
-namespace
-{
-
-constexpr std::string_view kWire[] = {
+constexpr std::string_view kTapHandWire[] = {
     "left",
     "right",
 };
-
-} // namespace
 
 TapHand TapHand::left() noexcept
 {
@@ -30,14 +25,14 @@ TapHand TapHand::right() noexcept
 
 std::string_view TapHand::toString() const noexcept
 {
-    return kWire[static_cast<std::size_t>(m_tag)];
+    return kTapHandWire[static_cast<std::size_t>(m_tag)];
 }
 
 bool TapHand::tryParse(std::string_view text, TapHand &out) noexcept
 {
-    for (std::size_t i = 0; i < std::size(kWire); ++i)
+    for (std::size_t i = 0; i < std::size(kTapHandWire); ++i)
     {
-        if (kWire[i] == text)
+        if (kTapHandWire[i] == text)
         {
             out = TapHand{static_cast<Tag>(i)};
             return true;

--- a/src/private/mx/core/generated/Tenths.cpp
+++ b/src/private/mx/core/generated/Tenths.cpp
@@ -9,27 +9,22 @@
 namespace mx::core
 {
 
-namespace
-{
-
-Decimal clamped(Decimal v)
+Decimal clampedTenths(Decimal v)
 {
     return v;
 }
 
-} // namespace
-
-Tenths::Tenths() : m_value{clamped(Decimal{})}
+Tenths::Tenths() : m_value{clampedTenths(Decimal{})}
 {
 }
 
-Tenths::Tenths(Decimal value) : m_value{clamped(std::move(value))}
+Tenths::Tenths(Decimal value) : m_value{clampedTenths(std::move(value))}
 {
 }
 
 void Tenths::setValue(Decimal value)
 {
-    m_value = clamped(std::move(value));
+    m_value = clampedTenths(std::move(value));
 }
 
 std::string Tenths::toString() const

--- a/src/private/mx/core/generated/TextDirection.cpp
+++ b/src/private/mx/core/generated/TextDirection.cpp
@@ -8,17 +8,12 @@
 namespace mx::core
 {
 
-namespace
-{
-
-constexpr std::string_view kWire[] = {
+constexpr std::string_view kTextDirectionWire[] = {
     "ltr",
     "rtl",
     "lro",
     "rlo",
 };
-
-} // namespace
 
 TextDirection TextDirection::ltr() noexcept
 {
@@ -42,14 +37,14 @@ TextDirection TextDirection::rlo() noexcept
 
 std::string_view TextDirection::toString() const noexcept
 {
-    return kWire[static_cast<std::size_t>(m_tag)];
+    return kTextDirectionWire[static_cast<std::size_t>(m_tag)];
 }
 
 bool TextDirection::tryParse(std::string_view text, TextDirection &out) noexcept
 {
-    for (std::size_t i = 0; i < std::size(kWire); ++i)
+    for (std::size_t i = 0; i < std::size(kTextDirectionWire); ++i)
     {
-        if (kWire[i] == text)
+        if (kTextDirectionWire[i] == text)
         {
             out = TextDirection{static_cast<Tag>(i)};
             return true;

--- a/src/private/mx/core/generated/TiedType.cpp
+++ b/src/private/mx/core/generated/TiedType.cpp
@@ -8,17 +8,12 @@
 namespace mx::core
 {
 
-namespace
-{
-
-constexpr std::string_view kWire[] = {
+constexpr std::string_view kTiedTypeWire[] = {
     "start",
     "stop",
     "continue",
     "let-ring",
 };
-
-} // namespace
 
 TiedType TiedType::start() noexcept
 {
@@ -42,14 +37,14 @@ TiedType TiedType::letRing() noexcept
 
 std::string_view TiedType::toString() const noexcept
 {
-    return kWire[static_cast<std::size_t>(m_tag)];
+    return kTiedTypeWire[static_cast<std::size_t>(m_tag)];
 }
 
 bool TiedType::tryParse(std::string_view text, TiedType &out) noexcept
 {
-    for (std::size_t i = 0; i < std::size(kWire); ++i)
+    for (std::size_t i = 0; i < std::size(kTiedTypeWire); ++i)
     {
-        if (kWire[i] == text)
+        if (kTiedTypeWire[i] == text)
         {
             out = TiedType{static_cast<Tag>(i)};
             return true;

--- a/src/private/mx/core/generated/TimeRelation.cpp
+++ b/src/private/mx/core/generated/TimeRelation.cpp
@@ -8,14 +8,9 @@
 namespace mx::core
 {
 
-namespace
-{
-
-constexpr std::string_view kWire[] = {
+constexpr std::string_view kTimeRelationWire[] = {
     "parentheses", "bracket", "equals", "slash", "space", "hyphen",
 };
-
-} // namespace
 
 TimeRelation TimeRelation::parentheses() noexcept
 {
@@ -49,14 +44,14 @@ TimeRelation TimeRelation::hyphen() noexcept
 
 std::string_view TimeRelation::toString() const noexcept
 {
-    return kWire[static_cast<std::size_t>(m_tag)];
+    return kTimeRelationWire[static_cast<std::size_t>(m_tag)];
 }
 
 bool TimeRelation::tryParse(std::string_view text, TimeRelation &out) noexcept
 {
-    for (std::size_t i = 0; i < std::size(kWire); ++i)
+    for (std::size_t i = 0; i < std::size(kTimeRelationWire); ++i)
     {
-        if (kWire[i] == text)
+        if (kTimeRelationWire[i] == text)
         {
             out = TimeRelation{static_cast<Tag>(i)};
             return true;

--- a/src/private/mx/core/generated/TimeSeparator.cpp
+++ b/src/private/mx/core/generated/TimeSeparator.cpp
@@ -8,14 +8,9 @@
 namespace mx::core
 {
 
-namespace
-{
-
-constexpr std::string_view kWire[] = {
+constexpr std::string_view kTimeSeparatorWire[] = {
     "none", "horizontal", "diagonal", "vertical", "adjacent",
 };
-
-} // namespace
 
 TimeSeparator TimeSeparator::none() noexcept
 {
@@ -44,14 +39,14 @@ TimeSeparator TimeSeparator::adjacent() noexcept
 
 std::string_view TimeSeparator::toString() const noexcept
 {
-    return kWire[static_cast<std::size_t>(m_tag)];
+    return kTimeSeparatorWire[static_cast<std::size_t>(m_tag)];
 }
 
 bool TimeSeparator::tryParse(std::string_view text, TimeSeparator &out) noexcept
 {
-    for (std::size_t i = 0; i < std::size(kWire); ++i)
+    for (std::size_t i = 0; i < std::size(kTimeSeparatorWire); ++i)
     {
-        if (kWire[i] == text)
+        if (kTimeSeparatorWire[i] == text)
         {
             out = TimeSeparator{static_cast<Tag>(i)};
             return true;

--- a/src/private/mx/core/generated/TimeSymbol.cpp
+++ b/src/private/mx/core/generated/TimeSymbol.cpp
@@ -8,14 +8,9 @@
 namespace mx::core
 {
 
-namespace
-{
-
-constexpr std::string_view kWire[] = {
+constexpr std::string_view kTimeSymbolWire[] = {
     "common", "cut", "single-number", "note", "dotted-note", "normal",
 };
-
-} // namespace
 
 TimeSymbol TimeSymbol::common() noexcept
 {
@@ -49,14 +44,14 @@ TimeSymbol TimeSymbol::normal() noexcept
 
 std::string_view TimeSymbol::toString() const noexcept
 {
-    return kWire[static_cast<std::size_t>(m_tag)];
+    return kTimeSymbolWire[static_cast<std::size_t>(m_tag)];
 }
 
 bool TimeSymbol::tryParse(std::string_view text, TimeSymbol &out) noexcept
 {
-    for (std::size_t i = 0; i < std::size(kWire); ++i)
+    for (std::size_t i = 0; i < std::size(kTimeSymbolWire); ++i)
     {
-        if (kWire[i] == text)
+        if (kTimeSymbolWire[i] == text)
         {
             out = TimeSymbol{static_cast<Tag>(i)};
             return true;

--- a/src/private/mx/core/generated/TipDirection.cpp
+++ b/src/private/mx/core/generated/TipDirection.cpp
@@ -8,14 +8,9 @@
 namespace mx::core
 {
 
-namespace
-{
-
-constexpr std::string_view kWire[] = {
+constexpr std::string_view kTipDirectionWire[] = {
     "up", "down", "left", "right", "northwest", "northeast", "southeast", "southwest",
 };
-
-} // namespace
 
 TipDirection TipDirection::up() noexcept
 {
@@ -59,14 +54,14 @@ TipDirection TipDirection::southwest() noexcept
 
 std::string_view TipDirection::toString() const noexcept
 {
-    return kWire[static_cast<std::size_t>(m_tag)];
+    return kTipDirectionWire[static_cast<std::size_t>(m_tag)];
 }
 
 bool TipDirection::tryParse(std::string_view text, TipDirection &out) noexcept
 {
-    for (std::size_t i = 0; i < std::size(kWire); ++i)
+    for (std::size_t i = 0; i < std::size(kTipDirectionWire); ++i)
     {
-        if (kWire[i] == text)
+        if (kTipDirectionWire[i] == text)
         {
             out = TipDirection{static_cast<Tag>(i)};
             return true;

--- a/src/private/mx/core/generated/TopBottom.cpp
+++ b/src/private/mx/core/generated/TopBottom.cpp
@@ -8,15 +8,10 @@
 namespace mx::core
 {
 
-namespace
-{
-
-constexpr std::string_view kWire[] = {
+constexpr std::string_view kTopBottomWire[] = {
     "top",
     "bottom",
 };
-
-} // namespace
 
 TopBottom TopBottom::top() noexcept
 {
@@ -30,14 +25,14 @@ TopBottom TopBottom::bottom() noexcept
 
 std::string_view TopBottom::toString() const noexcept
 {
-    return kWire[static_cast<std::size_t>(m_tag)];
+    return kTopBottomWire[static_cast<std::size_t>(m_tag)];
 }
 
 bool TopBottom::tryParse(std::string_view text, TopBottom &out) noexcept
 {
-    for (std::size_t i = 0; i < std::size(kWire); ++i)
+    for (std::size_t i = 0; i < std::size(kTopBottomWire); ++i)
     {
-        if (kWire[i] == text)
+        if (kTopBottomWire[i] == text)
         {
             out = TopBottom{static_cast<Tag>(i)};
             return true;

--- a/src/private/mx/core/generated/TremoloMarks.cpp
+++ b/src/private/mx/core/generated/TremoloMarks.cpp
@@ -9,10 +9,7 @@
 namespace mx::core
 {
 
-namespace
-{
-
-int clamped(int v)
+int clampedTremoloMarks(int v)
 {
     if (v < 0)
     {
@@ -25,19 +22,17 @@ int clamped(int v)
     return v;
 }
 
-} // namespace
-
-TremoloMarks::TremoloMarks() : m_value{clamped(int{})}
+TremoloMarks::TremoloMarks() : m_value{clampedTremoloMarks(int{})}
 {
 }
 
-TremoloMarks::TremoloMarks(int value) : m_value{clamped(std::move(value))}
+TremoloMarks::TremoloMarks(int value) : m_value{clampedTremoloMarks(std::move(value))}
 {
 }
 
 void TremoloMarks::setValue(int value)
 {
-    m_value = clamped(std::move(value));
+    m_value = clampedTremoloMarks(std::move(value));
 }
 
 std::string TremoloMarks::toString() const

--- a/src/private/mx/core/generated/TremoloType.cpp
+++ b/src/private/mx/core/generated/TremoloType.cpp
@@ -8,17 +8,12 @@
 namespace mx::core
 {
 
-namespace
-{
-
-constexpr std::string_view kWire[] = {
+constexpr std::string_view kTremoloTypeWire[] = {
     "start",
     "stop",
     "single",
     "unmeasured",
 };
-
-} // namespace
 
 TremoloType TremoloType::start() noexcept
 {
@@ -42,14 +37,14 @@ TremoloType TremoloType::unmeasured() noexcept
 
 std::string_view TremoloType::toString() const noexcept
 {
-    return kWire[static_cast<std::size_t>(m_tag)];
+    return kTremoloTypeWire[static_cast<std::size_t>(m_tag)];
 }
 
 bool TremoloType::tryParse(std::string_view text, TremoloType &out) noexcept
 {
-    for (std::size_t i = 0; i < std::size(kWire); ++i)
+    for (std::size_t i = 0; i < std::size(kTremoloTypeWire); ++i)
     {
-        if (kWire[i] == text)
+        if (kTremoloTypeWire[i] == text)
         {
             out = TremoloType{static_cast<Tag>(i)};
             return true;

--- a/src/private/mx/core/generated/TrillBeats.cpp
+++ b/src/private/mx/core/generated/TrillBeats.cpp
@@ -9,10 +9,7 @@
 namespace mx::core
 {
 
-namespace
-{
-
-Decimal clamped(Decimal v)
+Decimal clampedTrillBeats(Decimal v)
 {
     if (v.value() < 2.0)
     {
@@ -21,19 +18,17 @@ Decimal clamped(Decimal v)
     return v;
 }
 
-} // namespace
-
-TrillBeats::TrillBeats() : m_value{clamped(Decimal{})}
+TrillBeats::TrillBeats() : m_value{clampedTrillBeats(Decimal{})}
 {
 }
 
-TrillBeats::TrillBeats(Decimal value) : m_value{clamped(std::move(value))}
+TrillBeats::TrillBeats(Decimal value) : m_value{clampedTrillBeats(std::move(value))}
 {
 }
 
 void TrillBeats::setValue(Decimal value)
 {
-    m_value = clamped(std::move(value));
+    m_value = clampedTrillBeats(std::move(value));
 }
 
 std::string TrillBeats::toString() const

--- a/src/private/mx/core/generated/TrillStep.cpp
+++ b/src/private/mx/core/generated/TrillStep.cpp
@@ -8,16 +8,11 @@
 namespace mx::core
 {
 
-namespace
-{
-
-constexpr std::string_view kWire[] = {
+constexpr std::string_view kTrillStepWire[] = {
     "whole",
     "half",
     "unison",
 };
-
-} // namespace
 
 TrillStep TrillStep::whole() noexcept
 {
@@ -36,14 +31,14 @@ TrillStep TrillStep::unison() noexcept
 
 std::string_view TrillStep::toString() const noexcept
 {
-    return kWire[static_cast<std::size_t>(m_tag)];
+    return kTrillStepWire[static_cast<std::size_t>(m_tag)];
 }
 
 bool TrillStep::tryParse(std::string_view text, TrillStep &out) noexcept
 {
-    for (std::size_t i = 0; i < std::size(kWire); ++i)
+    for (std::size_t i = 0; i < std::size(kTrillStepWire); ++i)
     {
-        if (kWire[i] == text)
+        if (kTrillStepWire[i] == text)
         {
             out = TrillStep{static_cast<Tag>(i)};
             return true;

--- a/src/private/mx/core/generated/TwoNoteTurn.cpp
+++ b/src/private/mx/core/generated/TwoNoteTurn.cpp
@@ -8,16 +8,11 @@
 namespace mx::core
 {
 
-namespace
-{
-
-constexpr std::string_view kWire[] = {
+constexpr std::string_view kTwoNoteTurnWire[] = {
     "whole",
     "half",
     "none",
 };
-
-} // namespace
 
 TwoNoteTurn TwoNoteTurn::whole() noexcept
 {
@@ -36,14 +31,14 @@ TwoNoteTurn TwoNoteTurn::none() noexcept
 
 std::string_view TwoNoteTurn::toString() const noexcept
 {
-    return kWire[static_cast<std::size_t>(m_tag)];
+    return kTwoNoteTurnWire[static_cast<std::size_t>(m_tag)];
 }
 
 bool TwoNoteTurn::tryParse(std::string_view text, TwoNoteTurn &out) noexcept
 {
-    for (std::size_t i = 0; i < std::size(kWire); ++i)
+    for (std::size_t i = 0; i < std::size(kTwoNoteTurnWire); ++i)
     {
-        if (kWire[i] == text)
+        if (kTwoNoteTurnWire[i] == text)
         {
             out = TwoNoteTurn{static_cast<Tag>(i)};
             return true;

--- a/src/private/mx/core/generated/UpDown.cpp
+++ b/src/private/mx/core/generated/UpDown.cpp
@@ -8,15 +8,10 @@
 namespace mx::core
 {
 
-namespace
-{
-
-constexpr std::string_view kWire[] = {
+constexpr std::string_view kUpDownWire[] = {
     "up",
     "down",
 };
-
-} // namespace
 
 UpDown UpDown::up() noexcept
 {
@@ -30,14 +25,14 @@ UpDown UpDown::down() noexcept
 
 std::string_view UpDown::toString() const noexcept
 {
-    return kWire[static_cast<std::size_t>(m_tag)];
+    return kUpDownWire[static_cast<std::size_t>(m_tag)];
 }
 
 bool UpDown::tryParse(std::string_view text, UpDown &out) noexcept
 {
-    for (std::size_t i = 0; i < std::size(kWire); ++i)
+    for (std::size_t i = 0; i < std::size(kUpDownWire); ++i)
     {
-        if (kWire[i] == text)
+        if (kUpDownWire[i] == text)
         {
             out = UpDown{static_cast<Tag>(i)};
             return true;

--- a/src/private/mx/core/generated/UpDownStopContinue.cpp
+++ b/src/private/mx/core/generated/UpDownStopContinue.cpp
@@ -8,17 +8,12 @@
 namespace mx::core
 {
 
-namespace
-{
-
-constexpr std::string_view kWire[] = {
+constexpr std::string_view kUpDownStopContinueWire[] = {
     "up",
     "down",
     "stop",
     "continue",
 };
-
-} // namespace
 
 UpDownStopContinue UpDownStopContinue::up() noexcept
 {
@@ -42,14 +37,14 @@ UpDownStopContinue UpDownStopContinue::continue_() noexcept
 
 std::string_view UpDownStopContinue::toString() const noexcept
 {
-    return kWire[static_cast<std::size_t>(m_tag)];
+    return kUpDownStopContinueWire[static_cast<std::size_t>(m_tag)];
 }
 
 bool UpDownStopContinue::tryParse(std::string_view text, UpDownStopContinue &out) noexcept
 {
-    for (std::size_t i = 0; i < std::size(kWire); ++i)
+    for (std::size_t i = 0; i < std::size(kUpDownStopContinueWire); ++i)
     {
-        if (kWire[i] == text)
+        if (kUpDownStopContinueWire[i] == text)
         {
             out = UpDownStopContinue{static_cast<Tag>(i)};
             return true;

--- a/src/private/mx/core/generated/UprightInverted.cpp
+++ b/src/private/mx/core/generated/UprightInverted.cpp
@@ -8,15 +8,10 @@
 namespace mx::core
 {
 
-namespace
-{
-
-constexpr std::string_view kWire[] = {
+constexpr std::string_view kUprightInvertedWire[] = {
     "upright",
     "inverted",
 };
-
-} // namespace
 
 UprightInverted UprightInverted::upright() noexcept
 {
@@ -30,14 +25,14 @@ UprightInverted UprightInverted::inverted() noexcept
 
 std::string_view UprightInverted::toString() const noexcept
 {
-    return kWire[static_cast<std::size_t>(m_tag)];
+    return kUprightInvertedWire[static_cast<std::size_t>(m_tag)];
 }
 
 bool UprightInverted::tryParse(std::string_view text, UprightInverted &out) noexcept
 {
-    for (std::size_t i = 0; i < std::size(kWire); ++i)
+    for (std::size_t i = 0; i < std::size(kUprightInvertedWire); ++i)
     {
-        if (kWire[i] == text)
+        if (kUprightInvertedWire[i] == text)
         {
             out = UprightInverted{static_cast<Tag>(i)};
             return true;

--- a/src/private/mx/core/generated/Valign.cpp
+++ b/src/private/mx/core/generated/Valign.cpp
@@ -8,17 +8,12 @@
 namespace mx::core
 {
 
-namespace
-{
-
-constexpr std::string_view kWire[] = {
+constexpr std::string_view kValignWire[] = {
     "top",
     "middle",
     "bottom",
     "baseline",
 };
-
-} // namespace
 
 Valign Valign::top() noexcept
 {
@@ -42,14 +37,14 @@ Valign Valign::baseline() noexcept
 
 std::string_view Valign::toString() const noexcept
 {
-    return kWire[static_cast<std::size_t>(m_tag)];
+    return kValignWire[static_cast<std::size_t>(m_tag)];
 }
 
 bool Valign::tryParse(std::string_view text, Valign &out) noexcept
 {
-    for (std::size_t i = 0; i < std::size(kWire); ++i)
+    for (std::size_t i = 0; i < std::size(kValignWire); ++i)
     {
-        if (kWire[i] == text)
+        if (kValignWire[i] == text)
         {
             out = Valign{static_cast<Tag>(i)};
             return true;

--- a/src/private/mx/core/generated/ValignImage.cpp
+++ b/src/private/mx/core/generated/ValignImage.cpp
@@ -8,16 +8,11 @@
 namespace mx::core
 {
 
-namespace
-{
-
-constexpr std::string_view kWire[] = {
+constexpr std::string_view kValignImageWire[] = {
     "top",
     "middle",
     "bottom",
 };
-
-} // namespace
 
 ValignImage ValignImage::top() noexcept
 {
@@ -36,14 +31,14 @@ ValignImage ValignImage::bottom() noexcept
 
 std::string_view ValignImage::toString() const noexcept
 {
-    return kWire[static_cast<std::size_t>(m_tag)];
+    return kValignImageWire[static_cast<std::size_t>(m_tag)];
 }
 
 bool ValignImage::tryParse(std::string_view text, ValignImage &out) noexcept
 {
-    for (std::size_t i = 0; i < std::size(kWire); ++i)
+    for (std::size_t i = 0; i < std::size(kValignImageWire); ++i)
     {
-        if (kWire[i] == text)
+        if (kValignImageWire[i] == text)
         {
             out = ValignImage{static_cast<Tag>(i)};
             return true;

--- a/src/private/mx/core/generated/WedgeType.cpp
+++ b/src/private/mx/core/generated/WedgeType.cpp
@@ -8,17 +8,12 @@
 namespace mx::core
 {
 
-namespace
-{
-
-constexpr std::string_view kWire[] = {
+constexpr std::string_view kWedgeTypeWire[] = {
     "crescendo",
     "diminuendo",
     "stop",
     "continue",
 };
-
-} // namespace
 
 WedgeType WedgeType::crescendo() noexcept
 {
@@ -42,14 +37,14 @@ WedgeType WedgeType::continue_() noexcept
 
 std::string_view WedgeType::toString() const noexcept
 {
-    return kWire[static_cast<std::size_t>(m_tag)];
+    return kWedgeTypeWire[static_cast<std::size_t>(m_tag)];
 }
 
 bool WedgeType::tryParse(std::string_view text, WedgeType &out) noexcept
 {
-    for (std::size_t i = 0; i < std::size(kWire); ++i)
+    for (std::size_t i = 0; i < std::size(kWedgeTypeWire); ++i)
     {
-        if (kWire[i] == text)
+        if (kWedgeTypeWire[i] == text)
         {
             out = WedgeType{static_cast<Tag>(i)};
             return true;

--- a/src/private/mx/core/generated/Winged.cpp
+++ b/src/private/mx/core/generated/Winged.cpp
@@ -8,14 +8,9 @@
 namespace mx::core
 {
 
-namespace
-{
-
-constexpr std::string_view kWire[] = {
+constexpr std::string_view kWingedWire[] = {
     "none", "straight", "curved", "double-straight", "double-curved",
 };
-
-} // namespace
 
 Winged Winged::none() noexcept
 {
@@ -44,14 +39,14 @@ Winged Winged::doubleCurved() noexcept
 
 std::string_view Winged::toString() const noexcept
 {
-    return kWire[static_cast<std::size_t>(m_tag)];
+    return kWingedWire[static_cast<std::size_t>(m_tag)];
 }
 
 bool Winged::tryParse(std::string_view text, Winged &out) noexcept
 {
-    for (std::size_t i = 0; i < std::size(kWire); ++i)
+    for (std::size_t i = 0; i < std::size(kWingedWire); ++i)
     {
-        if (kWire[i] == text)
+        if (kWingedWire[i] == text)
         {
             out = Winged{static_cast<Tag>(i)};
             return true;

--- a/src/private/mx/core/generated/WoodValue.cpp
+++ b/src/private/mx/core/generated/WoodValue.cpp
@@ -8,18 +8,13 @@
 namespace mx::core
 {
 
-namespace
-{
-
-constexpr std::string_view kWire[] = {
+constexpr std::string_view kWoodValueWire[] = {
     "bamboo scraper",   "board clapper",   "cabasa",       "castanets", "castanets with handle",
     "claves",           "football rattle", "guiro",        "log drum",  "maraca",
     "maracas",          "quijada",         "rainstick",    "ratchet",   "reco-reco",
     "sandpaper blocks", "slit drum",       "temple block", "vibraslap", "whip",
     "wood block",
 };
-
-} // namespace
 
 WoodValue WoodValue::bambooScraper() noexcept
 {
@@ -128,14 +123,14 @@ WoodValue WoodValue::woodBlock() noexcept
 
 std::string_view WoodValue::toString() const noexcept
 {
-    return kWire[static_cast<std::size_t>(m_tag)];
+    return kWoodValueWire[static_cast<std::size_t>(m_tag)];
 }
 
 bool WoodValue::tryParse(std::string_view text, WoodValue &out) noexcept
 {
-    for (std::size_t i = 0; i < std::size(kWire); ++i)
+    for (std::size_t i = 0; i < std::size(kWoodValueWire); ++i)
     {
-        if (kWire[i] == text)
+        if (kWoodValueWire[i] == text)
         {
             out = WoodValue{static_cast<Tag>(i)};
             return true;

--- a/src/private/mx/core/generated/YesNo.cpp
+++ b/src/private/mx/core/generated/YesNo.cpp
@@ -8,15 +8,10 @@
 namespace mx::core
 {
 
-namespace
-{
-
-constexpr std::string_view kWire[] = {
+constexpr std::string_view kYesNoWire[] = {
     "yes",
     "no",
 };
-
-} // namespace
 
 YesNo YesNo::yes() noexcept
 {
@@ -30,14 +25,14 @@ YesNo YesNo::no() noexcept
 
 std::string_view YesNo::toString() const noexcept
 {
-    return kWire[static_cast<std::size_t>(m_tag)];
+    return kYesNoWire[static_cast<std::size_t>(m_tag)];
 }
 
 bool YesNo::tryParse(std::string_view text, YesNo &out) noexcept
 {
-    for (std::size_t i = 0; i < std::size(kWire); ++i)
+    for (std::size_t i = 0; i < std::size(kYesNoWire); ++i)
     {
-        if (kWire[i] == text)
+        if (kYesNoWire[i] == text)
         {
             out = YesNo{static_cast<Tag>(i)};
             return true;


### PR DESCRIPTION
## Summary

Each generated enum \`.cpp\` file (136 of them) contained an anonymous \`namespace {}\` wrapping a
\`constexpr std::string_view kWire[]\` lookup table. In a normal build this is fine — each
translation unit gets its own anonymous namespace and the names never conflict. In a unity build,
however, all included \`.cpp\` files share one translation unit, so the anonymous namespaces merge
and 136 definitions of \`kWire\` collide.

The fix is minimal: drop the anonymous namespace and give the array a per-type name
(\`kYesNoWire\`, \`kAboveBelowWire\`, etc.) so the names are unique within \`mx::core\` and unity
builds can include multiple enum files without redefinition errors.

Changes:
- `gen/cpp/templates/enum.cpp.tmpl` — remove the anonymous namespace, rename `kWire` to `k{{ident}}Wire`
- `src/private/mx/core/generated/*.cpp` — 97 regenerated files (the enum-class strategy files that had the anonymous namespace)

## Testing

- [ ] `make test` passes

## References

- Closes #245