### PR TITLE
fix: grace notes must not advance the tick cursor on write

### DIFF
--- a/src/private/mx/impl/MeasureWriter.cpp
+++ b/src/private/mx/impl/MeasureWriter.cpp
@@ -619,7 +619,9 @@ void MeasureWriter::advanceCursorIfNeeded(const api::NoteData &currentNote, cons
     if (isAdvanceNeeded(currentNote, inIter, inEnd))
     {
         const auto curTime = std::max(myHistory.getCursor().tickTimePosition, 0);
-        const auto duration = std::max(currentNote.durationData.durationTimeTicks, 0);
+        // a grace note carries no <duration> on the wire, so it must not advance the
+        // cursor even if the api struct's durationTimeTicks was left at its default (#312)
+        const auto duration = currentNote.isGrace ? 0 : std::max(currentNote.durationData.durationTimeTicks, 0);
         const auto newTime = curTime + duration;
         myHistory.setTime(newTime, "advance cursor");
         myPreviousCursor = myHistory.getCursor();

--- a/src/private/mxtest/api/GraceCueApiTest.cpp
+++ b/src/private/mxtest/api/GraceCueApiTest.cpp
@@ -336,4 +336,48 @@ TEST(graceSlashUnspecifiedOmitsAttribute, GraceCue)
 
 T_END;
 
+// Issue #312: two consecutive grace notes sharing a tick, followed by the normal note they
+// attach to, must not collapse on round trip.
+TEST(consecutiveGraceNotesAtSameTickSurviveRoundTrip, GraceCue)
+{
+    ScoreData score;
+    score.ticksPerQuarter = 4;
+    score.parts.emplace_back();
+    auto &part = score.parts.back();
+    part.measures.emplace_back();
+    auto &measure = part.measures.back();
+    measure.staves.emplace_back();
+    auto &staff = measure.staves.back();
+    auto &voice = staff.voices[0];
+
+    voice.notes.emplace_back();
+    voice.notes.back().isGrace = true;
+    voice.notes.back().tickTimePosition = 0;
+    voice.notes.back().durationData.durationName = DurationName::eighth;
+
+    voice.notes.emplace_back();
+    voice.notes.back().isGrace = true;
+    voice.notes.back().tickTimePosition = 0;
+    voice.notes.back().durationData.durationName = DurationName::eighth;
+
+    voice.notes.emplace_back();
+    voice.notes.back().tickTimePosition = 0;
+    voice.notes.back().durationData.durationName = DurationName::quarter;
+    voice.notes.back().durationData.durationTimeTicks = 4;
+
+    const auto xml = mxtest::toXml(score);
+
+    // no cursor-correcting <backup> should be needed: grace notes carry no wire duration
+    CHECK(xml.find("<backup>") == std::string::npos);
+
+    const auto out = roundTrip(score);
+    const auto &outNotes = out.parts.back().measures.back().staves.back().voices.at(0).notes;
+    REQUIRE(outNotes.size() == 3);
+    CHECK(outNotes.at(0).isGrace);
+    CHECK(outNotes.at(1).isGrace);
+    CHECK(!outNotes.at(2).isGrace);
+}
+
+T_END;
+
 #endif


### PR DESCRIPTION
## Human Summary

Fix for a writer bug in which a grace note advanced the tickTime cursor (it shouldn't).

## Summary

Two (or more) consecutive grace notes sharing a `tickTimePosition`, followed by the normal note
they attach to, collapsed to a single note on `createFromScore` -> `writeToStream` ->
`createFromStream` -> `getData`.

`NoteData::isGrace` is documented ("durationTimeTicks reads as 0 and is ignored on write") to mean
a grace note's `durationTimeTicks` has no effect on the wire, since grace notes carry no
`<duration>` element. But `DurationData`'s default constructor leaves `durationTimeTicks` at `1`,
and `MeasureWriter::advanceCursorIfNeeded` used that field unconditionally when advancing the
internal tick cursor after writing a note. A grace note left at the default therefore
phantom-advanced the cursor by one tick, forcing the writer to emit a `<backup>` to correct the
position before the next note. On read, `MeasureReader::parseBackup` treats any `<backup>` not
already in progress as the start of a new voice (its usual job is separating overlapping voices
sharing a staff), so each spurious `<backup>` pushed the following note into its own voice bucket.
With three notes all reporting the same (unspecified) `<voice>` number, the consolidation step
couldn't recognize them as one voice and left them split across three buckets -- so only the first
note showed up when reading `voices.at(0)`.

The fix makes a grace note always contribute `0` to the cursor advance, regardless of
`durationTimeTicks`, matching the documented contract and its wire representation. This removes the
spurious `<backup>` entirely, so the reader's existing voice-ordinal handling is never triggered by
this case.

## Testing

- [x] New test `consecutiveGraceNotesAtSameTickSurviveRoundTrip` (`GraceCueApiTest.cpp`) fails before
      the fix (`1 == 3`), passes after; also asserts no `<backup>` is emitted
- [x] `make test`: all pass (4718 assertions in 378 test cases)
- [x] `make test-api-roundtrip` (regression, pinned baseline): 158 passed, 0 failed
- [x] `make discover-api-roundtrip`: 158 PASS both before and after the fix -- no corpus files are
      newly unlocked, since the reader already always reads a grace note's `durationTimeTicks` as 0
      when parsing real MusicXML; this bug only affects hand-authored `ScoreData`
- [x] `make fmt` / format check clean

## References

- Closes #312
