### PR TITLE
fix: preserve clef-octave-change zero on round-trip

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -435,9 +435,15 @@ discover-api-roundtrip: $(DOCKER_STAMP) docker-volume
 
 dump-api-roundtrip: $(DOCKER_STAMP) docker-volume
 	$(DOCKER_RUN) make dump-api-roundtrip BUILD_TYPE=$(BUILD_TYPE)
+	@mkdir -p $(BUILD_ROOT)/api/roundtrip-dump
+	$(DOCKER) run --rm -v $(DOCKER_VOLUME):/vol:ro -v $(CURDIR)/$(BUILD_ROOT)/api/roundtrip-dump:/out \
+		alpine sh -c 'cp -a /vol/api/roundtrip-dump/. /out/'
 
 classify-api-roundtrip: $(DOCKER_STAMP) docker-volume
 	$(DOCKER_RUN) make classify-api-roundtrip BUILD_TYPE=$(BUILD_TYPE)
+	@mkdir -p $(BUILD_ROOT)/api
+	$(DOCKER) run --rm -v $(DOCKER_VOLUME):/vol:ro -v $(CURDIR)/$(BUILD_ROOT)/api:/out \
+		alpine cp /vol/api/classified.json /out/classified.json
 
 coverage-api: $(DOCKER_STAMP) docker-volume
 	@rm -rf $(COV_DIR)/api

--- a/src/include/mx/api/ClefData.h
+++ b/src/include/mx/api/ClefData.h
@@ -45,6 +45,7 @@ class ClefData
     // had no <line> element so the round-trip does not inject an implied default (#228).
     bool isLineSpecified;
     int octaveChange;
+    bool isOctaveChangeSpecified;
     int tickTimePosition;
     ClefLocation location;
     // Visibility of the clef via the MusicXML print-object attribute.
@@ -77,6 +78,7 @@ MXAPI_EQUALS_MEMBER(symbol)
 MXAPI_EQUALS_MEMBER(line)
 MXAPI_EQUALS_MEMBER(isLineSpecified)
 MXAPI_EQUALS_MEMBER(octaveChange)
+MXAPI_EQUALS_MEMBER(isOctaveChangeSpecified)
 MXAPI_EQUALS_MEMBER(tickTimePosition)
 MXAPI_EQUALS_MEMBER(location)
 MXAPI_EQUALS_MEMBER(printObject)

--- a/src/private/mx/api/ClefData.cpp
+++ b/src/private/mx/api/ClefData.cpp
@@ -11,8 +11,8 @@ namespace api
 {
 ClefData::ClefData()
     : symbol{DEFAULT_CLEF_SYMBOL}, line{DEFAULT_CLEF_LINE}, isLineSpecified{true},
-      octaveChange{DEFAULT_CLEF_OCTAVE_CHANGE}, tickTimePosition{0}, location{ClefLocation::unspecified},
-      printObject{Bool::unspecified}
+      octaveChange{DEFAULT_CLEF_OCTAVE_CHANGE}, isOctaveChangeSpecified{true}, tickTimePosition{0},
+      location{ClefLocation::unspecified}, printObject{Bool::unspecified}
 {
 }
 

--- a/src/private/mx/impl/MeasureReader.cpp
+++ b/src/private/mx/impl/MeasureReader.cpp
@@ -809,10 +809,12 @@ void MeasureReader::importClef(const core::Clef &inClef) const
     if (inClef.clef().clefOctaveChange().has_value())
     {
         clefData.octaveChange = *inClef.clef().clefOctaveChange();
+        clefData.isOctaveChangeSpecified = true;
     }
     else
     {
         clefData.octaveChange = 0;
+        clefData.isOctaveChangeSpecified = false;
     }
 
     if (inClef.printObject().has_value())

--- a/src/private/mx/impl/PropertiesWriter.cpp
+++ b/src/private/mx/impl/PropertiesWriter.cpp
@@ -216,7 +216,7 @@ void PropertiesWriter::writeClef(int staffIndex, const api::ClefData &inClefData
         cg.setLine(core::StaffLinePosition{inClefData.line});
     }
 
-    if (inClefData.octaveChange != 0)
+    if (inClefData.isOctaveChangeSpecified)
     {
         cg.setClefOctaveChange(inClefData.octaveChange);
     }


### PR DESCRIPTION
## Summary

PropertiesWriter.cpp guarded clef-octave-change emission with `!= 0`, silently dropping
`<clef-octave-change>0</clef-octave-change>` on round-trip. Zero is a valid value meaning
"no octave transposition" and must be preserved when present in the source.

Added `isOctaveChangeSpecified` to ClefData, mirroring the existing `isLineSpecified` pattern
from #228. The reader sets the flag based on whether the element is present; the writer checks
the flag instead of the value.

Also fixes the Makefile so `dump-api-roundtrip` and `classify-api-roundtrip` copy their output
from the Docker volume to the host `build/api/` directory after running.

## Files changed

- ClefData.h: new `isOctaveChangeSpecified` field and equality member
- ClefData.cpp: initialize to true in constructor
- MeasureReader.cpp: set flag in reader based on element presence
- PropertiesWriter.cpp: guard on flag instead of `!= 0`
- Makefile: post-run volume-to-host copy for dump and classify targets

## Testing

CI will validate. 14 corpus files have the `drop:clef-octave-change` divergence signature.

## References

- Closes #257
- Split from #229