### PR TITLE
build: isolate docker volumes per checkout

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -13,6 +13,13 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
+# Pin the Docker build-volume name so CI's bind-backed "mx-build" volume
+# (created per-job below) is the one the Makefile actually mounts. Without
+# this the Makefile computes a CURDIR-hashed name (for worktree isolation)
+# that doesn't match the pre-created volume.
+env:
+  DOCKER_VOLUME: mx-build
+
 jobs:
   linux-gen:
     name: Linux (generator gates)

--- a/Makefile
+++ b/Makefile
@@ -39,8 +39,9 @@ DOCKER_CACHE := --cache-from type=gha --cache-to type=gha,mode=max
 endif
 
 # Docker SDK image + build volume. Incremental state persists across runs.
+# Volume name includes a path hash so parallel worktrees get isolated caches.
 DOCKER_IMAGE  := mx-sdk
-DOCKER_VOLUME := mx-build
+DOCKER_VOLUME ?= mx-build-$(shell printf '%s' '$(CURDIR)' | md5sum 2>/dev/null | cut -c1-8 || printf '%s' '$(CURDIR)' | md5 -q | cut -c1-8)
 DOCKER_STAMP  := $(BUILD_ROOT)/.docker-image-stamp
 
 # Prevent root-owned files on Linux.


### PR DESCRIPTION
`DOCKER_VOLUME` was hardcoded to `mx-build`, so two worktrees building simultaneously would share
a single Docker volume and corrupt each other's build cache. Derive the volume name from an 8-char
hash of `$(CURDIR)` so each worktree gets an isolated cache. The `mx-sdk` image stays shared since
the toolchain is the same everywhere.

Uses `?=` so the name can be overridden via env. CI is unaffected — it hardcodes `mx-build`
directly in the workflow YAML, not through the Makefile variable.