### PR TITLE
fix: round-trip the four accidental presence attributes

### DIFF
--- a/src/private/mx/impl/NoteWriter.cpp
+++ b/src/private/mx/impl/NoteWriter.cpp
@@ -112,6 +112,22 @@ core::Note NoteWriter::getNote(bool isStartOfChord) const
     {
         core::Accidental accidental;
         accidental.setValue(myConverter.convert(myNoteData.pitchData.accidental));
+        if (myNoteData.pitchData.isAccidentalParenthetical)
+        {
+            accidental.setParentheses(core::YesNo::yes());
+        }
+        if (myNoteData.pitchData.isAccidentalCautionary)
+        {
+            accidental.setCautionary(core::YesNo::yes());
+        }
+        if (myNoteData.pitchData.isAccidentalEditorial)
+        {
+            accidental.setEditorial(core::YesNo::yes());
+        }
+        if (myNoteData.pitchData.isAccidentalBracketed)
+        {
+            accidental.setBracket(core::YesNo::yes());
+        }
         myOutNote.setAccidental(std::move(accidental));
     }
 

--- a/src/private/mxtest/api/PitchDataTest.cpp
+++ b/src/private/mxtest/api/PitchDataTest.cpp
@@ -343,4 +343,56 @@ TEST(ConstructorTest, PitchData)
 
 T_END;
 
+// The four <accidental> presence attributes (parentheses, cautionary, editorial, bracket)
+// were read into PitchData but never written back.
+TEST(AccidentalPresenceAttributesRoundTrip, PitchData)
+{
+    ScoreData score;
+    score.parts.emplace_back();
+    auto &part = score.parts.back();
+    part.measures.emplace_back();
+    auto &measure = part.measures.back();
+    measure.staves.emplace_back();
+    auto &staff = measure.staves.back();
+    auto &voice = staff.voices[0];
+    voice.notes.emplace_back();
+    auto &note = voice.notes.back();
+    note.durationData.durationTimeTicks = score.ticksPerQuarter;
+    note.durationData.durationName = DurationName::quarter;
+    note.pitchData.step = Step::f;
+    note.pitchData.accidental = Accidental::sharp;
+    note.pitchData.isAccidentalParenthetical = true;
+    note.pitchData.isAccidentalCautionary = true;
+    note.pitchData.isAccidentalEditorial = true;
+    note.pitchData.isAccidentalBracketed = true;
+
+    auto &mgr = DocumentManager::getInstance();
+    const auto r1 = mgr.createFromScore(score);
+    REQUIRE(r1.ok());
+    const int docId = r1.value();
+    std::stringstream ss;
+    mgr.writeToStream(docId, ss);
+    mgr.destroyDocument(docId);
+    const std::string xml = ss.str();
+    CHECK(xml.find(R"(parentheses="yes")") != std::string::npos);
+    CHECK(xml.find(R"(cautionary="yes")") != std::string::npos);
+    CHECK(xml.find(R"(editorial="yes")") != std::string::npos);
+    CHECK(xml.find(R"(bracket="yes")") != std::string::npos);
+
+    std::istringstream iss{xml};
+    const auto r2 = mgr.createFromStream(iss);
+    REQUIRE(r2.ok());
+    const int docId2 = r2.value();
+    const auto rd = mgr.getData(docId2);
+    REQUIRE(rd.ok());
+    mgr.destroyDocument(docId2);
+    const auto &outNote = rd.value().parts.back().measures.back().staves.back().voices.at(0).notes.back();
+    CHECK(outNote.pitchData.isAccidentalParenthetical);
+    CHECK(outNote.pitchData.isAccidentalCautionary);
+    CHECK(outNote.pitchData.isAccidentalEditorial);
+    CHECK(outNote.pitchData.isAccidentalBracketed);
+}
+
+T_END;
+
 #endif

--- a/src/private/mxtest/api/roundtrip-baseline.txt
+++ b/src/private/mxtest/api/roundtrip-baseline.txt
@@ -276,3 +276,12 @@ musuite/testNoteAttributes1.xml
 # NoteReader now reads it into a tri-state Bool field; NoteWriter emits
 # <grace slash="..."/> only when specified.
 musuite/testGrace1.xml
+
+# Unblocked by NoteWriter writing the four <accidental> presence attributes
+# (parentheses, cautionary, editorial, bracket): PitchData already modeled
+# all four (read-only, via NoteReader), but NoteWriter only ever wrote the
+# accidental's value, dropping all four attributes on round-trip.
+lysuite/ly01a_Pitches_Pitches.xml
+lysuite/ly01e_Pitches_ParenthesizedAccidentals.xml
+lysuite/ly01f_Pitches_ParenthesizedMicrotoneAccidentals.xml
+musuite/testAccidentals2.xml


### PR DESCRIPTION
## Human Summary

TL;DR simple: add some missing attributes to the accidental element.

## Summary

`PitchData::isAccidentalParenthetical`/`Cautionary`/`Editorial`/`Bracketed` were already modeled and
read by `NoteReader`, but `NoteWriter` only ever wrote the accidental's value -- all four presence
attributes (`parentheses`, `cautionary`, `editorial`, `bracket`) were silently dropped on round-trip
(`attr:accidental@editorial`, `attr:accidental@parentheses`).

`NoteWriter` now sets each `core::Accidental` attribute to `"yes"` when its matching `PitchData` bool
is true, mirroring the reader's true-only-on-`"yes"` semantics exactly: a false bool omits the
attribute, matching the fact that the source was either absent or explicitly `"no"` (the reader
already can't distinguish those two cases) -- read/write stay symmetric.

Stacked on `#313` (grace note slash fix).

## Testing

- [x] New `AccidentalPresenceAttributesRoundTrip` test (`PitchDataTest.cpp`): all four attributes
      round-trip through XML and back
- [x] `make test`: all pass (4605 assertions in 367 test cases, plus the three examples)
- [x] `make test-api-roundtrip`: 157 passed, 0 failed (of 157 pinned; 4 newly unlocked -- the fix
      also covered two additional parenthesized-accidental fixtures beyond the two identified
      candidates)
- [x] `make fmt` / `make check`: clean

## References

N/A