### PR TITLE
feat: support cross-staff notes in the api

### DIFF
--- a/src/include/mx/api/NoteData.h
+++ b/src/include/mx/api/NoteData.h
@@ -131,6 +131,17 @@ class NoteData
     Notehead notehead;
     PitchData pitchData; // step, alter, octave, accidental, etc
     int userRequestedVoiceNumber;
+
+    // The zero-based index of the staff on which this note is displayed, for the rare case
+    // that it differs from the staff that contains the note (cross-staff notation, e.g. a
+    // beamed piano run or a chord that dips onto the other staff). The note stays in its
+    // home staff's voice - containment still governs voice membership, timing, and beam
+    // adjacency - and the writer emits this value in the note's <staff> element instead of
+    // the containing staff's number. Leave it empty for normal notes; only set it to the
+    // index of another existing staff in the same part. The reader sets it only for notes
+    // whose <staff> diverges from their beam group's or chord's home staff.
+    std::optional<int> crossStaffIndex;
+
     Stem stem;
     PositionData stemPositionData;
 
@@ -174,6 +185,7 @@ MXAPI_EQUALS_MEMBER(isGrace)
 MXAPI_EQUALS_MEMBER(isCue)
 MXAPI_EQUALS_MEMBER(pitchData)
 MXAPI_EQUALS_MEMBER(userRequestedVoiceNumber)
+MXAPI_EQUALS_MEMBER(crossStaffIndex)
 MXAPI_EQUALS_MEMBER(stem)
 MXAPI_EQUALS_MEMBER(stemPositionData)
 MXAPI_EQUALS_MEMBER(tickTimePosition)

--- a/src/private/mx/impl/MeasureReader.cpp
+++ b/src/private/mx/impl/MeasureReader.cpp
@@ -110,7 +110,8 @@ int getFiguredBassStaffIndex(const MeasureCursor &cursor, const api::MeasureData
 MeasureReader::MeasureReader(const core::PartwiseMeasure &inPartwiseMeasureRef, const MeasureCursor &cursor,
                              const MeasureCursor &previousMeasureCursor)
     : myMutex{}, myPartwiseMeasure{inPartwiseMeasureRef}, myConverter{}, myOutMeasureData{}, myCurrentCursor{cursor},
-      myPreviousMeasureCursor{previousMeasureCursor}, myHistory{}
+      myPreviousMeasureCursor{previousMeasureCursor}, myHistory{}, myCrossStaffHomes{},
+      myPreviousNoteBucketStaffIndex{-1}
 {
     HistoryRecord initialCursorRecord;
     initialCursorRecord.amount = 0;
@@ -160,6 +161,10 @@ std::pair<api::MeasureData, std::optional<api::TransposeData>> MeasureReader::ge
     addStavesToOutMeasure();
     parseTimeSignature();
 
+    myCrossStaffHomes.clear();
+    myPreviousNoteBucketStaffIndex = -1;
+    scanForCrossStaffBeamGroups();
+
     const auto mdcSpan = myPartwiseMeasure.musicData();
     auto iter = mdcSpan.begin();
     const auto endIter = mdcSpan.end();
@@ -167,6 +172,7 @@ std::pair<api::MeasureData, std::optional<api::TransposeData>> MeasureReader::ge
     for (; iter != endIter; ++iter)
     {
         const auto &mdc = *iter;
+        const auto mdcIndex = static_cast<size_t>(iter - mdcSpan.begin());
 
         // incredibly, we need to know if the note following this one has a 'chord' tag
         // otherwise we don't know whether or not the current note if part of a chord,
@@ -185,7 +191,7 @@ std::pair<api::MeasureData, std::optional<api::TransposeData>> MeasureReader::ge
             nextNotePtr = &peekAheadAtNextNoteIter->asNote();
         }
 
-        auto maybeTranspose = parseMusicDataChoice(mdc, nextNotePtr);
+        auto maybeTranspose = parseMusicDataChoice(mdc, nextNotePtr, mdcIndex);
         if (myCurrentCursor.isFirstMeasureInPart && maybeTranspose.has_value())
         {
             transpose = maybeTranspose;
@@ -233,7 +239,8 @@ void MeasureReader::parseTimeSignature() const
 
 // see .h file for explanation of the return value
 std::optional<api::TransposeData> MeasureReader::parseMusicDataChoice(const core::MusicDataChoice &mdc,
-                                                                      const core::Note *nextNotePtr) const
+                                                                      const core::Note *nextNotePtr,
+                                                                      size_t inMdcIndex) const
 {
     // if we are parsing the first measure of the part, then we need to return transpose information
     std::optional<api::TransposeData> transpose;
@@ -241,7 +248,7 @@ std::optional<api::TransposeData> MeasureReader::parseMusicDataChoice(const core
     if (mdc.isNote())
     {
         myCurrentCursor.isBackupInProgress = false;
-        parseNote(mdc.asNote(), nextNotePtr);
+        parseNote(mdc.asNote(), nextNotePtr, inMdcIndex);
     }
     else if (mdc.isBackup())
     {
@@ -317,7 +324,7 @@ std::optional<api::TransposeData> MeasureReader::parseMusicDataChoice(const core
     return transpose;
 }
 
-void MeasureReader::parseNote(const core::Note &inMxNote, const core::Note *nextNotePtr) const
+void MeasureReader::parseNote(const core::Note &inMxNote, const core::Note *nextNotePtr, size_t inMdcIndex) const
 {
     bool isNextNotePartOfAChord = false;
 
@@ -339,7 +346,37 @@ void MeasureReader::parseNote(const core::Note &inMxNote, const core::Note *next
         noteDataStaffIndex = 0;
     }
 
-    myCurrentCursor.staffIndex = noteDataStaffIndex;
+    // cross-staff notation (issue #289): a note whose beam group or chord spans staves is
+    // filed into the unit's home staff so the unit stays adjacent in one voice, and the
+    // divergent <staff> value is preserved in NoteData::crossStaffIndex
+    int bucketStaffIndex = noteDataStaffIndex;
+
+    if (noteReader.getIsChord() && myPreviousNoteBucketStaffIndex >= 0)
+    {
+        bucketStaffIndex = myPreviousNoteBucketStaffIndex;
+    }
+    else
+    {
+        const auto crossStaffHome = myCrossStaffHomes.find(inMdcIndex);
+        if (crossStaffHome != myCrossStaffHomes.cend())
+        {
+            bucketStaffIndex = crossStaffHome->second;
+        }
+    }
+
+    const bool isBucketSane =
+        bucketStaffIndex >= 0 && static_cast<size_t>(bucketStaffIndex) < myOutMeasureData.staves.size();
+
+    if (!isBucketSane)
+    {
+        bucketStaffIndex = noteDataStaffIndex;
+    }
+    else if (bucketStaffIndex != noteDataStaffIndex)
+    {
+        noteData.crossStaffIndex = noteDataStaffIndex;
+    }
+
+    myCurrentCursor.staffIndex = bucketStaffIndex;
 
     bool isThisNotePartOfAChord = noteData.isChord || isNextNotePartOfAChord;
     noteData.isChord = isThisNotePartOfAChord;
@@ -349,9 +386,140 @@ void MeasureReader::parseNote(const core::Note &inMxNote, const core::Note *next
         advanceTickTimePosition(noteData.durationData.durationTimeTicks, "note");
     }
 
-    MX_ASSERT(noteDataStaffIndex >= 0);
-    MX_ASSERT(static_cast<size_t>(noteDataStaffIndex) < myOutMeasureData.staves.size());
+    MX_ASSERT(bucketStaffIndex >= 0);
+    MX_ASSERT(static_cast<size_t>(bucketStaffIndex) < myOutMeasureData.staves.size());
+    myPreviousNoteBucketStaffIndex = bucketStaffIndex;
     insertNoteData(std::move(noteData), myCurrentCursor.staffIndex, myCurrentCursor.voiceIndex);
+}
+
+void MeasureReader::scanForCrossStaffBeamGroups() const
+{
+    if (myCurrentCursor.getNumStaves() < 2)
+    {
+        return;
+    }
+
+    // an open level-1 beam group in one voice: the musicData indices of its non-chord,
+    // non-grace member notes and the set of staves those members name
+    struct OpenGroup
+    {
+        std::vector<size_t> memberIndices;
+        std::set<int> staves;
+        int beginStaffIndex = 0;
+    };
+
+    std::map<int, OpenGroup> openGroups; // key: backup-delimited voice ordinal
+    std::map<int, int> stickyHomes;      // voice ordinal -> the voice's current home staff
+    int voiceOrdinal = 0;
+    bool isBackupInProgress = false;
+
+    // a properly closed group that names more than one staff is a cross-staff group; its
+    // home is the staff the voice was on when the group began (or, when the group is the
+    // voice's first sighting, the staff of the group's first note)
+    const auto closeGroup = [this, &stickyHomes](int inVoiceOrdinal, const OpenGroup &inGroup) {
+        if (inGroup.staves.size() > 1)
+        {
+            const auto sticky = stickyHomes.find(inVoiceOrdinal);
+            const int home = sticky == stickyHomes.cend() ? inGroup.beginStaffIndex : sticky->second;
+            for (const auto memberIndex : inGroup.memberIndices)
+            {
+                myCrossStaffHomes[memberIndex] = home;
+            }
+            stickyHomes[inVoiceOrdinal] = home;
+        }
+        else if (!inGroup.staves.empty())
+        {
+            stickyHomes[inVoiceOrdinal] = *inGroup.staves.cbegin();
+        }
+    };
+
+    const auto mdcSpan = myPartwiseMeasure.musicData();
+
+    for (size_t mdcIndex = 0; mdcIndex < mdcSpan.size(); ++mdcIndex)
+    {
+        const auto &mdc = mdcSpan[mdcIndex];
+
+        if (mdc.isBackup())
+        {
+            // mirror parseBackup's voice-ordinal rule
+            if (!isBackupInProgress)
+            {
+                ++voiceOrdinal;
+            }
+            isBackupInProgress = true;
+            continue;
+        }
+
+        if (mdc.isListening())
+        {
+            // mirror parseMusicDataChoice, which skips listening without touching the
+            // backup-in-progress flag
+            continue;
+        }
+
+        if (!mdc.isNote())
+        {
+            isBackupInProgress = false;
+            if (mdc.isForward())
+            {
+                // a beam group cannot contain a time gap
+                openGroups.erase(voiceOrdinal);
+            }
+            continue;
+        }
+
+        isBackupInProgress = false;
+        const NoteReader reader{mdc.asNote()};
+
+        if (reader.getIsGrace() || reader.getIsChord())
+        {
+            // grace notes beam among themselves; <chord> members follow the bucket of the
+            // note they chord with (decided in parseNote), not the beam group scan
+            continue;
+        }
+
+        int wireStaffIndex = reader.getStaffNumber() - 1;
+
+        if (wireStaffIndex < 0)
+        {
+            wireStaffIndex = 0;
+        }
+
+        const auto &coreBeams = reader.getBeams();
+        const auto beamOne = coreBeams.empty() ? api::Beam::unspecified : myConverter.convert(coreBeams.front());
+
+        if (beamOne == api::Beam::begin)
+        {
+            OpenGroup group;
+            group.beginStaffIndex = wireStaffIndex;
+            group.memberIndices.push_back(mdcIndex);
+            group.staves.insert(wireStaffIndex);
+            openGroups[voiceOrdinal] = std::move(group);
+            continue;
+        }
+
+        const auto openGroupIter = openGroups.find(voiceOrdinal);
+        const bool continuesGroup =
+            (beamOne == api::Beam::extend || beamOne == api::Beam::end) && openGroupIter != openGroups.cend();
+
+        if (continuesGroup)
+        {
+            openGroupIter->second.memberIndices.push_back(mdcIndex);
+            openGroupIter->second.staves.insert(wireStaffIndex);
+
+            if (beamOne == api::Beam::end)
+            {
+                closeGroup(voiceOrdinal, openGroupIter->second);
+                openGroups.erase(openGroupIter);
+            }
+            continue;
+        }
+
+        // an unbeamed note (or an orphan or hooked level-1 beam value) interrupts any open
+        // group and moves the voice's home to its own staff
+        openGroups.erase(voiceOrdinal);
+        stickyHomes[voiceOrdinal] = wireStaffIndex;
+    }
 }
 
 void MeasureReader::parseBackup(const core::Backup &inMxBackup) const
@@ -362,6 +530,9 @@ void MeasureReader::parseBackup(const core::Backup &inMxBackup) const
     }
 
     myCurrentCursor.isBackupInProgress = true;
+
+    // a chord cannot straddle a timeline jump
+    myPreviousNoteBucketStaffIndex = -1;
     const int backupAmount = myCurrentCursor.convertDurationToGlobalTickScale(inMxBackup.duration());
     advanceTickTimePosition(-1 * backupAmount, "backup");
 
@@ -374,6 +545,8 @@ void MeasureReader::parseBackup(const core::Backup &inMxBackup) const
 
 void MeasureReader::parseForward(const core::Forward &inMxForward) const
 {
+    // a chord cannot straddle a timeline jump
+    myPreviousNoteBucketStaffIndex = -1;
     const int forwardAmount = myCurrentCursor.convertDurationToGlobalTickScale(inMxForward.duration());
     advanceTickTimePosition(forwardAmount, "forward");
 }

--- a/src/private/mx/impl/MeasureReader.h
+++ b/src/private/mx/impl/MeasureReader.h
@@ -8,6 +8,7 @@
 #include "mx/impl/Converter.h"
 #include "mx/impl/MeasureCursor.h"
 
+#include <map>
 #include <mutex>
 
 namespace mx
@@ -66,6 +67,16 @@ class MeasureReader
 
     mutable std::vector<HistoryRecord> myHistory;
 
+    // cross-staff bookkeeping (issue #289): for each note that belongs to a level-1 beam
+    // group spanning more than one <staff> value, the staff bucket that should contain it,
+    // keyed by the note's index in the measure's musicData sequence; built by
+    // scanForCrossStaffBeamGroups before the parse loop runs
+    mutable std::map<size_t, int> myCrossStaffHomes;
+
+    // the staff bucket that received the previous note; <chord> members follow it so a
+    // chord cannot be split across staff buckets; -1 means "no previous note"
+    mutable int myPreviousNoteBucketStaffIndex;
+
   private:
     void addStavesToOutMeasure() const;
     void parseTimeSignature() const;
@@ -76,9 +87,10 @@ class MeasureReader
     /// this function (as far as I can tell), the transpose info is returned up the call
     /// stack if measure index is zero and time index is zero.
     std::optional<api::TransposeData> parseMusicDataChoice(const core::MusicDataChoice &mdc,
-                                                           const core::Note *nextNotePtr) const;
+                                                           const core::Note *nextNotePtr, size_t inMdcIndex) const;
 
-    void parseNote(const core::Note &inMxNote, const core::Note *nextNotePtr) const;
+    void parseNote(const core::Note &inMxNote, const core::Note *nextNotePtr, size_t inMdcIndex) const;
+    void scanForCrossStaffBeamGroups() const;
     void parseBackup(const core::Backup &inMxBackup) const;
     void parseForward(const core::Forward &inMxForward) const;
     void parseDirection(const core::Direction &inDirection) const;

--- a/src/private/mx/impl/NoteFunctions.cpp
+++ b/src/private/mx/impl/NoteFunctions.cpp
@@ -72,7 +72,6 @@ api::NoteData NoteFunctions::parseNote() const
     }
 
     myOutNoteData.pitchData.octave = reader.getOctave();
-    // myOutNoteData.staffIndex = reader.getStaffNumber() - 1;
     myOutNoteData.userRequestedVoiceNumber = reader.getVoiceNumber();
 
     myOutNoteData.notehead = converter.convert(reader.getNoteheadValue());

--- a/src/private/mx/impl/NoteWriter.cpp
+++ b/src/private/mx/impl/NoteWriter.cpp
@@ -391,7 +391,15 @@ void NoteWriter::setFullNoteTypeChoice() const
 
 void NoteWriter::setStaffAndVoice() const
 {
-    if (myCursor.getNumStaves() > 1 && myCursor.staffIndex >= 0)
+    const bool isCrossStaff = myNoteData.crossStaffIndex.has_value() && *myNoteData.crossStaffIndex >= 0;
+
+    if (isCrossStaff)
+    {
+        // cross-staff note: the containing staff governs voice membership and stream
+        // position, but the displayed staff comes from the override (NoteData.h)
+        myOutNote.setStaff(*myNoteData.crossStaffIndex + 1);
+    }
+    else if (myCursor.getNumStaves() > 1 && myCursor.staffIndex >= 0)
     {
         myOutNote.setStaff(myCursor.staffIndex + 1);
     }

--- a/src/private/mxtest/api/CrossStaffApiTest.cpp
+++ b/src/private/mxtest/api/CrossStaffApiTest.cpp
@@ -1,0 +1,354 @@
+// MusicXML Class Library
+// Copyright (c) by Matthew James Briggs
+// Distributed under the MIT License
+
+#include "mxtest/control/CompileControl.h"
+#ifdef MX_COMPILE_API_TESTS
+
+#include "cpul/cpulTestHarness.h"
+#include "mx/api/DocumentManager.h"
+#include "mxtest/api/RoundTrip.h"
+#include "mxtest/api/TestHelpers.h"
+
+using namespace std;
+using namespace mx::api;
+using namespace mxtest;
+
+namespace crossStaffApiTest
+{
+inline size_t countOccurrences(const std::string &haystack, const std::string &needle)
+{
+    size_t count = 0;
+    for (auto pos = haystack.find(needle); pos != std::string::npos; pos = haystack.find(needle, pos + 1))
+    {
+        ++count;
+    }
+    return count;
+}
+
+// two staves, one voice on staff 1 whose beamed run dips onto staff 2 for its middle two
+// notes, plus a whole rest on staff 2
+inline ScoreData makeCrossStaffScore()
+{
+    ScoreData score;
+    score.ticksPerQuarter = 2;
+    score.parts.emplace_back();
+    auto &part = score.parts.back();
+    part.measures.emplace_back();
+    auto &measure = part.measures.back();
+    measure.staves.emplace_back();
+    measure.staves.emplace_back();
+
+    auto &notes = measure.staves.at(0).voices[0].notes;
+
+    for (int i = 0; i < 4; ++i)
+    {
+        NoteData note;
+        note.pitchData.step = Step::c;
+        note.pitchData.octave = 5;
+        note.tickTimePosition = i;
+        note.durationData.durationName = DurationName::eighth;
+        note.durationData.durationTimeTicks = 1;
+        notes.push_back(note);
+    }
+
+    notes.at(0).beams = {Beam::begin};
+    notes.at(1).beams = {Beam::extend};
+    notes.at(2).beams = {Beam::extend};
+    notes.at(3).beams = {Beam::end};
+    notes.at(1).crossStaffIndex = 1;
+    notes.at(2).crossStaffIndex = 1;
+
+    NoteData rest;
+    rest.isRest = true;
+    rest.tickTimePosition = 0;
+    rest.durationData.durationName = DurationName::whole;
+    rest.durationData.durationTimeTicks = 8;
+    measure.staves.at(1).voices[0].notes.push_back(rest);
+
+    return score;
+}
+} // namespace crossStaffApiTest
+
+TEST(writeCrossStaffOverride, CrossStaff)
+{
+    const auto score = crossStaffApiTest::makeCrossStaffScore();
+    const auto xml = mxtest::toXml(score);
+
+    // the two overridden notes plus the staff-2 rest
+    CHECK_EQUAL(3, crossStaffApiTest::countOccurrences(xml, "<staff>2</staff>"));
+
+    // the two non-overridden beamed notes
+    CHECK_EQUAL(2, crossStaffApiTest::countOccurrences(xml, "<staff>1</staff>"));
+
+    // the beamed run stays adjacent in the stream: no forward, and only the single backup
+    // that rewinds to write the staff-2 rest
+    CHECK_EQUAL(0, crossStaffApiTest::countOccurrences(xml, "<forward>"));
+    CHECK_EQUAL(1, crossStaffApiTest::countOccurrences(xml, "<backup>"));
+}
+
+T_END;
+
+TEST(roundTripCrossStaffOverride, CrossStaff)
+{
+    const auto score = crossStaffApiTest::makeCrossStaffScore();
+    const auto out = mxtest::roundTrip(score);
+
+    REQUIRE(out.parts.size() == 1);
+    const auto &measure = out.parts.at(0).measures.at(0);
+    REQUIRE(measure.staves.size() == 2);
+    REQUIRE(measure.staves.at(0).voices.size() == 1);
+    const auto &notes = measure.staves.at(0).voices.at(0).notes;
+    REQUIRE(notes.size() == 4);
+
+    CHECK(!notes.at(0).crossStaffIndex.has_value());
+    REQUIRE(notes.at(1).crossStaffIndex.has_value());
+    CHECK_EQUAL(1, *notes.at(1).crossStaffIndex);
+    REQUIRE(notes.at(2).crossStaffIndex.has_value());
+    CHECK_EQUAL(1, *notes.at(2).crossStaffIndex);
+    CHECK(!notes.at(3).crossStaffIndex.has_value());
+
+    CHECK_EQUAL(0, notes.at(0).tickTimePosition);
+    CHECK_EQUAL(1, notes.at(1).tickTimePosition);
+    CHECK_EQUAL(2, notes.at(2).tickTimePosition);
+    CHECK_EQUAL(3, notes.at(3).tickTimePosition);
+
+    REQUIRE(measure.staves.at(1).voices.size() == 1);
+    const auto &staffTwoNotes = measure.staves.at(1).voices.at(0).notes;
+    REQUIRE(staffTwoNotes.size() == 1);
+    CHECK(staffTwoNotes.at(0).isRest);
+    CHECK(!staffTwoNotes.at(0).crossStaffIndex.has_value());
+}
+
+T_END;
+
+namespace crossStaffApiTest
+{
+constexpr const char *const xmlHeader = R"(<score-partwise version="3.0">
+  <part-list>
+    <score-part id="P1">
+      <part-name>MusicXML Part</part-name>
+    </score-part>
+  </part-list>
+  <part id="P1">
+    <measure number="1">
+      <attributes>
+        <divisions>2</divisions>
+        <staves>2</staves>
+        <clef number="1">
+          <sign>G</sign>
+          <line>2</line>
+        </clef>
+        <clef number="2">
+          <sign>F</sign>
+          <line>4</line>
+        </clef>
+      </attributes>
+)";
+
+constexpr const char *const xmlFooter = R"(    </measure>
+  </part>
+</score-partwise>
+)";
+
+inline std::string makeNoteXml(const char *step, int octave, const char *staff, const char *beam)
+{
+    std::string xml;
+    xml += "      <note>\n        <pitch>\n          <step>";
+    xml += step;
+    xml += "</step>\n          <octave>";
+    xml += std::to_string(octave);
+    xml += "</octave>\n        </pitch>\n        <duration>1</duration>\n        <voice>1</voice>\n";
+    xml += "        <type>eighth</type>\n        <staff>";
+    xml += staff;
+    xml += "</staff>\n";
+    if (beam)
+    {
+        xml += "        <beam number=\"1\">";
+        xml += beam;
+        xml += "</beam>\n";
+    }
+    xml += "      </note>\n";
+    return xml;
+}
+} // namespace crossStaffApiTest
+
+// the ly43d measure 1 shape: a voice living on staff 2 with two beam groups that cross to
+// staff 1; the second group begins on the foreign staff, which exercises the sticky home
+TEST(readStickyHomeCrossStaffBeams, CrossStaff)
+{
+    using namespace crossStaffApiTest;
+    std::string xml = xmlHeader;
+    xml += makeNoteXml("A", 3, "2", "begin");
+    xml += makeNoteXml("E", 4, "1", "continue");
+    xml += makeNoteXml("A", 3, "2", "continue");
+    xml += makeNoteXml("E", 4, "1", "end");
+    xml += makeNoteXml("C", 5, "1", "begin");
+    xml += makeNoteXml("E", 4, "1", "continue");
+    xml += makeNoteXml("A", 3, "2", "continue");
+    xml += makeNoteXml("B", 4, "2", "end");
+    xml += xmlFooter;
+
+    const auto score = mxtest::fromXml(xml);
+    REQUIRE(score.parts.size() == 1);
+    const auto &measure = score.parts.at(0).measures.at(0);
+    REQUIRE(measure.staves.size() == 2);
+
+    // the whole voice stays on its home staff (staff 2)
+    CHECK(measure.staves.at(0).voices.empty());
+    REQUIRE(measure.staves.at(1).voices.size() == 1);
+    const auto &notes = measure.staves.at(1).voices.at(0).notes;
+    REQUIRE(notes.size() == 8);
+
+    // every note whose <staff> named staff 1 carries the override; the rest do not
+    const std::vector<bool> expectCross{false, true, false, true, true, true, false, false};
+    for (size_t i = 0; i < notes.size(); ++i)
+    {
+        if (expectCross.at(i))
+        {
+            REQUIRE(notes.at(i).crossStaffIndex.has_value());
+            CHECK_EQUAL(0, *notes.at(i).crossStaffIndex);
+        }
+        else
+        {
+            CHECK(!notes.at(i).crossStaffIndex.has_value());
+        }
+        CHECK_EQUAL(static_cast<int>(i), notes.at(i).tickTimePosition);
+    }
+}
+
+T_END;
+
+TEST(readCrossStaffChord, CrossStaff)
+{
+    using namespace crossStaffApiTest;
+    std::string xml = xmlHeader;
+    xml += R"(      <note>
+        <pitch>
+          <step>C</step>
+          <octave>3</octave>
+        </pitch>
+        <duration>2</duration>
+        <voice>1</voice>
+        <type>quarter</type>
+        <staff>2</staff>
+      </note>
+      <note>
+        <chord/>
+        <pitch>
+          <step>E</step>
+          <octave>4</octave>
+        </pitch>
+        <duration>2</duration>
+        <voice>1</voice>
+        <type>quarter</type>
+        <staff>1</staff>
+      </note>
+)";
+    xml += xmlFooter;
+
+    const auto score = mxtest::fromXml(xml);
+    const auto &measure = score.parts.at(0).measures.at(0);
+    REQUIRE(measure.staves.size() == 2);
+
+    // the chord member follows its chord's first note into staff 2 with the override set
+    CHECK(measure.staves.at(0).voices.empty());
+    REQUIRE(measure.staves.at(1).voices.size() == 1);
+    const auto &notes = measure.staves.at(1).voices.at(0).notes;
+    REQUIRE(notes.size() == 2);
+    CHECK(notes.at(0).isChord);
+    CHECK(notes.at(1).isChord);
+    CHECK(!notes.at(0).crossStaffIndex.has_value());
+    REQUIRE(notes.at(1).crossStaffIndex.has_value());
+    CHECK_EQUAL(0, *notes.at(1).crossStaffIndex);
+    CHECK_EQUAL(notes.at(0).tickTimePosition, notes.at(1).tickTimePosition);
+}
+
+T_END;
+
+TEST(readUnbeamedStaffChangeIsStructural, CrossStaff)
+{
+    using namespace crossStaffApiTest;
+    std::string xml = xmlHeader;
+    xml += R"(      <note>
+        <pitch>
+          <step>C</step>
+          <octave>5</octave>
+        </pitch>
+        <duration>2</duration>
+        <voice>1</voice>
+        <type>quarter</type>
+        <staff>1</staff>
+      </note>
+      <note>
+        <pitch>
+          <step>C</step>
+          <octave>3</octave>
+        </pitch>
+        <duration>2</duration>
+        <voice>1</voice>
+        <type>quarter</type>
+        <staff>2</staff>
+      </note>
+)";
+    xml += xmlFooter;
+
+    const auto score = mxtest::fromXml(xml);
+    const auto &measure = score.parts.at(0).measures.at(0);
+    REQUIRE(measure.staves.size() == 2);
+
+    // no beam, no chord: the notes bucket to the staves their <staff> values name
+    REQUIRE(measure.staves.at(0).voices.size() == 1);
+    REQUIRE(measure.staves.at(1).voices.size() == 1);
+    const auto &staffOneNotes = measure.staves.at(0).voices.at(0).notes;
+    const auto &staffTwoNotes = measure.staves.at(1).voices.at(0).notes;
+    REQUIRE(staffOneNotes.size() == 1);
+    REQUIRE(staffTwoNotes.size() == 1);
+    CHECK(!staffOneNotes.at(0).crossStaffIndex.has_value());
+    CHECK(!staffTwoNotes.at(0).crossStaffIndex.has_value());
+}
+
+T_END;
+
+TEST(readPureForeignStaffGroupNotRelocated, CrossStaff)
+{
+    using namespace crossStaffApiTest;
+    std::string xml = xmlHeader;
+    xml += R"(      <note>
+        <pitch>
+          <step>C</step>
+          <octave>5</octave>
+        </pitch>
+        <duration>2</duration>
+        <voice>1</voice>
+        <type>quarter</type>
+        <staff>1</staff>
+      </note>
+)";
+    xml += makeNoteXml("C", 3, "2", "begin");
+    xml += makeNoteXml("D", 3, "2", "continue");
+    xml += makeNoteXml("E", 3, "2", "continue");
+    xml += makeNoteXml("F", 3, "2", "end");
+    xml += xmlFooter;
+
+    const auto score = mxtest::fromXml(xml);
+    const auto &measure = score.parts.at(0).measures.at(0);
+    REQUIRE(measure.staves.size() == 2);
+
+    // a beam group entirely on one staff never relocates, even though the voice started
+    // on the other staff
+    REQUIRE(measure.staves.at(0).voices.size() == 1);
+    REQUIRE(measure.staves.at(1).voices.size() == 1);
+    CHECK_EQUAL(1, measure.staves.at(0).voices.at(0).notes.size());
+    const auto &groupNotes = measure.staves.at(1).voices.at(0).notes;
+    REQUIRE(groupNotes.size() == 4);
+
+    for (const auto &note : groupNotes)
+    {
+        CHECK(!note.crossStaffIndex.has_value());
+    }
+}
+
+T_END;
+
+#endif

--- a/src/private/mxtest/api/roundtrip-baseline.txt
+++ b/src/private/mxtest/api/roundtrip-baseline.txt
@@ -210,3 +210,11 @@ synthetic/cancel.location.3.0.xml
 # write. This synthetic fixture pins all four combinations (normal, cue, grace,
 # grace-cue) through the strict round-trip.
 synthetic/grace-cue.4.0.xml
+
+# Unblocked by #289 (cross-staff notes). A beamed run or chord that dips onto the
+# other staff used to be split across staff buckets, so the writer reordered the
+# notes and broke beam adjacency. The reader now files such a group into its
+# voice's home staff and preserves the divergent <staff> values in
+# NoteData::crossStaffIndex; the writer emits the override, keeping the stream
+# order and every <staff> value byte-faithful.
+lysuite/ly43d_MultiStaff_StaffChange.xml


### PR DESCRIPTION
## Human Summary

This seems fairly clean. If the note is to be displayed on a different staff from the one it is contained in, populate the std::optional crossStaffIndex.

## Summary

Cross-staff notes (a beamed run or chord that dips onto the other staff of a multi-staff part) could not be created through the api, and reading one split the beam group across staff buckets, so the writer reordered the measure and broke beam adjacency.

`NoteData::crossStaffIndex` (`std::optional<int>`) is the zero-based index of the staff on which the note is displayed, for the rare case that it differs from the staff that contains the note. Containment still governs voice membership, timing, and beam adjacency; the writer emits the override in the note's staff element instead of the containing staff's number. Authors set one field; everything else is unchanged.

On the read side, a per-measure pre-scan decides which notes are cross-staff before any bucketing happens:

- A level-1 beam group that properly closes and names more than one staff value is filed, whole, into its voice's home staff - the staff the voice was on when the group began - and each member whose staff value diverges from that home gets `crossStaffIndex`. This handles groups that begin on the foreign staff (ly43d measure 1).
- A chord member always follows the bucket of the note it chords with, so a chord can no longer be split across staves (ly43d measure 2 has chords with members on both staves).
- A beam group that stays on one staff never relocates, and single-staff parts skip the scan entirely, so behavior for non-crossing files is unchanged.

The design follows the containment principle rather than adding a second source of truth for ownership: the field overrides only where the note is displayed, never which staff/voice owns it. Also removed a long-dead commented-out `staffIndex` line in `NoteFunctions.cpp` that this feature supersedes.

## Testing

- [x] New `CrossStaffApiTest.cpp`: authoring writes the override with beam adjacency intact (no forward, single backup); round-trip preserves `crossStaffIndex`; reader relocates the ly43d sticky-home shape and cross-staff chords; unbeamed staff changes and pure foreign-staff groups still bucket structurally with no override
- [x] Full unit suite passes (4622 assertions in 363 test cases)
- [x] `lysuite/ly43d_MultiStaff_StaffChange.xml` now round-trips byte-faithfully and is pinned in `roundtrip-baseline.txt`
- [x] Regression gate passes 125/125 pinned files
- [x] Discovery over the full corpus: 140 -> 141 PASS, zero newly-failing files

## References

- Closes #289
- Related #275 (staff dropped triage; the corpus's 13 cross-staff files now serialize their note streams in source order, though most have other blockers)