### PR TITLE
test: add rpatters1 composite time-sig sample

### DIFF
--- a/data/rpatters1/timesigs_composite-ref.musicxml
+++ b/data/rpatters1/timesigs_composite-ref.musicxml
@@ -1,0 +1,121 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!DOCTYPE score-partwise PUBLIC "-//Recordare//DTD MusicXML 4.0 Partwise//EN" "http://www.musicxml.org/dtds/partwise.dtd">
+<score-partwise version="4.0">
+  <identification>
+    <encoding>
+      <software>Finale v27.4 for Mac</software>
+      <encoding-date>2026-06-30</encoding-date>
+      <supports attribute="new-system" element="print" type="yes" value="yes"/>
+      <supports attribute="new-page" element="print" type="yes" value="yes"/>
+      <supports element="accidental" type="yes"/>
+      <supports element="beam" type="yes"/>
+      <supports element="stem" type="yes"/>
+    </encoding>
+  </identification>
+  <defaults>
+    <scaling>
+      <millimeters>7.2319</millimeters>
+      <tenths>40</tenths>
+    </scaling>
+    <page-layout>
+      <page-height>1545</page-height>
+      <page-width>1194</page-width>
+      <page-margins type="both">
+        <left-margin>70</left-margin>
+        <right-margin>70</right-margin>
+        <top-margin>88</top-margin>
+        <bottom-margin>88</bottom-margin>
+      </page-margins>
+    </page-layout>
+    <system-layout>
+      <system-margins>
+        <left-margin>0</left-margin>
+        <right-margin>0</right-margin>
+      </system-margins>
+      <system-distance>121</system-distance>
+      <top-system-distance>70</top-system-distance>
+    </system-layout>
+    <appearance>
+      <line-width type="stem">0.7487</line-width>
+      <line-width type="beam">5</line-width>
+      <line-width type="staff">0.7487</line-width>
+      <line-width type="light barline">0.7487</line-width>
+      <line-width type="heavy barline">5</line-width>
+      <line-width type="leger">0.7487</line-width>
+      <line-width type="ending">0.7487</line-width>
+      <line-width type="wedge">0.7487</line-width>
+      <line-width type="enclosure">0.7487</line-width>
+      <line-width type="tuplet bracket">0.7487</line-width>
+      <note-size type="grace">60</note-size>
+      <note-size type="cue">60</note-size>
+      <distance type="hyphen">60</distance>
+      <distance type="beam">7.5</distance>
+    </appearance>
+    <music-font font-family="Maestro,engraved" font-size="20.5"/>
+    <word-font font-family="Times New Roman" font-size="10.25"/>
+  </defaults>
+  <part-list>
+    <score-part id="P1">
+      <part-name print-object="no">MusicXML Part</part-name>
+      <group>score</group>
+      <score-instrument id="P1-I1">
+        <instrument-name>SmartMusic SoftSynth 1</instrument-name>
+      </score-instrument>
+      <midi-instrument id="P1-I1">
+        <midi-channel>1</midi-channel>
+        <midi-bank>15489</midi-bank>
+        <midi-program>1</midi-program>
+        <volume>80</volume>
+        <pan>0</pan>
+      </midi-instrument>
+    </score-part>
+  </part-list>
+  <!--=========================================================-->
+  <part id="P1">
+    <measure number="1" width="983">
+      <print>
+        <system-layout>
+          <system-margins>
+            <left-margin>70</left-margin>
+            <right-margin>0</right-margin>
+          </system-margins>
+          <top-system-distance>211</top-system-distance>
+        </system-layout>
+        <measure-numbering multiple-rest-always="no" multiple-rest-range="no" system="only-top">system</measure-numbering>
+      </print>
+      <attributes>
+        <divisions>2</divisions>
+        <key>
+          <fifths>0</fifths>
+          <mode>major</mode>
+        </key>
+        <time>
+          <beats>1 + 2.5</beats>
+          <beat-type>2 + 4</beat-type>
+          <beats>3 + 2</beats>
+          <beat-type>16</beat-type>
+          <beats>1.5 + 5</beats>
+          <beat-type>8 + 16</beat-type>
+        </time>
+        <clef>
+          <sign>G</sign>
+          <line>2</line>
+        </clef>
+      </attributes>
+      <sound tempo="96">
+        <swing>
+          <straight/>
+        </swing>
+      </sound>
+      <note>
+        <rest measure="yes"/>
+        <duration>33</duration>
+        <voice>1</voice>
+      </note>
+      <barline location="right">
+        <bar-style>light-heavy</bar-style>
+      </barline>
+    </measure>
+  </part>
+  <!--=========================================================-->
+</score-partwise>

--- a/src/private/mxtest/corert/CoreRoundtripTest.cpp
+++ b/src/private/mxtest/corert/CoreRoundtripTest.cpp
@@ -127,12 +127,12 @@ const CoreRoundtripRegistrar g_coreRoundtripRegistrar;
 
 } // namespace
 
-// Pinned counts: 831 eligible files, none skipped. Count drift is a failure
+// Pinned counts: 832 eligible files, none skipped. Count drift is a failure
 // even with zero individual fails, so a corpus or version-gate change is a
 // conscious decision, not silent decay. Registered last (registration is
 // discovery order; "zz" keeps it last alphabetically for shuffled runs too).
 TEST_CASE("zz-corert-pinned-counts", "[core-roundtrip]")
 {
-    CHECK(mxtest::corert::discoverInputFiles().size() == 831);
+    CHECK(mxtest::corert::discoverInputFiles().size() == 832);
     CHECK(g_skippedCount == 0);
 }


### PR DESCRIPTION
## Summary

Adds the MusicXML file rpatters1 attached to #268 into a new `data/rpatters1/` corpus directory. It
is a Finale export exercising composite time signatures: multiple beats/beat-type pairs within a
single `<time>` (e.g. `1 + 2.5` over `2 + 4`). mx::core already models these (TimeChoiceGroup holds
OneOrMore<TimeSignatureGroup>), so the core round-trip suite picks up the file with no code change.

Bumps the corert pinned file count 831 -> 832 for the new file (`CoreRoundtripTest.cpp`).

Intentionally not added to the api round-trip allow list (`roundtrip-baseline.txt`), so the api
corpus round-trip skips it. The audit sidecars (`*.features.xml`, `corpus.xml`) are not regenerated
here; refresh with `make audit` if desired.

## Testing

Not built locally; relying on CI:

- core round-trip (corert) runs the new file and must match on round-trip
- the corert pinned-count check expects 832
- the api corpus round-trip skips it (not allow-listed)

## References

- Related #268
