### PR TITLE
feat: round-trip strong-accent direction (up/down)

### DIFF
--- a/src/include/mx/api/MarkData.h
+++ b/src/include/mx/api/MarkData.h
@@ -19,7 +19,9 @@ enum class MarkType
 
     // articulations
     accent,
-    strongAccent, // marcato
+    strongAccent, // marcato, direction unspecified
+    strongAccentUp,
+    strongAccentDown,
     staccato,
     tenuto,
     detachedLegato, // tenuto with dot

--- a/src/private/mx/api/MarkData.cpp
+++ b/src/private/mx/api/MarkData.cpp
@@ -99,13 +99,14 @@ bool isMarkArpeggiate(MarkType markType)
 
 bool isMarkArticulation(MarkType markType)
 {
-    return (markType == MarkType::accent) || (markType == MarkType::strongAccent) || (markType == MarkType::staccato) ||
-           (markType == MarkType::tenuto) || (markType == MarkType::detachedLegato) ||
-           (markType == MarkType::staccatissimo) || (markType == MarkType::spiccato) || (markType == MarkType::scoop) ||
-           (markType == MarkType::plop) || (markType == MarkType::doit) || (markType == MarkType::falloff) ||
-           (markType == MarkType::breathMark) || (markType == MarkType::caesura) || (markType == MarkType::stress) ||
-           (markType == MarkType::unstress) || (markType == MarkType::softAccent) ||
-           (markType == MarkType::otherArticulation);
+    return (markType == MarkType::accent) || (markType == MarkType::strongAccent) ||
+           (markType == MarkType::strongAccentUp) || (markType == MarkType::strongAccentDown) ||
+           (markType == MarkType::staccato) || (markType == MarkType::tenuto) ||
+           (markType == MarkType::detachedLegato) || (markType == MarkType::staccatissimo) ||
+           (markType == MarkType::spiccato) || (markType == MarkType::scoop) || (markType == MarkType::plop) ||
+           (markType == MarkType::doit) || (markType == MarkType::falloff) || (markType == MarkType::breathMark) ||
+           (markType == MarkType::caesura) || (markType == MarkType::stress) || (markType == MarkType::unstress) ||
+           (markType == MarkType::softAccent) || (markType == MarkType::otherArticulation);
 }
 
 bool isMarkOrnament(MarkType markType)

--- a/src/private/mx/impl/ArticulationsFunctions.cpp
+++ b/src/private/mx/impl/ArticulationsFunctions.cpp
@@ -45,8 +45,14 @@ void ArticulationsFunctions::parseArticulation(const core::ArticulationsChoice &
         break;
     }
     case core::ArticulationsChoice::Kind::strongAccent: {
-        parseMarkDataAttributes(inArticulation.asStrongAccent(), outMark);
+        const auto &strongAccent = inArticulation.asStrongAccent();
+        parseMarkDataAttributes(strongAccent, outMark);
         outMark.name = "strong-accent";
+        if (strongAccent.type().has_value())
+        {
+            outMark.markType = strongAccent.type()->tag() == core::UpDown::Tag::up ? api::MarkType::strongAccentUp
+                                                                                   : api::MarkType::strongAccentDown;
+        }
         break;
     }
     case core::ArticulationsChoice::Kind::staccato: {

--- a/src/private/mx/impl/Converter.cpp
+++ b/src/private/mx/impl/Converter.cpp
@@ -161,6 +161,8 @@ const Converter::EnumMap<core::CSSFontSize, api::CssSize> Converter::cssMap = {
 const Converter::EnumMap<core::ArticulationsChoice::Kind, api::MarkType> Converter::articulationsMap = {
     {core::ArticulationsChoice::Kind::accent, api::MarkType::accent},
     {core::ArticulationsChoice::Kind::strongAccent, api::MarkType::strongAccent},
+    {core::ArticulationsChoice::Kind::strongAccent, api::MarkType::strongAccentUp},
+    {core::ArticulationsChoice::Kind::strongAccent, api::MarkType::strongAccentDown},
     {core::ArticulationsChoice::Kind::staccato, api::MarkType::staccato},
     {core::ArticulationsChoice::Kind::tenuto, api::MarkType::tenuto},
     {core::ArticulationsChoice::Kind::detachedLegato, api::MarkType::detachedLegato},
@@ -1476,17 +1478,6 @@ core::ArticulationsChoice::Kind Converter::convertArticulation(api::MarkType val
 api::MarkType Converter::convertArticulation(core::ArticulationsChoice::Kind value) const
 {
     return findApiItem(articulationsMap, api::MarkType::unspecified, value);
-}
-
-bool Converter::isArticulation(api::MarkType value) const
-{
-    return value == api::MarkType::accent || value == api::MarkType::strongAccent || value == api::MarkType::staccato ||
-           value == api::MarkType::tenuto || value == api::MarkType::detachedLegato ||
-           value == api::MarkType::staccatissimo || value == api::MarkType::spiccato || value == api::MarkType::scoop ||
-           value == api::MarkType::plop || value == api::MarkType::doit || value == api::MarkType::falloff ||
-           value == api::MarkType::breathMark || value == api::MarkType::caesura || value == api::MarkType::stress ||
-           value == api::MarkType::unstress || value == api::MarkType::softAccent ||
-           value == api::MarkType::otherArticulation;
 }
 
 core::DynamicsChoice::Kind Converter::convertDynamic(api::MarkType value) const

--- a/src/private/mx/impl/Converter.h
+++ b/src/private/mx/impl/Converter.h
@@ -105,7 +105,6 @@ class Converter
 
     core::ArticulationsChoice::Kind convertArticulation(api::MarkType value) const;
     api::MarkType convertArticulation(core::ArticulationsChoice::Kind value) const;
-    bool isArticulation(api::MarkType value) const;
 
     core::DynamicsChoice::Kind convertDynamic(api::MarkType value) const;
     api::MarkType convertDynamic(core::DynamicsChoice::Kind value) const;

--- a/src/private/mx/impl/NotationsWriter.cpp
+++ b/src/private/mx/impl/NotationsWriter.cpp
@@ -399,7 +399,7 @@ core::NotationsChoice NotationsWriter::makeTechnicalNotationsChoice() const
 
 void NotationsWriter::addArticulation(const api::MarkData &mark, core::Articulations &outArticulations) const
 {
-    if (!myConverter.isArticulation(mark.markType) && !api::isMarkCustom(mark.markType))
+    if (!api::isMarkArticulation(mark.markType) && !api::isMarkCustom(mark.markType))
     {
         return;
     }
@@ -417,6 +417,14 @@ void NotationsWriter::addArticulation(const api::MarkData &mark, core::Articulat
     case core::ArticulationsChoice::Kind::strongAccent: {
         core::StrongAccent sa;
         setAttributesFromPositionData(mark.positionData, sa);
+        if (mark.markType == api::MarkType::strongAccentUp)
+        {
+            sa.setType(core::UpDown::up());
+        }
+        else if (mark.markType == api::MarkType::strongAccentDown)
+        {
+            sa.setType(core::UpDown::down());
+        }
         outArticulations.addChoice(core::ArticulationsChoice::strongAccent(sa));
         break;
     }

--- a/src/private/mxtest/api/NoteDataTest.cpp
+++ b/src/private/mxtest/api/NoteDataTest.cpp
@@ -1418,4 +1418,66 @@ TEST(printObjectNo, NoteData)
 
 T_END;
 
+TEST(strongAccentDirection, NoteData)
+{
+    ScoreData score;
+    score.parts.emplace_back();
+    auto &part = score.parts.back();
+    part.measures.emplace_back();
+    auto &measure = part.measures.back();
+    measure.staves.emplace_back();
+    auto &staff = measure.staves.back();
+    auto &voice = staff.voices[0];
+
+    NoteData upNote;
+    upNote.tickTimePosition = 0;
+    upNote.durationData.durationTimeTicks = score.ticksPerQuarter;
+    upNote.durationData.durationName = DurationName::quarter;
+    upNote.noteAttachmentData.marks.emplace_back(MarkType::strongAccentUp);
+    voice.notes.push_back(upNote);
+
+    NoteData downNote;
+    downNote.tickTimePosition = score.ticksPerQuarter;
+    downNote.durationData.durationTimeTicks = score.ticksPerQuarter;
+    downNote.durationData.durationName = DurationName::quarter;
+    downNote.noteAttachmentData.marks.emplace_back(MarkType::strongAccentDown);
+    voice.notes.push_back(downNote);
+
+    NoteData plainNote;
+    plainNote.tickTimePosition = score.ticksPerQuarter * 2;
+    plainNote.durationData.durationTimeTicks = score.ticksPerQuarter;
+    plainNote.durationData.durationName = DurationName::quarter;
+    plainNote.noteAttachmentData.marks.emplace_back(MarkType::strongAccent);
+    voice.notes.push_back(plainNote);
+
+    auto &mgr = DocumentManager::getInstance();
+    const auto r1 = mgr.createFromScore(score);
+    REQUIRE(r1.ok());
+    auto docId = r1.value();
+    std::stringstream ss;
+    mgr.writeToStream(docId, ss);
+    mgr.destroyDocument(docId);
+    const std::string xml = ss.str();
+    CHECK(xml.find(R"(<strong-accent type="up" />)") != std::string::npos);
+    CHECK(xml.find(R"(<strong-accent type="down" />)") != std::string::npos);
+    CHECK(xml.find("<strong-accent />") != std::string::npos);
+
+    std::istringstream iss{xml};
+    const auto r2 = mgr.createFromStream(iss);
+    REQUIRE(r2.ok());
+    docId = r2.value();
+    const auto rd = mgr.getData(docId);
+    REQUIRE(rd.ok());
+    const auto outScore = rd.value();
+    mgr.destroyDocument(docId);
+
+    const auto &outNotes = outScore.parts.back().measures.back().staves.back().voices.at(0).notes;
+    REQUIRE(outNotes.size() == static_cast<size_t>(3));
+    CHECK(outNotes.at(0).noteAttachmentData.marks.at(0).markType == MarkType::strongAccentUp);
+    CHECK(outNotes.at(1).noteAttachmentData.marks.at(0).markType == MarkType::strongAccentDown);
+    CHECK(outNotes.at(2).noteAttachmentData.marks.at(0).markType == MarkType::strongAccent);
+}
+
+T_END;
+
 #endif

--- a/src/private/mxtest/api/roundtrip-baseline.txt
+++ b/src/private/mxtest/api/roundtrip-baseline.txt
@@ -264,3 +264,9 @@ musuite/testLines2_ref.xml
 # WedgeStart gains isColorSpecified (matching the other four), so an unspecified
 # wedge color is no longer force-written.
 musuite/testWedge1.xml
+
+# Unblocked by MarkType::strongAccentUp/strongAccentDown: <strong-accent>'s type
+# (up/down) attribute was parsed by nothing and written by nothing.
+# Mirrors the existing arpeggiate/arpeggiateUp/arpeggiateDown precedent
+# (a direction folded into distinct MarkType values rather than a new field).
+musuite/testNoteAttributes1.xml


### PR DESCRIPTION
## Human Summary

Slightly awkward, but missing a missing attribute can now be specified with new items in the huge `markType` enum:

```c++
    strongAccent, // marcato, direction unspecified
    strongAccentUp,
    strongAccentDown,
```

## Summary

`<strong-accent>`'s `type` attribute (up/down) had no `mx::api` home, so it was silently dropped on read and never written back. Added `MarkType::strongAccentUp`/`strongAccentDown` next to the existing `strongAccent`, the same way `arpeggiate` already splits into `arpeggiateUp`/`arpeggiateDown`. The reader picks the directional variant when `type` is present; the writer sets `type` back from it.

Also removed a duplicate classification list. `Converter::isArticulation` and the free function `isMarkArticulation` (`MarkData.cpp`) independently listed the same set of mark types, and had drifted out of sync while I was testing this change — updating one without the other silently dropped the whole `<notations>` element. `Converter::isArticulation` had exactly one caller, so it's gone; that caller now uses `isMarkArticulation` directly.

## Testing

- [x] New `strongAccentDirection` test (`NoteDataTest.cpp`)
- [x] `make test`: 4623 assertions, 368 test cases, all pass
- [x] `make test-api-roundtrip`: 152/152 pinned pass (1 newly unlocked)
- [x] `make fmt` / `make check`: clean

## References

- No tracking issue; found via corpus round-trip discovery/classification.
