### PR TITLE
fix: remove remaining anonymous namespaces for unity build compat

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -98,6 +98,30 @@ serialization/deserialization libraries. See:
 What you need to know right now is that `gen/cpp` is where our MusicXML types are coming from. Run
 `make gen-cpp` to regenerate the C++ types.
 
+## C++ coding rules
+
+Do not use anonymous namespaces (`namespace { }`) anywhere in the codebase. All symbols must be in
+a named namespace. Anonymous namespaces give internal linkage, which is correct for a normal
+one-TU-per-file build but causes redefinition errors in unity builds (where multiple `.cpp` files
+are compiled as a single translation unit). Use a named helper function or per-type name instead:
+
+- For file-local helper functions: name them after the type or file, e.g. `tokenIsNameChar`,
+  `clampedTenths`.
+- For file-local constants (arrays, string_views): use a per-type prefix, e.g. `kYesNoWire`,
+  `kSmuflAccidentalGlyphNamePrefix`.
+- In code generator templates (`gen/cpp/templates/`): use `{{ident}}` to make names unique, e.g.
+  `k{{ident}}Wire`, `isNameChar{{ident}}`.
+
+Unity builds can be tested with CMake's built-in support — no changes to `CMakeLists.txt` are
+needed by contributors. To verify, configure with:
+
+```
+cmake -S . -B build/unity -DCMAKE_UNITY_BUILD=ON -DCMAKE_UNITY_BUILD_BATCH_SIZE=0
+cmake --build build/unity --target mx
+```
+
+`BATCH_SIZE=0` puts all files in a target into one translation unit, which is the strictest test.
+
 ## Quality gates
 
 Run `make fmt` to format. `make check` is the clang-format gate **only** — it builds and tests nothing.

--- a/gen/cpp/templates/nmtoken_string.cpp.tmpl
+++ b/gen/cpp/templates/nmtoken_string.cpp.tmpl
@@ -7,17 +7,12 @@
 namespace {{vars.namespace}}
 {
 
-namespace
-{
-
 // The ASCII subset of XML name characters (matches the schema's \c).
-bool isNameChar(char c) noexcept
+bool isNameChar{{ident}}(char c) noexcept
 {
     return (c >= 'a' && c <= 'z') || (c >= 'A' && c <= 'Z') || (c >= '0' && c <= '9') || c == '-' ||
            c == '.' || c == ':' || c == '_';
 }
-
-} // namespace
 
 {{ident}}::{{ident}}()
 {
@@ -41,7 +36,7 @@ void {{ident}}::repair()
     cleaned.reserve(m_value.size());
     for (const char c : m_value)
     {
-        if (isNameChar(c))
+        if (isNameChar{{ident}}(c))
         {
             cleaned.push_back(c);
         }
@@ -61,7 +56,7 @@ bool {{ident}}::tryParse(std::string_view text, {{ident}} &out)
     }
     for (const char c : text)
     {
-        if (!isNameChar(c))
+        if (!isNameChar{{ident}}(c))
         {
             return false;
         }

--- a/gen/cpp/templates/smufl_wavy.cpp.tmpl
+++ b/gen/cpp/templates/smufl_wavy.cpp.tmpl
@@ -7,21 +7,16 @@
 namespace {{vars.namespace}}
 {
 
-namespace
-{
-
 constexpr std::string_view kWiggle = "wiggle";
 constexpr std::string_view kGuitar = "guitar";
 constexpr std::string_view kVibratoStroke = "VibratoStroke";
 
 // The ASCII subset of XML name characters the schema's \c denotes.
-bool isNameChar(char c) noexcept
+bool isNameChar{{ident}}(char c) noexcept
 {
     return (c >= 'a' && c <= 'z') || (c >= 'A' && c <= 'Z') || (c >= '0' && c <= '9') || c == '-' ||
            c == '.' || c == ':' || c == '_';
 }
-
-} // namespace
 
 {{ident}}::{{ident}}()
 {
@@ -55,7 +50,7 @@ void {{ident}}::repair()
     cleaned.reserve(m_part.size());
     for (const char c : m_part)
     {
-        if (isNameChar(c))
+        if (isNameChar{{ident}}(c))
         {
             cleaned.push_back(c);
         }
@@ -86,7 +81,7 @@ bool {{ident}}::tryParse(std::string_view text, {{ident}} &out)
     const auto allNameChars = [](std::string_view s) {
         for (const char c : s)
         {
-            if (!isNameChar(c))
+            if (!isNameChar{{ident}}(c))
             {
                 return false;
             }

--- a/src/private/mx/core/NameToken.cpp
+++ b/src/private/mx/core/NameToken.cpp
@@ -9,16 +9,11 @@
 namespace mx::core
 {
 
-namespace
-{
-
-bool isNameChar(char c) noexcept
+bool nameTokenIsNameChar(char c) noexcept
 {
     return (c >= 'a' && c <= 'z') || (c >= 'A' && c <= 'Z') || (c >= '0' && c <= '9') || c == '-' || c == '.' ||
            c == ':' || c == '_';
 }
-
-} // namespace
 
 NameToken::NameToken()
 {
@@ -42,7 +37,7 @@ void NameToken::repair()
     cleaned.reserve(m_value.size());
     for (const char c : m_value)
     {
-        if (isNameChar(c))
+        if (nameTokenIsNameChar(c))
         {
             cleaned.push_back(c);
         }
@@ -62,7 +57,7 @@ bool NameToken::tryParse(std::string_view text, NameToken &out)
     }
     for (const char c : text)
     {
-        if (!isNameChar(c))
+        if (!nameTokenIsNameChar(c))
         {
             return false;
         }

--- a/src/private/mx/core/Token.cpp
+++ b/src/private/mx/core/Token.cpp
@@ -9,23 +9,18 @@
 namespace mx::core
 {
 
-namespace
-{
-
 // The ASCII subset of the XML NCName character classes (the schema's
 // vocabularies are ASCII; the strict parse is the only consumer, so the
 // approximation can only under-accept).
-bool isNameStart(char c) noexcept
+bool tokenIsNameStart(char c) noexcept
 {
     return (c >= 'a' && c <= 'z') || (c >= 'A' && c <= 'Z') || c == '_';
 }
 
-bool isNameChar(char c) noexcept
+bool tokenIsNameChar(char c) noexcept
 {
-    return isNameStart(c) || (c >= '0' && c <= '9') || c == '-' || c == '.';
+    return tokenIsNameStart(c) || (c >= '0' && c <= '9') || c == '-' || c == '.';
 }
-
-} // namespace
 
 Token::Token()
 {
@@ -49,14 +44,14 @@ void Token::repair()
     cleaned.reserve(m_value.size());
     for (const char c : m_value)
     {
-        if (isNameChar(c))
+        if (tokenIsNameChar(c))
         {
             cleaned.push_back(c);
         }
     }
     // An NCName cannot begin with a digit, '-', or '.'.
     std::size_t start = 0;
-    while (start < cleaned.size() && !isNameStart(cleaned[start]))
+    while (start < cleaned.size() && !tokenIsNameStart(cleaned[start]))
     {
         ++start;
     }
@@ -70,13 +65,13 @@ void Token::repair()
 
 bool Token::tryParse(std::string_view text, Token &out)
 {
-    if (text.empty() || !isNameStart(text.front()))
+    if (text.empty() || !tokenIsNameStart(text.front()))
     {
         return false;
     }
     for (const char c : text)
     {
-        if (!isNameChar(c))
+        if (!tokenIsNameChar(c))
         {
             return false;
         }

--- a/src/private/mx/core/generated/SmuflGlyphName.cpp
+++ b/src/private/mx/core/generated/SmuflGlyphName.cpp
@@ -7,17 +7,12 @@
 namespace mx::core
 {
 
-namespace
-{
-
 // The ASCII subset of XML name characters (matches the schema's \c).
-bool isNameChar(char c) noexcept
+bool isNameCharSmuflGlyphName(char c) noexcept
 {
     return (c >= 'a' && c <= 'z') || (c >= 'A' && c <= 'Z') || (c >= '0' && c <= '9') || c == '-' || c == '.' ||
            c == ':' || c == '_';
 }
-
-} // namespace
 
 SmuflGlyphName::SmuflGlyphName()
 {
@@ -41,7 +36,7 @@ void SmuflGlyphName::repair()
     cleaned.reserve(m_value.size());
     for (const char c : m_value)
     {
-        if (isNameChar(c))
+        if (isNameCharSmuflGlyphName(c))
         {
             cleaned.push_back(c);
         }
@@ -61,7 +56,7 @@ bool SmuflGlyphName::tryParse(std::string_view text, SmuflGlyphName &out)
     }
     for (const char c : text)
     {
-        if (!isNameChar(c))
+        if (!isNameCharSmuflGlyphName(c))
         {
             return false;
         }

--- a/src/private/mx/core/generated/SmuflWavyLineGlyphName.cpp
+++ b/src/private/mx/core/generated/SmuflWavyLineGlyphName.cpp
@@ -7,21 +7,16 @@
 namespace mx::core
 {
 
-namespace
-{
-
 constexpr std::string_view kWiggle = "wiggle";
 constexpr std::string_view kGuitar = "guitar";
 constexpr std::string_view kVibratoStroke = "VibratoStroke";
 
 // The ASCII subset of XML name characters the schema's \c denotes.
-bool isNameChar(char c) noexcept
+bool isNameCharSmuflWavyLineGlyphName(char c) noexcept
 {
     return (c >= 'a' && c <= 'z') || (c >= 'A' && c <= 'Z') || (c >= '0' && c <= '9') || c == '-' || c == '.' ||
            c == ':' || c == '_';
 }
-
-} // namespace
 
 SmuflWavyLineGlyphName::SmuflWavyLineGlyphName()
 {
@@ -55,7 +50,7 @@ void SmuflWavyLineGlyphName::repair()
     cleaned.reserve(m_part.size());
     for (const char c : m_part)
     {
-        if (isNameChar(c))
+        if (isNameCharSmuflWavyLineGlyphName(c))
         {
             cleaned.push_back(c);
         }
@@ -86,7 +81,7 @@ bool SmuflWavyLineGlyphName::tryParse(std::string_view text, SmuflWavyLineGlyphN
     const auto allNameChars = [](std::string_view s) {
         for (const char c : s)
         {
-            if (!isNameChar(c))
+            if (!isNameCharSmuflWavyLineGlyphName(c))
             {
                 return false;
             }


### PR DESCRIPTION
## Summary

Follow-up to #246. The previous PR fixed the generated enum, number, string, and smufl_prefixed
templates. This PR covers the remaining cases found by doing an actual unity build
(`CMAKE_UNITY_BUILD=ON`, `BATCH_SIZE=0`):

- `src/private/mx/core/Token.cpp` and `NameToken.cpp` — both defined `isNameChar` in an anonymous
  namespace inside `mx::core`. Renamed to `tokenIsNameChar` / `nameTokenIsNameChar`.
- `gen/cpp/templates/nmtoken_string.cpp.tmpl` and `smufl_wavy.cpp.tmpl` — same pattern, both
  generating `isNameChar` in anonymous namespaces. Renamed to `isNameChar{{ident}}`.
- `AGENTS.md` — added a project-wide rule prohibiting anonymous namespaces, with the unity build
  test command so contributors can verify.

No CMake changes are needed by contributors wanting unity builds. The standard CMake flags work
as-is:

```
cmake -S . -B build/unity -DCMAKE_UNITY_BUILD=ON -DCMAKE_UNITY_BUILD_BATCH_SIZE=0
cmake --build build/unity --target mx
```

## Testing

- Unity build passes clean (`cmake --build` with `CMAKE_UNITY_BUILD=ON BATCH_SIZE=0`, target `mx`)
- [ ] `make test` passes

## References

- Closes #245
- Follow-up to #246