### PR TITLE
fix: round-trip the note-level print-object attribute

### DIFF
--- a/src/private/mx/impl/NoteWriter.cpp
+++ b/src/private/mx/impl/NoteWriter.cpp
@@ -83,6 +83,10 @@ core::Note NoteWriter::getNote(bool isStartOfChord) const
     setMiscData();
     NotationsWriter notationsWriter{myNoteData, myCursor, myScoreWriter};
     impl::setAttributesFromPositionData(myNoteData.positionData, myOutNote);
+    if (myNoteData.printData.printObject != api::Bool::unspecified)
+    {
+        myOutNote.setPrintObject(myConverter.convert(myNoteData.printData.printObject));
+    }
 
     // The tie <notations> come first (as in the old writer, where they were
     // created during setNoteChoiceAndFullNoteGroup).

--- a/src/private/mxtest/api/NoteDataTest.cpp
+++ b/src/private/mxtest/api/NoteDataTest.cpp
@@ -1375,6 +1375,47 @@ TEST(noteheadOtherRoundtrip, NoteData)
     CHECK(outNote.notehead == Notehead::other);
 }
 
+TEST(printObjectNo, NoteData)
+{
+    ScoreData score;
+    score.parts.emplace_back();
+    auto &part = score.parts.back();
+    part.measures.emplace_back();
+    auto &measure = part.measures.back();
+    measure.staves.emplace_back();
+    auto &staff = measure.staves.back();
+    auto &voice = staff.voices[0];
+
+    NoteData note;
+    note.isRest = true;
+    note.isMeasureRest = true;
+    note.durationData.durationTimeTicks = score.ticksPerQuarter * 4;
+    note.printData.printObject = Bool::no;
+    voice.notes.push_back(note);
+
+    auto &mgr = DocumentManager::getInstance();
+    const auto r1 = mgr.createFromScore(score);
+    REQUIRE(r1.ok());
+    auto docId = r1.value();
+    std::stringstream ss;
+    mgr.writeToStream(docId, ss);
+    mgr.destroyDocument(docId);
+    const std::string xml = ss.str();
+    CHECK(xml.find(R"(print-object="no")") != std::string::npos);
+
+    std::istringstream iss{xml};
+    const auto r2 = mgr.createFromStream(iss);
+    REQUIRE(r2.ok());
+    docId = r2.value();
+    const auto rd = mgr.getData(docId);
+    REQUIRE(rd.ok());
+    const auto outScore = rd.value();
+    mgr.destroyDocument(docId);
+
+    const auto &outNote = outScore.parts.back().measures.back().staves.back().voices.at(0).notes.back();
+    CHECK(outNote.printData.printObject == Bool::no);
+}
+
 T_END;
 
 #endif

--- a/src/private/mxtest/api/roundtrip-baseline.txt
+++ b/src/private/mxtest/api/roundtrip-baseline.txt
@@ -210,3 +210,23 @@ synthetic/cancel.location.3.0.xml
 # write. This synthetic fixture pins all four combinations (normal, cue, grace,
 # grace-cue) through the strict round-trip.
 synthetic/grace-cue.4.0.xml
+
+# Catch-up: already passing since lyric support (#290 "Write lyricdata") landed,
+# but never pinned. No code change here -- discovery mode confirms these
+# round-trip losslessly today; this commit only grows the pass-list to match.
+lysuite/ly01c_Pitches_NoVoiceElement.xml
+lysuite/ly46a_Barlines.xml
+lysuite/ly61a_Lyrics.xml
+lysuite/ly61b_MultipleLyrics.xml
+lysuite/ly61c_Lyrics_Pianostaff.xml
+lysuite/ly61e_Lyrics_Chords.xml
+lysuite/ly61g_Lyrics_NameNumber.xml
+lysuite/ly61h_Lyrics_BeamsMelismata.xml
+lysuite/ly61k_Lyrics_SpannersExtenders.xml
+lysuite/ly99b_Lyrics_BeamsMelismata_IgnoreBeams.xml
+musuite/testLyricsVoice2a.xml
+musuite/testLyricsVoice2b.xml
+musuite/testLyricsVoice2b_ref.xml
+musuite/testNoteAttributes3.xml
+musuite/testNumberedLyrics.xml
+musuite/testNumberedLyrics_ref.xml

--- a/src/private/mxtest/api/roundtrip-baseline.txt
+++ b/src/private/mxtest/api/roundtrip-baseline.txt
@@ -230,3 +230,12 @@ musuite/testLyricsVoice2b_ref.xml
 musuite/testNoteAttributes3.xml
 musuite/testNumberedLyrics.xml
 musuite/testNumberedLyrics_ref.xml
+
+# Unblocked by note-level print-object round-trip: NoteData::printData.printObject
+# (already declared, wired on read via NoteFunctions::getPrintData) was never
+# applied on write. NoteWriter now emits print-object on <note> when specified,
+# matching the existing ClefData/ChordData::printObject precedent.
+musuite/testEmptyMeasure_ref.xml
+musuite/testEmptyVoice1_ref.xml
+musuite/testMeasureLength_ref.xml
+musuite/testUnusualDurations_ref.xml


### PR DESCRIPTION
## Human Summary

Simple addition of a missing attribute that unlocks `mx::api` round trip tests.

## Summary

`NoteData::printData.printObject` (a `PrintData`, same tri-state `Bool` as `ClefData`/`ChordData`)
was already declared and already read on parse (`NoteFunctions::parseNote` calls
`impl::getPrintData(myNote)`), but `NoteWriter` never applied it back to the core `Note` on write.
A source `<note print-object="no">` (commonly used for the invisible whole-measure rest in an
empty measure/voice) silently lost the attribute on round-trip.

`NoteWriter::getNote` now emits `print-object` on `<note>` whenever `printData.printObject` is
specified, mirroring the existing `ClefData`/`ChordData`/lyric `print-object` handling elsewhere in
the writer.

Stacked on `#306` (pure allow-list catch-up, no source changes) so this diff is just the real fix.

## Testing

- [x] New `printObjectNo_NoteData` test (`NoteDataTest.cpp`): writes and round-trips a
      `print-object="no"` rest, asserting both the serialized XML and the re-parsed value
- [x] `make test`: all pass (4554 assertions in 358 test cases, plus the three examples)
- [x] `make test-api-roundtrip`: 144 passed, 0 failed (of 144 pinned; 4 newly unlocked)
- [x] `make check` (fmt-check): clean

## References

- No tracking issue existed for this gap; found via corpus round-trip discovery/classification.
