### PR TITLE
feat: add clef print-object support in mx::api

### DIFF
--- a/src/include/mx/api/ClefData.h
+++ b/src/include/mx/api/ClefData.h
@@ -47,6 +47,9 @@ class ClefData
     int octaveChange;
     int tickTimePosition;
     ClefLocation location;
+    // Visibility of the clef via the MusicXML print-object attribute.
+    // unspecified -> omit the attribute, yes/no -> write print-object verbatim.
+    Bool printObject;
     std::string toString() const;
 
     // convenience - set symbol, line and octave for common clefs
@@ -76,6 +79,7 @@ MXAPI_EQUALS_MEMBER(isLineSpecified)
 MXAPI_EQUALS_MEMBER(octaveChange)
 MXAPI_EQUALS_MEMBER(tickTimePosition)
 MXAPI_EQUALS_MEMBER(location)
+MXAPI_EQUALS_MEMBER(printObject)
 MXAPI_EQUALS_END;
 MXAPI_NOT_EQUALS_AND_VECTORS(ClefData);
 } // namespace api

--- a/src/private/mx/api/ClefData.cpp
+++ b/src/private/mx/api/ClefData.cpp
@@ -11,7 +11,8 @@ namespace api
 {
 ClefData::ClefData()
     : symbol{DEFAULT_CLEF_SYMBOL}, line{DEFAULT_CLEF_LINE}, isLineSpecified{true},
-      octaveChange{DEFAULT_CLEF_OCTAVE_CHANGE}, tickTimePosition{0}, location{ClefLocation::unspecified}
+      octaveChange{DEFAULT_CLEF_OCTAVE_CHANGE}, tickTimePosition{0}, location{ClefLocation::unspecified},
+      printObject{Bool::unspecified}
 {
 }
 

--- a/src/private/mx/impl/MeasureReader.cpp
+++ b/src/private/mx/impl/MeasureReader.cpp
@@ -815,6 +815,11 @@ void MeasureReader::importClef(const core::Clef &inClef) const
         clefData.octaveChange = 0;
     }
 
+    if (inClef.printObject().has_value())
+    {
+        clefData.printObject = converter.convert(*inClef.printObject());
+    }
+
     int celfStaffIndex = -1;
     if (inClef.number().has_value())
     {

--- a/src/private/mx/impl/PropertiesWriter.cpp
+++ b/src/private/mx/impl/PropertiesWriter.cpp
@@ -221,6 +221,11 @@ void PropertiesWriter::writeClef(int staffIndex, const api::ClefData &inClefData
         cg.setClefOctaveChange(inClefData.octaveChange);
     }
 
+    if (inClefData.printObject != api::Bool::unspecified)
+    {
+        mxClef.setPrintObject(converter.convert(inClefData.printObject));
+    }
+
     mxClef.setClef(cg);
     myAttributes.addClef(mxClef);
     myHasContent = true;

--- a/src/private/mxtest/api/ClefDataTest.cpp
+++ b/src/private/mxtest/api/ClefDataTest.cpp
@@ -1,0 +1,81 @@
+// MusicXML Class Library
+// Copyright (c) by Matthew James Briggs
+// Distributed under the MIT License
+
+#include "mxtest/control/CompileControl.h"
+#ifdef MX_COMPILE_API_TESTS
+
+#include "cpul/cpulTestHarness.h"
+#include "mxtest/api/TestHelpers.h"
+
+#include <string>
+
+using namespace mx::api;
+
+namespace mxtest::api::clef_data_test
+{
+ScoreData makeScoreWithClef(Bool printObject)
+{
+    ScoreData score;
+    score.parts.emplace_back();
+    auto &part = score.parts.back();
+    part.measures.emplace_back();
+    auto &measure = part.measures.back();
+    measure.staves.emplace_back();
+    auto &staff = measure.staves.back();
+
+    staff.clefs.emplace_back();
+    auto &clef = staff.clefs.back();
+    clef.printObject = printObject;
+
+    staff.voices[0].notes.emplace_back();
+    return score;
+}
+} // namespace mxtest::api::clef_data_test
+
+TEST(clefPrintObjectNoRoundTrip, ClefData)
+{
+    const auto xml = mxtest::toXml(mxtest::api::clef_data_test::makeScoreWithClef(Bool::no));
+    CHECK(xml.find("print-object=\"no\"") != std::string::npos);
+
+    const auto out = mxtest::fromXml(xml);
+    CHECK_EQUAL(1, out.parts.size());
+    CHECK_EQUAL(1, out.parts.front().measures.size());
+    CHECK_EQUAL(1, out.parts.front().measures.front().staves.size());
+    CHECK_EQUAL(1, out.parts.front().measures.front().staves.front().clefs.size());
+    CHECK(Bool::no == out.parts.front().measures.front().staves.front().clefs.front().printObject);
+}
+
+T_END;
+
+TEST(clefPrintObjectYesRoundTrip, ClefData)
+{
+    const auto xml = mxtest::toXml(mxtest::api::clef_data_test::makeScoreWithClef(Bool::yes));
+    CHECK(xml.find("print-object=\"yes\"") != std::string::npos);
+
+    const auto out = mxtest::fromXml(xml);
+    CHECK_EQUAL(1, out.parts.size());
+    CHECK_EQUAL(1, out.parts.front().measures.size());
+    CHECK_EQUAL(1, out.parts.front().measures.front().staves.size());
+    CHECK_EQUAL(1, out.parts.front().measures.front().staves.front().clefs.size());
+    CHECK(Bool::yes == out.parts.front().measures.front().staves.front().clefs.front().printObject);
+}
+
+T_END;
+
+TEST(clefPrintObjectUnspecifiedIsOmitted, ClefData)
+{
+    const auto xml = mxtest::toXml(mxtest::api::clef_data_test::makeScoreWithClef(Bool::unspecified));
+    CHECK(xml.find("print-object=") == std::string::npos);
+
+    const auto out = mxtest::fromXml(xml);
+    CHECK_EQUAL(1, out.parts.size());
+    CHECK_EQUAL(1, out.parts.front().measures.size());
+    CHECK_EQUAL(1, out.parts.front().measures.front().staves.size());
+    CHECK_EQUAL(1, out.parts.front().measures.front().staves.front().clefs.size());
+    CHECK(Bool::unspecified == out.parts.front().measures.front().staves.front().clefs.front().printObject);
+}
+
+T_END;
+
+#endif


### PR DESCRIPTION
Add `clefData.printObject` to api, with round trip access.