### PR TITLE
feat: round-trip grace note slash attribute

### DIFF
--- a/src/include/mx/api/NoteData.h
+++ b/src/include/mx/api/NoteData.h
@@ -126,6 +126,9 @@ class NoteData
     // as 0 and is ignored on write), and cue notes -- including grace-cue
     // notes -- cannot carry <tie> (ties on them are silently dropped on write).
     bool isGrace;
+    // <grace>'s slash attribute. Only meaningful when isGrace is true.
+    Bool graceSlash;
+
     bool isCue;
 
     Notehead notehead;
@@ -172,6 +175,7 @@ MXAPI_EQUALS_MEMBER(isTieStop)
 MXAPI_EQUALS_MEMBER(tieLetRing)
 MXAPI_EQUALS_MEMBER(isGrace)
 MXAPI_EQUALS_MEMBER(isCue)
+MXAPI_EQUALS_MEMBER(graceSlash)
 MXAPI_EQUALS_MEMBER(pitchData)
 MXAPI_EQUALS_MEMBER(userRequestedVoiceNumber)
 MXAPI_EQUALS_MEMBER(stem)

--- a/src/private/mx/api/NoteData.cpp
+++ b/src/private/mx/api/NoteData.cpp
@@ -10,9 +10,9 @@ namespace api
 {
 NoteData::NoteData()
     : isRest{false}, isMeasureRest{false}, isUnpitched{false}, isDisplayStepOctaveSpecified{false}, isChord{false},
-      isTieStart{false}, isTieStop{false}, tieLetRing{}, isGrace{false}, isCue{false}, notehead{Notehead::normal},
-      pitchData{}, userRequestedVoiceNumber{VALUE_UNSPECIFIED}, stem{Stem::unspecified}, tickTimePosition{0},
-      durationData{}, beams{}, positionData{}, printData{}, noteAttachmentData{}, lyrics{}
+      isTieStart{false}, isTieStop{false}, tieLetRing{}, isGrace{false}, graceSlash{Bool::unspecified}, isCue{false},
+      notehead{Notehead::normal}, pitchData{}, userRequestedVoiceNumber{VALUE_UNSPECIFIED}, stem{Stem::unspecified},
+      tickTimePosition{0}, durationData{}, beams{}, positionData{}, printData{}, noteAttachmentData{}, lyrics{}
 {
 }
 } // namespace api

--- a/src/private/mx/impl/NoteFunctions.cpp
+++ b/src/private/mx/impl/NoteFunctions.cpp
@@ -56,6 +56,10 @@ api::NoteData NoteFunctions::parseNote() const
     myOutNoteData.isCue = reader.getIsCue();
 
     auto converter = Converter{};
+    if (reader.getIsGraceSlashSpecified())
+    {
+        myOutNoteData.graceSlash = converter.convert(reader.getGraceSlash());
+    }
     myOutNoteData.pitchData.step = converter.convert(reader.getStep());
     myOutNoteData.pitchData.alter = reader.getAlter();
     myOutNoteData.pitchData.cents = reader.getCents();

--- a/src/private/mx/impl/NoteReader.cpp
+++ b/src/private/mx/impl/NoteReader.cpp
@@ -150,8 +150,8 @@ NoteReader::NoteReader(const core::Note &mxNote)
       myTimeModificationNormalNotes(-1), myTimeModificationNormalType(core::NoteTypeValue::maxima()),
       myTimeModificationNormalTypeDots(0), myHasAccidental(false), myAccidental(core::AccidentalValue::natural()),
       myIsAccidentalParenthetical(false), myIsAccidentalCautionary{false}, myIsAccidentalEditorial{false},
-      myIsAccidentalBracketed{false}, myIsStemSpecified{false}, myStem{}, myIsTieStart{false}, myIsTieStop{false},
-      myHasLyric{false}
+      myIsAccidentalBracketed{false}, myIsStemSpecified{false}, myStem{}, myIsGraceSlashSpecified{false},
+      myGraceSlash{}, myIsTieStart{false}, myIsTieStop{false}, myHasLyric{false}
 {
     setNormalGraceCueItems();
     setRestPitchUnpitchedItems();
@@ -208,6 +208,11 @@ void NoteReader::setNormalGraceCueItems()
         myIsGrace = true;
         const auto &noteGuts = myNoteChoice.asGraceNoteGroup();
         myDurationValue = 0;
+        if (noteGuts.grace().slash().has_value())
+        {
+            myIsGraceSlashSpecified = true;
+            myGraceSlash = *noteGuts.grace().slash();
+        }
         if (noteGuts.graceNoteChoice().isGraceNormalNoteGroup())
         {
             setTie(noteGuts.graceNoteChoice().asGraceNormalNoteGroup().tie());

--- a/src/private/mx/impl/NoteReader.h
+++ b/src/private/mx/impl/NoteReader.h
@@ -207,6 +207,16 @@ class NoteReader
         return myStem;
     }
 
+    inline bool getIsGraceSlashSpecified() const
+    {
+        return myIsGraceSlashSpecified;
+    }
+
+    inline core::YesNo getGraceSlash() const
+    {
+        return myGraceSlash;
+    }
+
     bool getIsTieStart() const
     {
         return myIsTieStart;
@@ -259,6 +269,8 @@ class NoteReader
     bool myIsAccidentalBracketed;
     bool myIsStemSpecified;
     core::StemValue myStem;
+    bool myIsGraceSlashSpecified;
+    core::YesNo myGraceSlash;
     bool myIsTieStart;
     bool myIsTieStop;
     bool myHasLyric;

--- a/src/private/mx/impl/NoteWriter.cpp
+++ b/src/private/mx/impl/NoteWriter.cpp
@@ -299,6 +299,12 @@ void NoteWriter::assembleNoteChoice() const
     {
         // Grace notes have no wire <duration>; durationTimeTicks is ignored.
         core::GraceNoteGroup choiceObj;
+        if (myNoteData.graceSlash != api::Bool::unspecified)
+        {
+            core::Grace grace;
+            grace.setSlash(myConverter.convert(myNoteData.graceSlash));
+            choiceObj.setGrace(std::move(grace));
+        }
         if (myNoteData.isCue)
         {
             // <grace/> + <cue/>: the grace-cue group carries no <tie>.

--- a/src/private/mxtest/api/GraceCueApiTest.cpp
+++ b/src/private/mxtest/api/GraceCueApiTest.cpp
@@ -269,4 +269,71 @@ TEST(graceNormalNoteTiesAreKept, GraceCue)
 
 T_END;
 
+// <grace>'s slash attribute (slashed grace notes, e.g. acciaccatura).
+TEST(graceSlashRoundTrip, GraceCue)
+{
+    ScoreData score;
+    score.ticksPerQuarter = 4;
+    score.parts.emplace_back();
+    auto &part = score.parts.back();
+    part.measures.emplace_back();
+    auto &measure = part.measures.back();
+    measure.staves.emplace_back();
+    auto &staff = measure.staves.back();
+    auto &voice = staff.voices[0];
+
+    voice.notes.emplace_back();
+    voice.notes.back().isGrace = true;
+    voice.notes.back().graceSlash = Bool::yes;
+    voice.notes.back().durationData.durationName = DurationName::eighth;
+    voice.notes.back().durationData.durationTimeTicks = 0;
+
+    voice.notes.emplace_back();
+    voice.notes.back().durationData.durationName = DurationName::quarter;
+    voice.notes.back().durationData.durationTimeTicks = 4;
+
+    const auto xml = mxtest::toXml(score);
+    CHECK(xml.find(R"(<grace slash="yes" />)") != std::string::npos);
+
+    const auto out = roundTrip(score);
+    const auto &outNotes = out.parts.back().measures.back().staves.back().voices.at(0).notes;
+    REQUIRE(outNotes.size() == 2);
+    CHECK(outNotes.at(0).graceSlash == Bool::yes);
+}
+
+T_END;
+
+// An unspecified graceSlash (the default) must not emit the attribute at all.
+TEST(graceSlashUnspecifiedOmitsAttribute, GraceCue)
+{
+    ScoreData score;
+    score.ticksPerQuarter = 4;
+    score.parts.emplace_back();
+    auto &part = score.parts.back();
+    part.measures.emplace_back();
+    auto &measure = part.measures.back();
+    measure.staves.emplace_back();
+    auto &staff = measure.staves.back();
+    auto &voice = staff.voices[0];
+
+    voice.notes.emplace_back();
+    voice.notes.back().isGrace = true;
+    voice.notes.back().durationData.durationName = DurationName::eighth;
+    voice.notes.back().durationData.durationTimeTicks = 0;
+
+    voice.notes.emplace_back();
+    voice.notes.back().durationData.durationName = DurationName::quarter;
+    voice.notes.back().durationData.durationTimeTicks = 4;
+
+    const auto xml = mxtest::toXml(score);
+    CHECK(xml.find("slash") == std::string::npos);
+
+    const auto out = roundTrip(score);
+    const auto &outNotes = out.parts.back().measures.back().staves.back().voices.at(0).notes;
+    REQUIRE(outNotes.size() == 2);
+    CHECK(outNotes.at(0).graceSlash == Bool::unspecified);
+}
+
+T_END;
+
 #endif

--- a/src/private/mxtest/api/roundtrip-baseline.txt
+++ b/src/private/mxtest/api/roundtrip-baseline.txt
@@ -270,3 +270,9 @@ musuite/testWedge1.xml
 # Mirrors the existing arpeggiate/arpeggiateUp/arpeggiateDown precedent
 # (a direction folded into distinct MarkType values rather than a new field).
 musuite/testNoteAttributes1.xml
+
+# Unblocked by NoteData::graceSlash: <grace>'s slash attribute (slashed grace
+# notes, e.g. acciaccatura) was parsed by nothing and written by nothing.
+# NoteReader now reads it into a tri-state Bool field; NoteWriter emits
+# <grace slash="..."/> only when specified.
+musuite/testGrace1.xml


### PR DESCRIPTION
## Human Summary

Simple fix for a missing attribute.

## Summary

`<grace>`'s `slash` attribute (slashed grace notes, e.g. acciaccatura) was parsed by nothing and
written by nothing -- `NoteData` had no field for it (`attr:grace@slash`).

Added `NoteData::graceSlash` (tri-state `Bool`, only meaningful when `isGrace` is true).
`NoteReader` reads it off the grace note's `<grace>` element, mirroring the existing
`getIsStemSpecified`/`getStem` accessor pattern already used for other optional grace-adjacent
attributes; `NoteWriter` emits `<grace slash="..."/>` only when specified, otherwise the bare
`<grace/>`.

`stealTimePrevious`/`stealTimeFollowing`/`makeTime` (the other three `<grace>` attributes) remain
unmodeled -- no corpus file currently needs them.

While writing this PR's test, an unrelated pre-existing bug surfaced: two consecutive grace notes
sharing a tick position collapse to one note on round-trip, independent of `slash`. Filed as #312
rather than folded into this fix; the test here avoids that scenario (one grace note per case).

Stacked on `#311` (strong-accent direction fix).

## Testing

- [x] New `graceSlashRoundTrip` / `graceSlashUnspecifiedOmitsAttribute` tests (`GraceCueApiTest.cpp`)
- [x] `make test`: all pass (4594 assertions in 366 test cases, plus the three examples)
- [x] `make test-api-roundtrip`: 153 passed, 0 failed (of 153 pinned; 1 newly unlocked)
- [x] `make fmt` / `make check`: clean

## References

- Related: #312 (pre-existing grace-note collapse bug found while testing this fix)
