### PR TITLE
fix(api): round-trip repeat times attribute

### DIFF
--- a/src/include/mx/api/BarlineData.h
+++ b/src/include/mx/api/BarlineData.h
@@ -45,11 +45,14 @@ class BarlineData
     EndingType endingType;
     int endingNumber;
     bool repeat;
+    // Number of times a backward repeat is played (the repeat's `times` attribute). 0 = not
+    // specified, mirroring endingNumber above.
+    int repeatTimes;
     HorizontalAlignment location;
 
     BarlineData()
         : tickTimePosition{0}, barlineType{BarlineType::normal}, endingType{EndingType::none}, endingNumber{0},
-          repeat{false}, location{HorizontalAlignment::unspecified}
+          repeat{false}, repeatTimes{0}, location{HorizontalAlignment::unspecified}
     {
     }
 };
@@ -60,6 +63,7 @@ MXAPI_EQUALS_MEMBER(barlineType)
 MXAPI_EQUALS_MEMBER(endingType)
 MXAPI_EQUALS_MEMBER(endingNumber)
 MXAPI_EQUALS_MEMBER(repeat)
+MXAPI_EQUALS_MEMBER(repeatTimes)
 MXAPI_EQUALS_MEMBER(location)
 MXAPI_EQUALS_END;
 MXAPI_NOT_EQUALS_AND_VECTORS(BarlineData);

--- a/src/private/mx/impl/MeasureReader.cpp
+++ b/src/private/mx/impl/MeasureReader.cpp
@@ -655,6 +655,7 @@ void MeasureReader::parseBarline(const core::Barline &inMxBarline) const
     auto endingType = api::EndingType::none;
     auto endingNumber = 0;
     auto repeat = false;
+    auto repeatTimes = 0;
 
     if (inMxBarline.location().has_value())
     {
@@ -705,6 +706,7 @@ void MeasureReader::parseBarline(const core::Barline &inMxBarline) const
     if (inMxBarline.repeat().has_value())
     {
         repeat = true;
+        repeatTimes = inMxBarline.repeat()->times().value_or(0);
     }
 
     barline.barlineType = style;
@@ -712,6 +714,7 @@ void MeasureReader::parseBarline(const core::Barline &inMxBarline) const
     barline.endingType = endingType;
     barline.endingNumber = endingNumber;
     barline.repeat = repeat;
+    barline.repeatTimes = repeatTimes;
     myOutMeasureData.barlines.emplace_back(std::move(barline));
 }
 

--- a/src/private/mx/impl/MeasureWriter.cpp
+++ b/src/private/mx/impl/MeasureWriter.cpp
@@ -742,6 +742,11 @@ void MeasureWriter::writeBarlines(int tickTimePosition)
                 repeatElement.setDirection(mx::core::BackwardForward::backward());
             }
 
+            if (myBarlinesIter->repeatTimes > 0)
+            {
+                repeatElement.setTimes(myBarlinesIter->repeatTimes);
+            }
+
             barlineElement.setRepeat(repeatElement);
         }
 

--- a/src/private/mxtest/api/roundtrip-baseline.txt
+++ b/src/private/mxtest/api/roundtrip-baseline.txt
@@ -184,3 +184,10 @@ ksuite/k006t_Clefs_sign_TAB_ln_3_oct_0_Tab.xml
 ksuite/k006u_Clefs_sign_jianpu_ln_3_oct_0_Jianpu.xml
 ksuite/k006v_Clefs_sign_none_ln_3_oct_0_None.xml
 lysuite/ly46c_Midmeasure_Clef.xml
+
+# Unblocked by #271 (repeat @times round-trip). The reader recorded only a bool
+# for a repeat and dropped the times count; the writer never emitted it. Added
+# BarlineData::repeatTimes (0 = unspecified, mirroring endingNumber) so a backward
+# repeat's times attribute survives the round-trip.
+lysuite/ly45a_SimpleRepeat.xml
+lysuite/ly45c_RepeatMultipleTimes.xml

--- a/src/private/mxtest/impl/MeasureWriterTest.cpp
+++ b/src/private/mxtest/impl/MeasureWriterTest.cpp
@@ -144,6 +144,43 @@ TEST(leftBarlineFirstNoteRequiresForward, MeasureWriter)
 
 T_END
 
+TEST(rightBarlineRepeatTimes, MeasureWriter)
+{
+    // A backward repeat carrying a times count must round-trip that count (#271).
+    mxtest::TestParameters params;
+    params.ticksPerQuarter = 101;
+    params.measureIndex = 0;
+    params.partIndex = 0;
+    params.numStaves = 1;
+    mxtest::TestItems t = mxtest::setupTestItems(params);
+    t.measureData->barlines.emplace_back(api::BarlineData{});
+    auto &barline = t.measureData->barlines.front();
+    barline.barlineType = api::BarlineType::lightHeavy;
+    barline.location = api::HorizontalAlignment::right;
+    barline.tickTimePosition = api::TICK_TIME_INFINITY;
+    barline.repeat = true;
+    barline.repeatTimes = 5;
+
+    const auto partwiseMeasure = t.measureWriter->getPartwiseMeasure();
+    auto musicData = partwiseMeasure.musicData();
+
+    const core::Barline *outBarline = nullptr;
+    for (const auto &mdc : musicData)
+    {
+        if (mdc.isBarline())
+        {
+            outBarline = &mdc.asBarline();
+        }
+    }
+
+    CHECK(outBarline != nullptr);
+    CHECK(outBarline->repeat().has_value());
+    CHECK(outBarline->repeat()->times().has_value());
+    CHECK_EQUAL(5, *outBarline->repeat()->times());
+}
+
+T_END
+
 TEST(PropertiesButNoNotes, MeasureWriter)
 {
     mxtest::TestParameters params;


### PR DESCRIPTION
## Summary

A `<repeat>` lost its `times` count on api round-trip. `BarlineData` carried only a
`bool repeat`, so the barline reader discarded the count and the writer never emitted it.

Added `BarlineData::repeatTimes` (an int where 0 means not specified, mirroring the
existing `endingNumber` convention on the same struct). The barline reader now reads
`repeat()->times()`, and the barline writer emits `times` when the count is set. The
common no-times case stays at 0 and nothing is written.

## Testing

- [x] New `rightBarlineRepeatTimes` MeasureWriter test: a backward repeat with
      `repeatTimes = 5` emits a `<repeat>` carrying `times="5"`
- [x] Full unit suite passes (4334 assertions in 320 test cases)
- [x] Corpus api round-trip regression: 121 passed, 0 failed (up from 119).
      lysuite/ly45a_SimpleRepeat.xml and lysuite/ly45c_RepeatMultipleTimes.xml now
      round-trip and are pinned in the baseline.

## References

- Closes #271
- Split from #230 · Part of #208 · feeds #213