### PR TITLE
fix: correct ottava up/down direction and add stop size support

### DIFF
--- a/src/include/mx/api/DirectionData.h
+++ b/src/include/mx/api/DirectionData.h
@@ -107,7 +107,7 @@ struct DirectionData
     std::vector<WedgeStart> wedgeStarts;
     std::vector<WedgeStop> wedgeStops;
     std::vector<OttavaStart> ottavaStarts;
-    std::vector<SpannerStop> ottavaStops;
+    std::vector<OttavaStop> ottavaStops;
     std::vector<SpannerStart> bracketStarts;
     std::vector<SpannerStop> bracketStops;
     std::vector<SpannerStart> dashesStarts;

--- a/src/include/mx/api/OttavaData.h
+++ b/src/include/mx/api/OttavaData.h
@@ -33,12 +33,32 @@ class OttavaStart
     }
 };
 
-// SpannerStop is used for OttavaStops
+class OttavaStop
+{
+  public:
+    SpannerStop spannerStop;
+
+    // MusicXML's octave-shift allows a size attribute ("8" or "15") on the stop, not just the
+    // start. Most writers omit it there since it is implied by the corresponding start, but some
+    // importers (e.g. MuseScore) expect it to be present. Absent by default; set it to have the
+    // writer emit it explicitly.
+    std::optional<int> size;
+
+    OttavaStop() : spannerStop{}, size{std::nullopt}
+    {
+    }
+};
 
 MXAPI_EQUALS_BEGIN(OttavaStart)
 MXAPI_EQUALS_MEMBER(spannerStart)
 MXAPI_EQUALS_MEMBER(ottavaType)
 MXAPI_EQUALS_END;
 MXAPI_NOT_EQUALS_AND_VECTORS(OttavaStart);
+
+MXAPI_EQUALS_BEGIN(OttavaStop)
+MXAPI_EQUALS_MEMBER(spannerStop)
+MXAPI_EQUALS_MEMBER(size)
+MXAPI_EQUALS_END;
+MXAPI_NOT_EQUALS_AND_VECTORS(OttavaStop);
 } // namespace api
 } // namespace mx

--- a/src/include/mx/api/OttavaData.h
+++ b/src/include/mx/api/OttavaData.h
@@ -9,13 +9,17 @@ namespace mx
 {
 namespace api
 {
+// Names follow common notation usage (an "8va" line raises the sounding pitch an octave above
+// what is written). Per the MusicXML spec, the underlying octave-shift/@type attribute instead
+// describes the direction the *written* notes are shifted from the true pitch, which is the
+// opposite sense: o8va/o15ma write type="down" and o8vb/o15mb write type="up".
 enum class OttavaType
 {
     unspecified,
-    o8va,  // octave up
-    o8vb,  // octave down
-    o15ma, // 2 octaves up
-    o15mb  // 2 octaves down
+    o8va,  // octave up (writes octave-shift type="down")
+    o8vb,  // octave down (writes octave-shift type="up")
+    o15ma, // 2 octaves up (writes octave-shift type="down")
+    o15mb  // 2 octaves down (writes octave-shift type="up")
 };
 
 class OttavaStart

--- a/src/private/mx/impl/DirectionReader.cpp
+++ b/src/private/mx/impl/DirectionReader.cpp
@@ -762,8 +762,10 @@ void DirectionReader::parseOctaveShift(const core::DirectionType &directionType)
     bool isStop = octaveShift.type().tag() == core::UpDownStopContinue::Tag::stop;
     if (isStop)
     {
-        auto stop = impl::getSpannerStop(octaveShift);
-        stop.tickTimePosition = myCursor.tickTimePosition;
+        api::OttavaStop stop;
+        stop.spannerStop = impl::getSpannerStop(octaveShift);
+        stop.spannerStop.tickTimePosition = myCursor.tickTimePosition;
+        stop.size = octaveShift.size();
         myOutDirectionData.ottavaStops.emplace_back(std::move(stop));
         appendOrderedComponent(api::DirectionComponentKind::ottavaStop,
                                static_cast<int>(myOutDirectionData.ottavaStops.size()) - 1);

--- a/src/private/mx/impl/DirectionReader.cpp
+++ b/src/private/mx/impl/DirectionReader.cpp
@@ -778,21 +778,26 @@ void DirectionReader::parseOctaveShift(const core::DirectionType &directionType)
         amount = *octaveShift.size();
     }
 
+    // Per the MusicXML spec, octave-shift's type attribute describes the direction the
+    // *written* notes are shifted from the true (sounding) pitch: an 8va, which sounds an
+    // octave above what is written, is encoded as type="down" (notes are written below true
+    // pitch). So type="down" maps to the "up" ottava variants (o8va/o15ma) and type="up" maps
+    // to the "down" variants (o8vb/o15mb).
     bool isUp = octaveShift.type().tag() == core::UpDownStopContinue::Tag::up;
 
-    if (isUp && amount > 8)
+    if (!isUp && amount > 8)
     {
         ottavaType = api::OttavaType::o15ma;
     }
-    else if (isUp)
+    else if (!isUp)
     {
         ottavaType = api::OttavaType::o8va;
     }
-    else if (!isUp && amount > 8)
+    else if (isUp && amount > 8)
     {
         ottavaType = api::OttavaType::o15mb;
     }
-    else if (!isUp)
+    else if (isUp)
     {
         ottavaType = api::OttavaType::o8vb;
     }

--- a/src/private/mx/impl/DirectionWriter.cpp
+++ b/src/private/mx/impl/DirectionWriter.cpp
@@ -323,22 +323,22 @@ void DirectionWriter::emitOttavaStart(const api::OttavaStart &ottavaStart, core:
     switch (ottavaStart.ottavaType)
     {
     case api::OttavaType::o15ma: {
-        os.setType(core::UpDownStopContinue::up());
+        os.setType(core::UpDownStopContinue::down());
         os.setSize(15);
         break;
     }
     case api::OttavaType::o15mb: {
-        os.setType(core::UpDownStopContinue::down());
+        os.setType(core::UpDownStopContinue::up());
         os.setSize(15);
         break;
     }
     case api::OttavaType::o8va: {
-        os.setType(core::UpDownStopContinue::up());
+        os.setType(core::UpDownStopContinue::down());
         os.setSize(8);
         break;
     }
     case api::OttavaType::o8vb: {
-        os.setType(core::UpDownStopContinue::down());
+        os.setType(core::UpDownStopContinue::up());
         os.setSize(8);
         break;
     }

--- a/src/private/mx/impl/DirectionWriter.cpp
+++ b/src/private/mx/impl/DirectionWriter.cpp
@@ -73,7 +73,6 @@
 #include "mx/impl/PrintFunctions.h"
 #include "mx/impl/SoundFunctions.h"
 #include "mx/impl/SpannerFunctions.h"
-#include "mx/utility/Unused.h"
 
 namespace mx
 {
@@ -305,11 +304,12 @@ void DirectionWriter::emitWedgeStart(const api::WedgeStart &wedgeStart, core::Di
     addDirectionType(std::move(dt), direction);
 }
 
-void DirectionWriter::emitOttavaStop(const api::SpannerStop &ottavaStop, core::Direction &direction)
+void DirectionWriter::emitOttavaStop(const api::OttavaStop &ottavaStop, core::Direction &direction)
 {
     core::OctaveShift os{};
+    setAttributesFromSpannerStop(ottavaStop.spannerStop, os);
     os.setType(core::UpDownStopContinue::stop());
-    MX_UNUSED(ottavaStop);
+    os.setSize(ottavaStop.size);
     core::DirectionType dt{};
     dt.setChoice(core::DirectionTypeChoice::octaveShift(os));
     addDirectionType(std::move(dt), direction);

--- a/src/private/mx/impl/DirectionWriter.h
+++ b/src/private/mx/impl/DirectionWriter.h
@@ -35,7 +35,7 @@ class DirectionWriter
     void emitPedalStop(const api::SpannerStop &pedalStop, core::Direction &direction);
     void emitWedgeStop(const api::WedgeStop &wedgeStop, core::Direction &direction);
     void emitWedgeStart(const api::WedgeStart &wedgeStart, core::Direction &direction);
-    void emitOttavaStop(const api::SpannerStop &ottavaStop, core::Direction &direction);
+    void emitOttavaStop(const api::OttavaStop &ottavaStop, core::Direction &direction);
     void emitOttavaStart(const api::OttavaStart &ottavaStart, core::Direction &direction);
     void emitBracketStart(const api::SpannerStart &item, core::Direction &direction);
     void emitBracketStop(const api::SpannerStop &item, core::Direction &direction);

--- a/src/private/mxtest/impl/DirectionReaderTest.cpp
+++ b/src/private/mxtest/impl/DirectionReaderTest.cpp
@@ -105,8 +105,10 @@ TEST(ottavaStop, DirectionReader)
     auto directionData = reader.getDirectionData();
     CHECK_EQUAL(1, directionData.ottavaStops.size());
     const auto &ottavaStop = directionData.ottavaStops.front();
-    CHECK_EQUAL(tickTimePosition, ottavaStop.tickTimePosition);
-    CHECK_EQUAL(-1, ottavaStop.numberLevel);
+    CHECK_EQUAL(tickTimePosition, ottavaStop.spannerStop.tickTimePosition);
+    CHECK_EQUAL(-1, ottavaStop.spannerStop.numberLevel);
+    CHECK(ottavaStop.size.has_value());
+    CHECK_EQUAL(15, *ottavaStop.size);
 }
 
 T_END

--- a/src/private/mxtest/impl/DirectionReaderTest.cpp
+++ b/src/private/mxtest/impl/DirectionReaderTest.cpp
@@ -18,7 +18,7 @@
 using namespace mx;
 using namespace mx::impl;
 
-TEST(ottavaStart15mb, DirectionReader)
+TEST(ottavaStart15ma, DirectionReader)
 {
     const int tickTimePosition = 150;
     core::Direction dir{};
@@ -35,7 +35,7 @@ TEST(ottavaStart15mb, DirectionReader)
     CHECK_EQUAL(1, directionData.ottavaStarts.size());
     const auto &ottavaStart = directionData.ottavaStarts.front();
     CHECK_EQUAL(tickTimePosition, ottavaStart.spannerStart.tickTimePosition);
-    CHECK(api::OttavaType::o15mb == ottavaStart.ottavaType);
+    CHECK(api::OttavaType::o15ma == ottavaStart.ottavaType);
 }
 
 T_END
@@ -44,7 +44,7 @@ TEST(ottavaStart8vaAnd8vb, DirectionReader)
 {
     const int tickTimePosition = 199;
 
-    // add an 8va start
+    // add an 8vb start
     core::OctaveShift oct1{};
     oct1.setType(core::UpDownStopContinue::up());
     oct1.setSize(8);
@@ -57,7 +57,7 @@ TEST(ottavaStart8vaAnd8vb, DirectionReader)
     core::DirectionType dirType2{};
     dirType2.setChoice(core::DirectionTypeChoice::octaveShift(oct2));
 
-    // add an 8vb but rely on the default 'size'
+    // add an 8va but rely on the default 'size'
     core::OctaveShift oct3{};
     oct3.setType(core::UpDownStopContinue::down());
     oct3.setNumber(core::NumberLevel{3});
@@ -78,12 +78,12 @@ TEST(ottavaStart8vaAnd8vb, DirectionReader)
     auto ottavaStart = directionData.ottavaStarts.front();
 
     CHECK_EQUAL(tickTimePosition, ottavaStart.spannerStart.tickTimePosition);
-    CHECK(api::OttavaType::o8va == ottavaStart.ottavaType);
+    CHECK(api::OttavaType::o8vb == ottavaStart.ottavaType);
     CHECK_EQUAL(-1, ottavaStart.spannerStart.numberLevel);
 
     ottavaStart = directionData.ottavaStarts.at(1);
     CHECK_EQUAL(tickTimePosition, ottavaStart.spannerStart.tickTimePosition);
-    CHECK(api::OttavaType::o8vb == ottavaStart.ottavaType);
+    CHECK(api::OttavaType::o8va == ottavaStart.ottavaType);
     CHECK_EQUAL(3, ottavaStart.spannerStart.numberLevel);
 }
 

--- a/src/private/mxtest/impl/DirectionWriterTest.cpp
+++ b/src/private/mxtest/impl/DirectionWriterTest.cpp
@@ -26,9 +26,10 @@ TEST(ottavaStartStop, DirectionWriter)
     cursor.isFirstMeasureInPart = false;
     api::DirectionData directionData;
 
-    directionData.ottavaStops.emplace_back(api::SpannerStop{});
+    directionData.ottavaStops.emplace_back(api::OttavaStop{});
     auto &stop = directionData.ottavaStops.back();
-    stop.numberLevel = 2;
+    stop.spannerStop.numberLevel = 2;
+    stop.size = 15;
 
     directionData.ottavaStarts.emplace_back(api::OttavaStart{});
     auto &start = directionData.ottavaStarts.back();
@@ -43,6 +44,14 @@ TEST(ottavaStartStop, DirectionWriter)
     const auto &directionTypes = direction.directionType();
 
     CHECK_EQUAL(2, directionTypes.size());
+
+    DirectionReader reader{direction, cursor};
+    const auto roundTripped = reader.getDirectionData();
+    REQUIRE(roundTripped.ottavaStops.size() == 1);
+    const auto &roundTrippedStop = roundTripped.ottavaStops.front();
+    CHECK_EQUAL(2, roundTrippedStop.spannerStop.numberLevel);
+    CHECK(roundTrippedStop.size.has_value());
+    CHECK_EQUAL(15, *roundTrippedStop.size);
 }
 
 T_END


### PR DESCRIPTION
## Human Summary

Bugfix (MusicXML is super weird with ottava) and add size to the ottava stop.

## Summary

Two related ottava fixes, reported by the same user in back-to-back issues:

**#314 - reversed up/down mapping.** Per the spec, `octave-shift`'s `type` attribute describes the
direction the *written* notes are shifted from the true pitch, not the sounding direction implied by
names like `8va`. A standard `8va` sounds an octave above what's written, so the notated pitch sits
below true pitch, and the spec's own example says this is `type="down"`. `mx::api` had it backwards:
`o8va`/`o15ma` wrote `type="up"` and `o8vb`/`o15mb` wrote `type="down"`. Fixed both `DirectionReader`
and `DirectionWriter` (they were flipped in tandem, which is why neither our internal nor the api
corpus round-trip caught it) and documented the mapping on the enum.

**#316 - missing `size` on ottava stops.** `octave-shift` stops can carry `size`, and some importers
(MuseScore) expect it, but `mx::api` had no way to set one. `ottavaStops` used the shared
`SpannerStop`, which is also used by bracket/dashes/pedal stops where `size` isn't meaningful, so
this adds a dedicated `OttavaStop` with an `std::optional<int> size` instead. While rewriting
`emitOttavaStop` (previously an `MX_UNUSED` stub that silently dropped the stop entirely), also wired
up the stop's `number`/position/line data, which was being lost on write.

Checked the full corpus discovery run before and after the #316 change: the set of passing files is
identical, so nothing new to add to `roundtrip-baseline.txt` for this PR.

## Testing

- [x] `DirectionReaderTest`/`DirectionWriterTest` ottava cases updated for the corrected mapping and
  extended to cover `size` and stop `number` round-tripping
- [x] Full `mxtest` suite passes (4719 assertions in 377 test cases)
- [x] `make test-api-roundtrip` passes (158/158 pinned corpus files)
- [x] `make check-core-dev` (fmt-check + warning-free build) passes
- [x] Unity build (`CMAKE_UNITY_BUILD=ON`, batch size 0) compiles clean

## References

- Closes #314
- Closes #316


---
_Generated by [Claude Code](https://claude.ai/code/session_01WTVa9cSe5uvEuMuvwBxxUf)_