### PR TITLE
fix: round-trip wedge color presence (WedgeStart::isColorSpecified)

### DIFF
--- a/src/include/mx/api/ScoreData.h
+++ b/src/include/mx/api/ScoreData.h
@@ -61,10 +61,11 @@ class ScoreData
     std::string lyricist;
     std::string arranger;
     std::string publisher;
-    std::string copyright;
 
+    std::string copyright;
     // The <rights> type attribute for `copyright` (above).
     std::optional<std::string> copyrightType;
+
     EncodingData encoding;
     std::vector<PageTextData> pageTextItems;
 

--- a/src/include/mx/api/WedgeData.h
+++ b/src/include/mx/api/WedgeData.h
@@ -28,11 +28,12 @@ struct WedgeStart
     double spread;
     LineData lineData;
     PositionData positionData;
+    bool isColorSpecified;
     ColorData colorData;
 
     WedgeStart()
         : numberLevel{NUMBER_LEVEL_UNSPECIFIED}, wedgeType{WedgeType::unspecified}, isSpreadSpecified{false},
-          spread{0.0}, lineData{}, positionData{}, colorData{}
+          spread{0.0}, lineData{}, positionData{}, isColorSpecified{false}, colorData{}
     {
     }
 };
@@ -56,6 +57,7 @@ MXAPI_EQUALS_MEMBER(isSpreadSpecified)
 MXAPI_EQUALS_MEMBER(spread)
 MXAPI_EQUALS_MEMBER(lineData)
 MXAPI_EQUALS_MEMBER(positionData)
+MXAPI_EQUALS_MEMBER(isColorSpecified)
 MXAPI_EQUALS_MEMBER(colorData)
 MXAPI_EQUALS_END;
 MXAPI_NOT_EQUALS_AND_VECTORS(WedgeStart);

--- a/src/private/mx/impl/DirectionReader.cpp
+++ b/src/private/mx/impl/DirectionReader.cpp
@@ -498,7 +498,8 @@ void DirectionReader::parseWedge(const core::DirectionType &directionType)
     const double spread = isSpreadSpecified ? static_cast<double>(wedge.spread()->value().value()) : 0.0;
     auto positionData = getPositionData(wedge);
     auto lineData = getLineData(wedge);
-    auto colorData = getColor(wedge);
+    const bool isColorSpecified = wedge.color().has_value();
+    const auto colorData = isColorSpecified ? getColor(wedge) : api::ColorData{};
 
     if (wedge.type().tag() == core::WedgeType::Tag::stop)
     {
@@ -533,6 +534,7 @@ void DirectionReader::parseWedge(const core::DirectionType &directionType)
         start.wedgeType = wedgeType;
         start.positionData = positionData;
         start.lineData = lineData;
+        start.isColorSpecified = isColorSpecified;
         start.colorData = colorData;
         myOutDirectionData.wedgeStarts.emplace_back(std::move(start));
         appendOrderedComponent(api::DirectionComponentKind::wedgeStart,

--- a/src/private/mx/impl/DirectionWriter.cpp
+++ b/src/private/mx/impl/DirectionWriter.cpp
@@ -296,7 +296,10 @@ void DirectionWriter::emitWedgeStart(const api::WedgeStart &wedgeStart, core::Di
 
     setAttributesFromPositionData(wedgeStart.positionData, wedge);
     setAttributesFromLineData(wedgeStart.lineData, wedge);
-    setAttributesFromColorData(wedgeStart.colorData, wedge);
+    if (wedgeStart.isColorSpecified)
+    {
+        setAttributesFromColorData(wedgeStart.colorData, wedge);
+    }
     core::DirectionType dt{};
     dt.setChoice(core::DirectionTypeChoice::wedge(wedge));
     addDirectionType(std::move(dt), direction);

--- a/src/private/mxtest/api/DirectionDataTest.cpp
+++ b/src/private/mxtest/api/DirectionDataTest.cpp
@@ -314,4 +314,45 @@ TEST(RehearsalUnspecifiedEnclosureNoPhantomAttribute, DirectionData)
 
 T_END;
 
+// Verify that a wedge with no color set (isColorSpecified == false) does not emit a color
+// attribute in the serialized XML, and that the field round-trips as unspecified.
+TEST(WedgeUnspecifiedColorNoPhantomAttribute, DirectionData)
+{
+    ScoreData oscore;
+    oscore.ticksPerQuarter = 10;
+    oscore.parts.emplace_back();
+    auto &opart = oscore.parts.back();
+    opart.measures.emplace_back();
+    auto &omeasure = opart.measures.back();
+    omeasure.staves.emplace_back();
+    auto &ostaff = omeasure.staves.back();
+    auto &ovoice = ostaff.voices[0];
+
+    NoteData onote{};
+    onote.tickTimePosition = 0;
+    onote.durationData.durationTimeTicks = 10;
+    onote.durationData.durationName = DurationName::quarter;
+    ovoice.notes.push_back(onote);
+
+    WedgeStart wedge;
+    wedge.wedgeType = WedgeType::crescendo;
+    // isColorSpecified left at default (false) -- must not appear in XML or round-trip as white
+
+    DirectionData directionData;
+    directionData.tickTimePosition = 0;
+    directionData.wedgeStarts.push_back(wedge);
+    ostaff.directions.push_back(directionData);
+
+    const auto xml = mxtest::toXml(oscore);
+    CHECK(xml.find("color") == std::string::npos);
+
+    const auto rscore = mxtest::roundTrip(oscore);
+    REQUIRE(rscore.parts.front().measures.front().staves.front().directions.size() == 1);
+    REQUIRE(rscore.parts.front().measures.front().staves.front().directions.front().wedgeStarts.size() == 1);
+    CHECK(
+        !rscore.parts.front().measures.front().staves.front().directions.front().wedgeStarts.front().isColorSpecified);
+}
+
+T_END;
+
 #endif

--- a/src/private/mxtest/api/roundtrip-baseline.txt
+++ b/src/private/mxtest/api/roundtrip-baseline.txt
@@ -257,3 +257,10 @@ lysuite/ly71f_AllChordTypes.xml
 lysuite/ly90a_Compressed_MusicXML.xml
 musuite/testLines2.xml
 musuite/testLines2_ref.xml
+
+# Unblocked by WedgeStart::isColorSpecified: unlike Rehearsal/Segno/Words/Coda
+# (which all guard color on presence), the wedge reader/writer path always
+# read/wrote a color, defaulting to white when the source's <wedge> had none.
+# WedgeStart gains isColorSpecified (matching the other four), so an unspecified
+# wedge color is no longer force-written.
+musuite/testWedge1.xml


### PR DESCRIPTION
## Human Summary

A missing, presumably rarely used, attribute that unlocks some corpus files for `mx::api` round-trip fidelity testing.

## Summary

`RehearsalData`/`SegnoData`/`WordsData`/`CodaData` all guard their color attribute on an
`isColorSpecified` bool, only reading/writing a color when the source actually declared one.
`WedgeStart` was the one outlier: `DirectionReader::parseWedge` always called `getColor(wedge)` and
`DirectionWriter::emitWedgeStart` always applied the result, so a source `<wedge>` with no color
attribute round-tripped with a spurious `color="#FFFFFF"` (`ColorData`'s default-constructed white)
-- an `attr:wedge@color` addition.

Added `WedgeStart::isColorSpecified`, matching the other four direction types exactly: the reader
sets it from `wedge.color().has_value()`, the writer only emits the attribute when it is true.

Stacked on `#309` (copyright rights-type fix).

## Testing

- [x] New `WedgeUnspecifiedColorNoPhantomAttribute` test (`DirectionDataTest.cpp`), mirroring the
      existing `RehearsalUnspecifiedEnclosureNoPhantomAttribute` pattern
- [x] `make test`: all pass (4578 assertions in 363 test cases, plus the three examples)
- [x] `make test-api-roundtrip`: 151 passed, 0 failed (of 151 pinned; 1 newly unlocked)
- [x] `make fmt` / `make check`: clean

## References

- No tracking issue existed for this gap; found via corpus round-trip discovery/classification.


---
_Generated by [Claude Code](https://claude.ai/code/session_01BABa1xPR45JRAsU1ZF82BB)_