### PR TITLE
Add support for bar types "tick" and "short" to mx::api

### DIFF
--- a/src/include/mx/api/BarlineData.h
+++ b/src/include/mx/api/BarlineData.h
@@ -24,7 +24,9 @@ enum class BarlineType
     dotted,
     dashed,
     heavy,
-    heavyHeavy
+    heavyHeavy,
+    tick,
+    short_
 };
 
 enum class EndingType

--- a/src/private/mx/impl/Converter.cpp
+++ b/src/private/mx/impl/Converter.cpp
@@ -351,8 +351,8 @@ const Converter::EnumMap<core::BarStyle, api::BarlineType> Converter::barlineMap
     {core::BarStyle::lightHeavy(), api::BarlineType::lightHeavy},
     {core::BarStyle::heavyLight(), api::BarlineType::heavyLight},
     {core::BarStyle::heavyHeavy(), api::BarlineType::heavyHeavy},
-    {core::BarStyle::tick(), api::BarlineType::unsupported},
-    {core::BarStyle::short_(), api::BarlineType::unsupported},
+    {core::BarStyle::tick(), api::BarlineType::tick},
+    {core::BarStyle::short_(), api::BarlineType::short_},
     {core::BarStyle::none(), api::BarlineType::none},
 };
 

--- a/src/private/mxtest/api/MeasureDataTest.cpp
+++ b/src/private/mxtest/api/MeasureDataTest.cpp
@@ -117,6 +117,40 @@ TEST(backwardRepeat, MeasureData)
 
 T_END;
 
+TEST(tickAndShortBarlinesRoundTrip, MeasureData)
+{
+    ScoreData score;
+    score.parts.emplace_back();
+    auto &part = score.parts.back();
+    part.measures.emplace_back();
+    auto &measure = part.measures.back();
+    measure.staves.emplace_back();
+    auto &staff = measure.staves.back();
+    staff.voices[0].notes.emplace_back();
+
+    measure.barlines.emplace_back();
+    auto &tickBarline = measure.barlines.back();
+    tickBarline.barlineType = BarlineType::tick;
+
+    measure.barlines.emplace_back();
+    auto &shortBarline = measure.barlines.back();
+    shortBarline.barlineType = BarlineType::short_;
+
+    const auto xml = mxtest::toXml(score);
+    CHECK(xml.find("<bar-style>tick</bar-style>") != std::string::npos);
+    CHECK(xml.find("<bar-style>short</bar-style>") != std::string::npos);
+
+    const auto outScore = mxtest::fromXml(xml);
+    REQUIRE(outScore.parts.size() == 1);
+    REQUIRE(outScore.parts.front().measures.size() == 1);
+    const auto &outBarlines = outScore.parts.front().measures.front().barlines;
+    REQUIRE(outBarlines.size() == 2);
+    CHECK(outBarlines.at(0).barlineType == BarlineType::tick);
+    CHECK(outBarlines.at(1).barlineType == BarlineType::short_);
+}
+
+T_END;
+
 TEST(staffLinesRoundTrip, MeasureData)
 {
     ScoreData score;


### PR DESCRIPTION
This PR presumptuously takes the answer to #262 to be "not any reason". If there is a reason, ignore this PR.
