### PR TITLE
fix: cap authored decimal serialization at 8 fractional digits

### DIFF
--- a/src/private/mx/core/Decimal.h
+++ b/src/private/mx/core/Decimal.h
@@ -16,8 +16,11 @@ namespace mx::core
 /// text face for round-trip fidelity (plan §2.6). A Decimal parsed from text
 /// remembers the exact input spelling and serializes it back verbatim; a
 /// Decimal constructed or mutated numerically serializes the shortest
-/// fixed-notation string that round-trips the value. Comparison is numeric:
-/// the text face is presentation, not identity.
+/// fixed-notation string that round-trips the value, capped at 8 fractional
+/// digits (issue #248: the cap keeps client arithmetic noise from being
+/// amplified to 16-17 significant digits; max introduced error 5e-9, below
+/// MX_API_EQUALITY_EPSILON = 1e-8). Comparison is numeric: the text face is
+/// presentation, not identity.
 class Decimal
 {
   public:

--- a/src/private/mx/core/Lexical.cpp
+++ b/src/private/mx/core/Lexical.cpp
@@ -144,42 +144,80 @@ bool musicXmlVersionExceeds(std::string_view declared, std::string_view supporte
 
 std::string formatDouble(double value)
 {
-    // Shortest fixed-notation string that round-trips; never exponent notation
-    // (xs:decimal forbids it). std::to_chars(double) is unavailable on
-    // AppleClang's libc++ below macOS 13.3 / iOS 16.3, and mx targets older, so
-    // reproduce its contract with snprintf: grow the fractional precision until
-    // the printed text parses back to exactly the input. snprintf and strtod
-    // share the active locale's decimal point, so the round-trip check is
-    // locale-agnostic; only the returned spelling is normalized back to '.'.
-    // Large magnitudes round-trip at low precision (their ULP exceeds 1), so the
-    // 340-digit cap is only ever approached by sub-unit values whose fixed form
-    // stays well inside the buffer; MusicXML decimals never reach it.
+    // Bounded shortest fixed-notation string: the shortest spelling that
+    // round-trips the exact double, capped at 8 fractional digits; never
+    // exponent notation (xs:decimal forbids it). std::to_chars(double) is
+    // unavailable on AppleClang's libc++ below macOS 13.3 / iOS 16.3, and mx
+    // targets older, so reproduce the shortest-round-trip contract with
+    // snprintf: grow the fractional precision until the printed text parses
+    // back to exactly the input. snprintf and strtod share the active locale's
+    // decimal point, so the round-trip check is locale-agnostic; only the
+    // returned spelling is normalized back to '.'.
+    //
+    // The 8-digit cap (issue #248) stops client arithmetic noise (a double a
+    // few ULPs from a clean value) from being amplified to 16-17 significant
+    // digits: when no precision within 8 round-trips, the value is rounded to
+    // 8 places and trailing zeros trimmed. The introduced error is at most
+    // 5e-9, below MX_API_EQUALITY_EPSILON (1e-8), so api round-trip equality
+    // is unaffected. Large magnitudes round-trip at precision 0 (their exact
+    // decimal expansion is an integer-digit string), so %.8f of any double
+    // stays well inside the buffer.
     const char decimalPoint = *std::localeconv()->decimal_point;
     char buf[400];
-    for (int precision = 0; precision <= 340; ++precision)
+    int n = 0;
+    bool exact = false;
+    for (int precision = 0; precision <= 8 && !exact; ++precision)
     {
-        const int n = std::snprintf(buf, sizeof(buf), "%.*f", precision, value);
+        n = std::snprintf(buf, sizeof(buf), "%.*f", precision, value);
         if (n <= 0 || static_cast<std::size_t>(n) >= sizeof(buf))
         {
+            n = 0;
             continue;
         }
         if (std::strtod(buf, nullptr) == value)
         {
-            std::string result(buf, static_cast<std::size_t>(n));
-            if (decimalPoint != '.')
-            {
-                for (char &c : result)
-                {
-                    if (c == decimalPoint)
-                    {
-                        c = '.';
-                    }
-                }
-            }
-            return result;
+            exact = true;
         }
     }
-    return "0";
+    if (!exact)
+    {
+        n = std::snprintf(buf, sizeof(buf), "%.8f", value);
+        if (n <= 0 || static_cast<std::size_t>(n) >= sizeof(buf))
+        {
+            return "0";
+        }
+    }
+    std::string result(buf, static_cast<std::size_t>(n));
+    if (decimalPoint != '.')
+    {
+        for (char &c : result)
+        {
+            if (c == decimalPoint)
+            {
+                c = '.';
+            }
+        }
+    }
+    // The capped spelling can carry trailing zeros ("0.12000000"); the exact
+    // search cannot (a shorter precision would have round-tripped first), but
+    // trimming is spelling-safe either way.
+    if (result.find('.') != std::string::npos)
+    {
+        while (!result.empty() && result.back() == '0')
+        {
+            result.pop_back();
+        }
+        if (!result.empty() && result.back() == '.')
+        {
+            result.pop_back();
+        }
+    }
+    // Rounding a tiny negative to 8 places (or printing -0.0) leaves "-0".
+    if (result == "-0")
+    {
+        result = "0";
+    }
+    return result;
 }
 
 } // namespace mx::core

--- a/src/private/mx/core/Lexical.h
+++ b/src/private/mx/core/Lexical.h
@@ -38,8 +38,11 @@ std::string formatInt(int value);
 /// 1.0 had no version attribute; absence means oldest).
 bool musicXmlVersionExceeds(std::string_view declared, std::string_view supported);
 
-/// Shortest fixed-notation decimal that round-trips the double (xs:decimal
-/// forbids exponent notation).
+/// Shortest fixed-notation decimal that round-trips the double, capped at 8
+/// fractional digits (xs:decimal forbids exponent notation). When no spelling
+/// within 8 digits round-trips exactly, the value is rounded to 8 places,
+/// trailing zeros trimmed, and -0 normalized to 0; the introduced error is at
+/// most 5e-9, below MX_API_EQUALITY_EPSILON (1e-8).
 std::string formatDouble(double value);
 
 } // namespace mx::core

--- a/src/private/mx/impl/LayoutFunctions.cpp
+++ b/src/private/mx/impl/LayoutFunctions.cpp
@@ -5,6 +5,7 @@
 #include "mx/impl/LayoutFunctions.h"
 #include "mx/api/ScoreData.h"
 #include "mx/core/Decimal.h"
+#include "mx/core/Lexical.h"
 #include "mx/core/NameToken.h"
 #include "mx/core/generated/AllMarginsGroup.h"
 #include "mx/core/generated/Appearance.h"
@@ -280,7 +281,7 @@ void addAppearance(const api::DefaultsData &inDefaults, core::ScoreHeaderGroup &
         {
             core::OtherAppearance oa;
             oa.setType(appearanceData.appearanceSubType);
-            oa.setValue(std::to_string(appearanceData.value));
+            oa.setValue(core::formatDouble(appearanceData.value));
             appearance.addOtherAppearance(oa);
         }
     }

--- a/src/private/mxtest/core/ValueTest.cpp
+++ b/src/private/mxtest/core/ValueTest.cpp
@@ -10,6 +10,7 @@
 #include "cpul/cpulTestHarness.h"
 
 #include "mx/core/Decimal.h"
+#include "mx/core/Lexical.h"
 #include "mx/core/NameToken.h"
 #include "mx/core/Token.h"
 #include "mx/core/generated/AboveBelow.h"
@@ -89,6 +90,37 @@ TEST(DecimalClampAndTextFace, Values)
     // An in-range parse keeps its exact spelling.
     CHECK_EQUAL(std::string{"1.50"}, PositiveDivisions::parse("1.50").toString());
     CHECK_EQUAL(std::string{"-180"}, RotationDegrees::parse("-700").toString());
+}
+
+TEST(FormatDoubleBoundedShortestRoundTrip, Values)
+{
+    // Issue #248: the numeric face is the shortest fixed-notation round-trip
+    // capped at 8 fractional digits, so client arithmetic noise a few ULPs
+    // from a clean value is not amplified to 16-17 significant digits.
+    CHECK_EQUAL(std::string{"6.096"}, formatDouble(6.095999999999998));
+    CHECK_EQUAL(std::string{"6.096"}, Decimal{6.095999999999998}.toString());
+    // Clean literals are unchanged.
+    CHECK_EQUAL(std::string{"7.2319"}, formatDouble(7.2319));
+    CHECK_EQUAL(std::string{"0.5"}, formatDouble(0.5));
+    CHECK_EQUAL(std::string{"40"}, formatDouble(40.0));
+    CHECK_EQUAL(std::string{"6.096"}, formatDouble(6.096));
+    // A value needing more than 8 places is rounded at 8.
+    CHECK_EQUAL(std::string{"0.33333333"}, formatDouble(1.0 / 3.0));
+    // Capped spellings trim trailing zeros (and any orphaned point).
+    CHECK_EQUAL(std::string{"0.12"}, formatDouble(0.1200000000001));
+    // Magnitudes that round to zero at 8 places emit "0".
+    CHECK_EQUAL(std::string{"0"}, formatDouble(0.0000000001));
+    CHECK_EQUAL(std::string{"0"}, formatDouble(0.0000000024));
+    // Negative zero normalizes, whether authored or produced by rounding.
+    CHECK_EQUAL(std::string{"0"}, formatDouble(-0.0));
+    CHECK_EQUAL(std::string{"0"}, formatDouble(-0.0000000001));
+}
+
+TEST(DecimalParsedTextFaceVerbatim, Values)
+{
+    // The 8-digit cap applies to the numeric face only: a Decimal parsed
+    // from text re-emits its exact input spelling.
+    CHECK_EQUAL(std::string{"6.0959999999999983"}, Decimal::parse("6.0959999999999983").toString());
 }
 
 TEST(ColorStructural, Values)


### PR DESCRIPTION
## Human Summary

This seems like a reasonable fix to the issue at hand. If decimals go out to more than 8 places (which is the epsilon that tests were already using as equivalence, admittedly arbitrarily) then it gets rounded. Seems like this would be far less than a pixel in most cases.

## Summary

Fixes the float over-precision artifact from #248: authoring a `ScoreData` with a double carrying arithmetic noise (e.g. `25.4 * 6.0 / 25.4` producing `6.095999999999998`) emitted that noise verbatim, e.g. `<millimeters>6.095999999999998</millimeters>`.

`formatDouble` in `src/private/mx/core/Lexical.cpp` printed the shortest fixed-notation string that round-trips the exact double — faithfully amplifying client noise to 16-17 significant digits. It now caps the round-trip search at 8 fractional digits: if no spelling within 8 digits reproduces the exact double, the value is rounded to 8 places, trailing zeros are trimmed, and `-0` normalizes to `0`. So `6.095999999999998` serializes as `6.096`, while clean values (`7.2319`, `0.5`, `40`) are unchanged.

Why 8: the maximum introduced error is 5e-9, below `MX_API_EQUALITY_EPSILON` (1e-8) in `ApiCommon.h`, so api round-trip equality is unaffected. Output remains fixed-notation only (xs:decimal forbids exponents) and locale-safe.

This is non-breaking, and the parse -> serialize path is untouched: a `Decimal` parsed from text still re-emits its input spelling verbatim via the preserved text face (`Decimal.h` doc comment updated to state the contract). The cap applies only to the numeric (authoring) face.

Also routes the `<other-appearance>` writer in `src/private/mx/impl/LayoutFunctions.cpp` through `core::formatDouble` instead of `std::to_string`, which produced fixed-6 text like `1.000000`.

## Testing

- [x] New unit tests in `ValueTest.cpp`: noisy double `6.095999999999998` formats as `"6.096"`; clean literals unchanged; values needing more than 8 places are capped and trimmed; magnitudes below 5e-9 emit `"0"`; negative zero normalizes; a parsed `"6.0959999999999983"` still re-emits verbatim
- [x] `make test-cpp-unit` passes (212 assertions in 41 test cases, including the new ones)
- [x] `make test-core-dev` passes (corert corpus round-trip, 833 test cases)
- [x] `make test-api-roundtrip` passes: 121 passed, 0 failed (of 121 pinned) — no baseline movement
- [x] `make check` (format gate) passes

## References

- Closes #248