### PR TITLE
ci: post PR comments via a workflow_run companion so fork PRs work

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -3,7 +3,7 @@ name: CI
 on:
   pull_request:
   push:
-    branches: [master]
+    branches: [main]
 
 # Cancel an in-flight run when a newer push supersedes it. The group is keyed
 # on the ref, so a new push to a PR cancels that PR's prior run without
@@ -18,10 +18,11 @@ jobs:
     name: Linux (generator gates)
     runs-on: ubuntu-latest
 
-    # pull-requests: write lets the gen-quality score comment post on PRs.
+    # Read-only token: this job builds untrusted fork PR code, so it never
+    # requests write. The gen-quality comment is posted by the pr-comment.yaml
+    # companion workflow (workflow_run) from the base-repo context instead.
     permissions:
       contents: read
-      pull-requests: write
 
     steps:
       - uses: actions/checkout@v4
@@ -91,19 +92,28 @@ jobs:
             cat data/testOutput/gen-quality/report.md 2>/dev/null || echo '(no report produced)'
           } >> "$GITHUB_STEP_SUMMARY"
 
-      - name: Post gen-quality PR comment
+      # Fork PRs run with a read-only token, so this job can't post the comment
+      # itself. Stage the body + PR number as an artifact; pr-comment.yaml posts
+      # it after CI completes. always() so a gate failure still reports why.
+      - name: Stage gen-quality PR comment
         if: always() && github.event_name == 'pull_request'
-        env:
-          GH_TOKEN: ${{ github.token }}
         run: |
+          mkdir -p pr-comment
           {
             echo '### gen-quality `gen/`'
             echo ''
             cat data/testOutput/gen-quality/report.md 2>/dev/null || echo '(no report produced)'
             echo ''
             echo 'Commit `${{ github.sha }}`.'
-          } > gen-quality-comment.md
-          gh pr comment "${{ github.event.pull_request.number }}" --body-file gen-quality-comment.md
+          } > pr-comment/body.md
+          echo '${{ github.event.pull_request.number }}' > pr-comment/number
+
+      - name: Upload gen-quality PR comment
+        if: always() && github.event_name == 'pull_request'
+        uses: actions/upload-artifact@v4
+        with:
+          name: pr-comment-gen
+          path: pr-comment/
 
   linux-api:
     name: Linux (mx::api/mx::impl)
@@ -202,10 +212,11 @@ jobs:
     name: Linux (coverage-core-dev)
     runs-on: ubuntu-latest
 
-    # pull-requests: write lets the coverage comment post on PRs.
+    # Read-only token: posting the coverage comment is delegated to the
+    # pr-comment.yaml companion workflow so fork PRs get a comment too (their
+    # GITHUB_TOKEN is capped to read-only here).
     permissions:
       contents: read
-      pull-requests: write
 
     steps:
       - uses: actions/checkout@v4
@@ -289,9 +300,13 @@ jobs:
           path: data/testOutput/coverage/api/index.html
           compression-level: 0
 
-      - name: Compose PR comment
+      # Stage the body + PR number as an artifact; pr-comment.yaml posts it
+      # after CI completes (this job's fork-PR token is read-only). It posts a
+      # fresh comment each run, so the PR keeps a per-push coverage history.
+      - name: Stage PR comment
         if: github.event_name == 'pull_request'
         run: |
+          mkdir -p pr-comment
           {
             echo '### Coverage report'
             echo ''
@@ -300,15 +315,15 @@ jobs:
             echo '[Core HTML report](${{ steps.upload.outputs.artifact-url }}) | [API HTML report](${{ steps.upload-api.outputs.artifact-url }})'
             echo ''
             echo 'Commit `${{ github.sha }}`.'
-          } > comment.md
+          } > pr-comment/body.md
+          echo '${{ github.event.pull_request.number }}' > pr-comment/number
 
-      # gh pr comment posts a fresh comment each run, so the PR keeps a
-      # per-push coverage history instead of overwriting one sticky comment.
-      - name: Post PR comment
+      - name: Upload PR comment
         if: github.event_name == 'pull_request'
-        env:
-          GH_TOKEN: ${{ github.token }}
-        run: gh pr comment "${{ github.event.pull_request.number }}" --body-file comment.md
+        uses: actions/upload-artifact@v4
+        with:
+          name: pr-comment-coverage
+          path: pr-comment/
 
   macos:
     name: macOS (mx::core, AppleClang)

--- a/.github/workflows/pr-comment.yaml
+++ b/.github/workflows/pr-comment.yaml
@@ -15,6 +15,7 @@ on:
     types: [completed]
 
 permissions:
+  actions: read
   contents: read
   pull-requests: write
 

--- a/.github/workflows/pr-comment.yaml
+++ b/.github/workflows/pr-comment.yaml
@@ -53,7 +53,7 @@ jobs:
           for dir in pr-comments/pr-comment-*; do
             [ -f "$dir/number" ] && [ -f "$dir/body.md" ] || continue
             number="$(cat "$dir/number")"
-            [ -n "$number" ] || continue
+            [[ "$number" =~ ^[0-9]+$ ]] || continue
             gh pr comment "$number" --repo "$REPO" --body-file "$dir/body.md"
             posted=$((posted + 1))
           done

--- a/.github/workflows/pr-comment.yaml
+++ b/.github/workflows/pr-comment.yaml
@@ -1,0 +1,60 @@
+name: PR Comment
+
+# Companion to ci.yaml. A PR from a fork runs CI with a GITHUB_TOKEN that
+# GitHub caps to read-only (the same job builds the fork's untrusted code), so
+# the gh-pr-comment steps there cannot post. Those jobs instead stage each
+# comment body + PR number as a `pr-comment-*` artifact.
+#
+# This workflow triggers when CI finishes. workflow_run always runs from the
+# default branch in the base-repo context, where the token genuinely has
+# pull-requests: write even for fork PRs -- and the untrusted PR code never
+# runs here. It downloads the staged artifacts and posts the comments.
+on:
+  workflow_run:
+    workflows: ["CI"]
+    types: [completed]
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  post-comments:
+    name: Post PR comments
+    runs-on: ubuntu-latest
+    # Only PR runs stage comment artifacts; a cancelled run (e.g. superseded by
+    # a newer push) has nothing to post.
+    if: >-
+      github.event.workflow_run.event == 'pull_request' &&
+      github.event.workflow_run.conclusion != 'cancelled'
+
+    steps:
+      # run-id + github-token fetch artifacts from the triggering CI run (a
+      # different run than this one). continue-on-error so a run that staged no
+      # comment artifacts doesn't red-X this workflow.
+      - name: Download comment artifacts
+        id: download
+        continue-on-error: true
+        uses: actions/download-artifact@v4
+        with:
+          run-id: ${{ github.event.workflow_run.id }}
+          github-token: ${{ github.token }}
+          pattern: pr-comment-*
+          path: pr-comments
+
+      - name: Post comments
+        if: steps.download.outcome == 'success'
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
+        run: |
+          shopt -s nullglob
+          posted=0
+          for dir in pr-comments/pr-comment-*; do
+            [ -f "$dir/number" ] && [ -f "$dir/body.md" ] || continue
+            number="$(cat "$dir/number")"
+            [ -n "$number" ] || continue
+            gh pr comment "$number" --repo "$REPO" --body-file "$dir/body.md"
+            posted=$((posted + 1))
+          done
+          echo "Posted $posted PR comment(s)."


### PR DESCRIPTION
## Summary

CI failed on PRs opened from forks (e.g. #244, #250) at the `gh pr comment` steps in the `linux-gen` and `coverage` jobs:

```
GraphQL: Resource not accessible by integration (addComment)
```

For a PR from a fork, GitHub caps the `GITHUB_TOKEN` to read-only regardless of the `permissions:` block, because the same job builds the fork's untrusted code. So the `pull-requests: write` those jobs declared is silently ignored, and the comment post fails the job.

This switches to GitHub's supported pattern for commenting on fork PRs:

- The `linux-gen` and `coverage` jobs no longer comment directly. They stage the comment body plus the PR number as a `pr-comment-*` artifact, and drop the now-unused `pull-requests: write` (least privilege — the jobs that run untrusted code no longer request write at all).
- A new `pr-comment.yaml` runs on `workflow_run` when CI completes. `workflow_run` executes from the default branch in the base-repo context, where the token does have `pull-requests: write` even for fork PRs. It downloads the staged artifacts and posts the comments. The untrusted PR code never runs with that write token.

Behavior is otherwise unchanged: a fresh comment per push, and the gen-quality comment still posts on gate failure (`always()`).

## Testing

- [x] Both workflow files parse (`yaml.safe_load`)
- [ ] End-to-end posting is exercised only once this is on the default branch: `workflow_run` triggers from the default-branch copy of the workflow, so the companion will not fire from this PR branch. The artifact-staging half does run on this PR's checks.

## References

- Fixes the CI comment-step failures seen on fork PRs #244 and #250
- No tracking issue

