### PR TITLE
fix: round-trip the credit-words justify attribute

### DIFF
--- a/src/include/mx/api/PageTextData.h
+++ b/src/include/mx/api/PageTextData.h
@@ -34,6 +34,12 @@ class PageTextData
     // `creditTypes` is non-empty, this represents a metadata-only credit
     // (a `<credit>` with no `<credit-words>`).
     std::vector<std::string> creditTypes;
+
+    // The `justify` attribute of `<credit-words>`. `unspecified` means the
+    // attribute is absent. Distinct from the `halign` attribute, which is
+    // carried in `positionData.horizontalAlignmnet`; MusicXML defines both
+    // attributes on `<credit-words>`.
+    HorizontalAlignment justify = HorizontalAlignment::unspecified;
 };
 
 MXAPI_EQUALS_BEGIN(PageTextData)
@@ -47,6 +53,7 @@ if (!areVectorsEqual(lhs.creditTypes, rhs.creditTypes))
     MX_SHOW_UNEQUAL("PageTextData", "creditTypes");
     return false;
 }
+MXAPI_EQUALS_MEMBER(justify)
 MXAPI_EQUALS_END;
 MXAPI_NOT_EQUALS_AND_VECTORS(PageTextData);
 } // namespace api

--- a/src/private/mx/impl/PageTextFunctions.cpp
+++ b/src/private/mx/impl/PageTextFunctions.cpp
@@ -13,6 +13,7 @@
 #include "mx/core/generated/Image.h"
 #include "mx/core/generated/ScoreHeaderGroup.h"
 #include "mx/core/generated/Tenths.h"
+#include "mx/impl/Converter.h"
 #include "mx/impl/FontFunctions.h"
 #include "mx/impl/PositionFunctions.h"
 
@@ -84,6 +85,12 @@ void createCredits(const api::ScoreData &inScoreData, core::ScoreHeaderGroup &ou
             impl::setAttributesFromFontData(p.fontData, words);
             impl::setAttributesFromPositionData(p.positionData, words);
 
+            if (p.justify != api::HorizontalAlignment::unspecified)
+            {
+                const Converter converter;
+                words.setJustify(converter.convert(p.justify));
+            }
+
             core::CreditChoiceGroupChoice groupChoice = core::CreditChoiceGroupChoice::creditWords(words);
             core::CreditChoiceGroup group;
             group.setChoice(groupChoice);
@@ -151,6 +158,12 @@ void createCredits(const core::ScoreHeaderGroup &inHeader, api::ScoreData &outSc
             pageText.text = words.value();
             pageText.positionData = impl::getPositionData(words);
             pageText.fontData = impl::getFontData(words);
+
+            if (words.justify().has_value())
+            {
+                const Converter converter;
+                pageText.justify = converter.convert(*words.justify());
+            }
         }
 
         for (const auto &ct : c.creditType())

--- a/src/private/mxtest/api/CreditRoundTripTest.cpp
+++ b/src/private/mxtest/api/CreditRoundTripTest.cpp
@@ -8,6 +8,7 @@
 #include "cpul/cpulTestHarness.h"
 #include "mx/api/DocumentManager.h"
 #include "mxtest/api/RoundTrip.h"
+#include "mxtest/api/TestHelpers.h"
 
 using namespace std;
 using namespace mx::api;
@@ -109,6 +110,43 @@ TEST(creditRoundTrip, creditImage)
     CHECK_EQUAL(50.0, got.positionData.defaultX);
     CHECK(got.positionData.isDefaultYSpecified);
     CHECK_EQUAL(60.0, got.positionData.defaultY);
+}
+
+TEST(creditRoundTrip, justifySurvives)
+{
+    auto in = makeMinimalScore();
+    PageTextData credit{};
+    credit.text = "Layout options";
+    credit.pageNumber = 1;
+    credit.justify = HorizontalAlignment::center;
+    in.pageTextItems.push_back(credit);
+
+    const auto xml = mxtest::toXml(in);
+    CHECK(xml.find("justify=\"center\"") != std::string::npos);
+
+    const auto out = mxtest::roundTrip(in);
+
+    REQUIRE(out.pageTextItems.size() == 1);
+    const auto &got = out.pageTextItems.at(0);
+    CHECK_EQUAL("Layout options", got.text);
+    CHECK(HorizontalAlignment::center == got.justify);
+}
+
+TEST(creditRoundTrip, justifyAbsentStaysAbsent)
+{
+    auto in = makeMinimalScore();
+    PageTextData credit{};
+    credit.text = "no justify here";
+    credit.pageNumber = 1;
+    in.pageTextItems.push_back(credit);
+
+    const auto xml = mxtest::toXml(in);
+    CHECK(xml.find("justify=") == std::string::npos);
+
+    const auto out = mxtest::roundTrip(in);
+
+    REQUIRE(out.pageTextItems.size() == 1);
+    CHECK(HorizontalAlignment::unspecified == out.pageTextItems.at(0).justify);
 }
 
 #endif

--- a/src/private/mxtest/api/roundtrip-baseline.txt
+++ b/src/private/mxtest/api/roundtrip-baseline.txt
@@ -191,3 +191,10 @@ lysuite/ly46c_Midmeasure_Clef.xml
 # repeat's times attribute survives the round-trip.
 lysuite/ly45a_SimpleRepeat.xml
 lysuite/ly45c_RepeatMultipleTimes.xml
+
+# Unblocked by #273 (credit-words justify round-trip). PageTextData had no
+# field for the justify attribute, so the reader dropped it and the writer
+# never emitted it. Added PageTextData::justify (HorizontalAlignment,
+# unspecified = absent) wired through PageTextFunctions; this file's only
+# remaining divergence was the dropped attribute.
+lysuite/ly52a_PageLayout.xml


### PR DESCRIPTION
## Human Summary

Looks like a straightforward and correct fix for a missing attribute to me.

## Summary

The api round-trip dropped the `justify` attribute of `<credit-words>`: `PageTextData` had no field for it, so the impl reader never captured it and the writer never emitted it.

- `PageTextData` (src/include/mx/api/PageTextData.h) gains a `justify` field using the existing `HorizontalAlignment` enum, with `unspecified` meaning the attribute is absent — the same idiom as its neighboring halign field (`positionData.horizontalAlignmnet`). justify is kept separate from halign because MusicXML defines both attributes on `<credit-words>`.
- `PageTextFunctions.cpp` reads `justify` off the core `FormattedTextID` and writes it back, through the existing `Converter` halignMap (`core::LeftCenterRight` <-> `api::HorizontalAlignment`). No new enum and no new converter entries.

Non-breaking: one new defaulted field plus its equality line.

## Testing

- [x] New unit tests in CreditRoundTripTest.cpp: `justify="center"` survives the api round trip and appears in the serialized XML; an absent justify stays absent (no attribute emitted)
- [x] Verified on the issue's repro: `lysuite/ly52a_PageLayout.xml` now surfaces `justify=center` in `PageTextData` and re-emits `justify="center"` — the file now survives the strict DOM compare entirely and is pinned in the baseline (121 -> 122 files, `make test-api-roundtrip`: 122 passed, 0 failed)
- [x] The other two candidate files (foundsuite Adagio and Fugue K.546, musetrainer Canon_in_D) no longer diverge at `credit-words@justify`; they remain blocked by unrelated gaps, so they are not pinned
- [x] Full unit suite passes (4465 assertions in 348 test cases), `make fmt` / `make check` clean

## References

- Closes #273