### PR TITLE
chore: pin already-passing lyric corpus files to the api roundtrip allow list

### DIFF
--- a/src/private/mxtest/api/roundtrip-baseline.txt
+++ b/src/private/mxtest/api/roundtrip-baseline.txt
@@ -210,3 +210,23 @@ synthetic/cancel.location.3.0.xml
 # write. This synthetic fixture pins all four combinations (normal, cue, grace,
 # grace-cue) through the strict round-trip.
 synthetic/grace-cue.4.0.xml
+
+# Catch-up: already passing since lyric support (#290 "Write lyricdata") landed,
+# but never pinned. No code change here -- discovery mode confirms these
+# round-trip losslessly today; this commit only grows the pass-list to match.
+lysuite/ly01c_Pitches_NoVoiceElement.xml
+lysuite/ly46a_Barlines.xml
+lysuite/ly61a_Lyrics.xml
+lysuite/ly61b_MultipleLyrics.xml
+lysuite/ly61c_Lyrics_Pianostaff.xml
+lysuite/ly61e_Lyrics_Chords.xml
+lysuite/ly61g_Lyrics_NameNumber.xml
+lysuite/ly61h_Lyrics_BeamsMelismata.xml
+lysuite/ly61k_Lyrics_SpannersExtenders.xml
+lysuite/ly99b_Lyrics_BeamsMelismata_IgnoreBeams.xml
+musuite/testLyricsVoice2a.xml
+musuite/testLyricsVoice2b.xml
+musuite/testLyricsVoice2b_ref.xml
+musuite/testNoteAttributes3.xml
+musuite/testNumberedLyrics.xml
+musuite/testNumberedLyrics_ref.xml


### PR DESCRIPTION
## Human Summary

We had some already-passing corpus files that had not been added to the `mx::api` allow list.

## Summary

Lyric support (`#290`, "Write lyricdata") already made 16 corpus files round-trip losslessly
through `mx::api`, but the pinned pass-list (`roundtrip-baseline.txt`) was never grown to match.
Discovery mode currently reports 140 passing files against a 124-file baseline; this commit pins
the 16 that were already passing so future regressions on them are caught.

No source changes. This is the first of a stack of PRs working through the corpus round-trip
worklist; it establishes a clean, up-to-date base before the next PR (a real fix) builds on top.

## Testing

- [x] `make test-api-roundtrip` (regression mode): 140 passed, 0 failed (of 140 pinned)
- [x] `make check` (fmt-check): clean

## References

- Related to `#290` (lyric support that unblocked these files)


---
_Generated by [Claude Code](https://claude.ai/code/session_01BABa1xPR45JRAsU1ZF82BB)_