### PR TITLE
fix: make lyric syllabic absent-able (LyricSyllabic::unspecified)

### DIFF
--- a/src/include/mx/api/LyricData.h
+++ b/src/include/mx/api/LyricData.h
@@ -12,8 +12,11 @@ namespace mx
 {
 namespace api
 {
+// unspecified -> <syllabic> is omitted (a plain, non-hyphenated lyric word).
+// single/begin/end/middle -> <syllabic> is written verbatim.
 enum class LyricSyllabic
 {
+    unspecified,
     single,
     begin,
     end,
@@ -24,7 +27,7 @@ class LyricData
 {
   public:
     LyricData()
-        : text{}, verseNumber{}, verseName{}, syllabic{LyricSyllabic::single}, hasExtend{false}, positionData{},
+        : text{}, verseNumber{}, verseName{}, syllabic{LyricSyllabic::unspecified}, hasExtend{false}, positionData{},
           printData{}
     {
     }

--- a/src/private/mx/impl/NoteReader.cpp
+++ b/src/private/mx/impl/NoteReader.cpp
@@ -490,16 +490,11 @@ void NoteReader::setLyric()
         case core::LyricChoice::Kind::lyricTextGroup: {
             const auto &textGroup = textChoice.asLyricTextGroup();
 
-            core::Syllabic syllabic = core::Syllabic::single();
-            if (textGroup.syllabic().has_value())
-            {
-                syllabic = *textGroup.syllabic();
-            }
-
             lyricData.text = getLyricDisplayText(textGroup);
             lyricData.printData = getLyricPrintData(lyric, &textGroup.text());
 
-            lyricData.syllabic = convertLyricSyllabic(syllabic);
+            lyricData.syllabic = textGroup.syllabic().has_value() ? convertLyricSyllabic(*textGroup.syllabic())
+                                                                  : api::LyricSyllabic::unspecified;
             lyricData.hasExtend = textGroup.extend().has_value();
             myLyrics.emplace_back(lyricData);
             myHasLyric = true;

--- a/src/private/mx/impl/NoteWriter.cpp
+++ b/src/private/mx/impl/NoteWriter.cpp
@@ -83,6 +83,10 @@ core::Note NoteWriter::getNote(bool isStartOfChord) const
     setMiscData();
     NotationsWriter notationsWriter{myNoteData, myCursor, myScoreWriter};
     impl::setAttributesFromPositionData(myNoteData.positionData, myOutNote);
+    if (myNoteData.printData.printObject != api::Bool::unspecified)
+    {
+        myOutNote.setPrintObject(myConverter.convert(myNoteData.printData.printObject));
+    }
 
     // The tie <notations> come first (as in the old writer, where they were
     // created during setNoteChoiceAndFullNoteGroup).

--- a/src/private/mx/impl/NoteWriter.cpp
+++ b/src/private/mx/impl/NoteWriter.cpp
@@ -43,6 +43,8 @@ core::Syllabic convertLyricSyllabicForNoteWriter(api::LyricSyllabic value)
 {
     switch (value)
     {
+    case api::LyricSyllabic::unspecified:
+        break;
     case api::LyricSyllabic::single:
         return core::Syllabic::single();
     case api::LyricSyllabic::begin:
@@ -491,7 +493,10 @@ void NoteWriter::setLyrics() const
             setAttributesFromFontData(lyricData.printData.fontData, text);
 
             core::LyricTextGroup textGroup;
-            textGroup.setSyllabic(convertLyricSyllabicForNoteWriter(lyricData.syllabic));
+            if (lyricData.syllabic != api::LyricSyllabic::unspecified)
+            {
+                textGroup.setSyllabic(convertLyricSyllabicForNoteWriter(lyricData.syllabic));
+            }
             textGroup.setText(std::move(text));
             if (lyricData.hasExtend)
             {

--- a/src/private/mxtest/api/LyricDataTest.cpp
+++ b/src/private/mxtest/api/LyricDataTest.cpp
@@ -130,4 +130,37 @@ TEST(lyricsRoundTripThroughApi, LyricData)
 
 T_END;
 
+TEST(unspecifiedSyllabicIsOmitted, LyricData)
+{
+    ScoreData score;
+    score.ticksPerQuarter = 4;
+    score.parts.emplace_back();
+    auto &part = score.parts.back();
+    part.measures.emplace_back();
+    auto &measure = part.measures.back();
+    measure.staves.emplace_back();
+    auto &staff = measure.staves.back();
+    auto &voice = staff.voices[0];
+    voice.notes.emplace_back();
+    auto &note = voice.notes.back();
+    note.durationData.durationTimeTicks = 4;
+    note.durationData.durationName = DurationName::quarter;
+    note.durationData.isDurationNameSpecified = true;
+
+    LyricData lyric;
+    lyric.text = "plain";
+    CHECK(lyric.syllabic == LyricSyllabic::unspecified);
+    note.lyrics.emplace_back(lyric);
+
+    const auto xml = mxtest::toXml(score);
+    auto xmlNote = mxtest::api::lyric_data_test::firstNote(xml);
+    CHECK(xmlNote.child("lyric").child("syllabic").empty());
+
+    const auto out = mxtest::fromXml(xml);
+    const auto &outNote = out.parts.at(0).measures.at(0).staves.at(0).voices.at(0).notes.at(0);
+    CHECK(outNote.lyrics.at(0).syllabic == LyricSyllabic::unspecified);
+}
+
+T_END;
+
 #endif

--- a/src/private/mxtest/api/NoteDataTest.cpp
+++ b/src/private/mxtest/api/NoteDataTest.cpp
@@ -1375,6 +1375,47 @@ TEST(noteheadOtherRoundtrip, NoteData)
     CHECK(outNote.notehead == Notehead::other);
 }
 
+TEST(printObjectNo, NoteData)
+{
+    ScoreData score;
+    score.parts.emplace_back();
+    auto &part = score.parts.back();
+    part.measures.emplace_back();
+    auto &measure = part.measures.back();
+    measure.staves.emplace_back();
+    auto &staff = measure.staves.back();
+    auto &voice = staff.voices[0];
+
+    NoteData note;
+    note.isRest = true;
+    note.isMeasureRest = true;
+    note.durationData.durationTimeTicks = score.ticksPerQuarter * 4;
+    note.printData.printObject = Bool::no;
+    voice.notes.push_back(note);
+
+    auto &mgr = DocumentManager::getInstance();
+    const auto r1 = mgr.createFromScore(score);
+    REQUIRE(r1.ok());
+    auto docId = r1.value();
+    std::stringstream ss;
+    mgr.writeToStream(docId, ss);
+    mgr.destroyDocument(docId);
+    const std::string xml = ss.str();
+    CHECK(xml.find(R"(print-object="no")") != std::string::npos);
+
+    std::istringstream iss{xml};
+    const auto r2 = mgr.createFromStream(iss);
+    REQUIRE(r2.ok());
+    docId = r2.value();
+    const auto rd = mgr.getData(docId);
+    REQUIRE(rd.ok());
+    const auto outScore = rd.value();
+    mgr.destroyDocument(docId);
+
+    const auto &outNote = outScore.parts.back().measures.back().staves.back().voices.at(0).notes.back();
+    CHECK(outNote.printData.printObject == Bool::no);
+}
+
 T_END;
 
 #endif

--- a/src/private/mxtest/api/roundtrip-baseline.txt
+++ b/src/private/mxtest/api/roundtrip-baseline.txt
@@ -239,3 +239,13 @@ musuite/testEmptyMeasure_ref.xml
 musuite/testEmptyVoice1_ref.xml
 musuite/testMeasureLength_ref.xml
 musuite/testUnusualDurations_ref.xml
+
+# Unblocked by LyricSyllabic::unspecified: <syllabic> is optional in MusicXML
+# (a plain, non-hyphenated lyric word omits it), but LyricData::syllabic had no
+# absent state, so the writer force-wrote <syllabic>single</syllabic> onto every
+# lyric whose source omitted it. LyricSyllabic gains unspecified (default);
+# NoteReader now maps a missing <syllabic> to it and NoteWriter omits the
+# element when it is set.
+lysuite/ly22c_Noteheads_Chords.xml
+lysuite/ly61i_Lyrics_Chords.xml
+lysuite/ly71f_AllChordTypes.xml

--- a/src/private/mxtest/api/roundtrip-baseline.txt
+++ b/src/private/mxtest/api/roundtrip-baseline.txt
@@ -210,3 +210,23 @@ synthetic/cancel.location.3.0.xml
 # write. This synthetic fixture pins all four combinations (normal, cue, grace,
 # grace-cue) through the strict round-trip.
 synthetic/grace-cue.4.0.xml
+
+# Catch-up: already passing since lyric support (#290 "Write lyricdata") landed,
+# but never pinned. No code change here -- discovery mode confirms these
+# round-trip losslessly today; this commit only grows the pass-list to match.
+lysuite/ly01c_Pitches_NoVoiceElement.xml
+lysuite/ly46a_Barlines.xml
+lysuite/ly61a_Lyrics.xml
+lysuite/ly61b_MultipleLyrics.xml
+lysuite/ly61c_Lyrics_Pianostaff.xml
+lysuite/ly61e_Lyrics_Chords.xml
+lysuite/ly61g_Lyrics_NameNumber.xml
+lysuite/ly61h_Lyrics_BeamsMelismata.xml
+lysuite/ly61k_Lyrics_SpannersExtenders.xml
+lysuite/ly99b_Lyrics_BeamsMelismata_IgnoreBeams.xml
+musuite/testLyricsVoice2a.xml
+musuite/testLyricsVoice2b.xml
+musuite/testLyricsVoice2b_ref.xml
+musuite/testNoteAttributes3.xml
+musuite/testNumberedLyrics.xml
+musuite/testNumberedLyrics_ref.xml

--- a/src/private/mxtest/api/roundtrip-baseline.txt
+++ b/src/private/mxtest/api/roundtrip-baseline.txt
@@ -230,3 +230,12 @@ musuite/testLyricsVoice2b_ref.xml
 musuite/testNoteAttributes3.xml
 musuite/testNumberedLyrics.xml
 musuite/testNumberedLyrics_ref.xml
+
+# Unblocked by note-level print-object round-trip: NoteData::printData.printObject
+# (already declared, wired on read via NoteFunctions::getPrintData) was never
+# applied on write. NoteWriter now emits print-object on <note> when specified,
+# matching the existing ClefData/ChordData::printObject precedent.
+musuite/testEmptyMeasure_ref.xml
+musuite/testEmptyVoice1_ref.xml
+musuite/testMeasureLength_ref.xml
+musuite/testUnusualDurations_ref.xml


### PR DESCRIPTION
## Human Summary

Looks like a straight forward fix. We lacked a way to suppress the emission of a `<syllabic>` element, so an `unspecified` selector was added to the enum. Seems like the correct thing to do.

## Summary

`<syllabic>` is optional in MusicXML: a plain, non-hyphenated lyric word omits it entirely.
`LyricData::syllabic` had no absent state (default was `single`), so `NoteWriter` force-wrote
`<syllabic>single</syllabic>` onto every lyric whose source omitted the element -- a spurious
addition (`add:syllabic`) on round-trip, breaking chord/lyric files that never had the element to
begin with.

`LyricSyllabic` gains `unspecified` as its first enumerator and default, following the
`ClefData`/`PartData::printObject`-style tri-state convention (`AGENTS.md`: absent-able enums get an
`unspecified` first value, never `std::optional<SomeEnum>`). `NoteReader` now maps a missing
`<syllabic>` to `unspecified` instead of defaulting to `single`; `NoteWriter` omits the element when
the value is `unspecified` instead of always writing something.

This is a breaking change: `LyricSyllabic`'s ordinal values shift (new first member), and code
relying on a default-constructed `LyricData::syllabic` reading as `single` will now see
`unspecified`. Any caller who wants an explicit single-syllable lyric already had to set
`syllabic = LyricSyllabic::single` (the enum's meaning for the other three values is unchanged), so
the rework is a small, mechanical adjustment.

Stacked on `#307` (note-level print-object fix).

## Testing

- [x] New `unspecifiedSyllabicIsOmitted` test (`LyricDataTest.cpp`): a lyric with no syllabic set
      round-trips with no `<syllabic>` element and reads back as `unspecified`
- [x] Existing `lyricsWriteToMusicXml` / `lyricsRoundTripThroughApi` tests (explicit `begin`) still pass
- [x] `make test`: all pass (4557 assertions in 359 test cases, plus the three examples)
- [x] `make test-api-roundtrip`: 147 passed, 0 failed (of 147 pinned; 3 newly unlocked)
- [x] `make fmt` / `make check`: clean

## References

- No tracking issue existed for this gap; found via corpus round-trip discovery/classification.


---
_Generated by [Claude Code](https://claude.ai/code/session_01BABa1xPR45JRAsU1ZF82BB)_