### PR TITLE
feat(api): support the full time-signature model

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,15 +1,4 @@
 {
-    "permissions": {
-        "allow": [
-            "Agent",
-            "Edit",
-            "WebSearch",
-            "WebFetch",
-            "Write",
-            "Read",
-            "Bash"
-        ]
-    },
     "hooks":
     {
         "SessionStart":

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 build/
 build-*/
 cmake-build-*
+.cache/
 src/private/mxtest/file/PathRoot.h
 *.DS_Store
 compile_commands.json

--- a/data/rpatters1/timesigs_composite-ref-modified.musicxml
+++ b/data/rpatters1/timesigs_composite-ref-modified.musicxml
@@ -101,11 +101,7 @@
           <line>2</line>
         </clef>
       </attributes>
-      <sound tempo="96">
-        <swing>
-          <straight/>
-        </swing>
-      </sound>
+      <sound tempo="96"/>
       <note>
         <rest measure="yes"/>
         <duration>33</duration>

--- a/data/rpatters1/timesigs_composite-ref-modified.musicxml
+++ b/data/rpatters1/timesigs_composite-ref-modified.musicxml
@@ -1,0 +1,120 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!DOCTYPE score-partwise PUBLIC "-//Recordare//DTD MusicXML 4.0 Partwise//EN" "http://www.musicxml.org/dtds/partwise.dtd">
+<score-partwise version="4.0">
+  <identification>
+    <encoding>
+      <software>Finale v27.4 for Mac</software>
+      <encoding-date>2026-06-30</encoding-date>
+      <supports attribute="new-system" element="print" type="yes" value="yes"/>
+      <supports attribute="new-page" element="print" type="yes" value="yes"/>
+      <supports element="accidental" type="yes"/>
+      <supports element="beam" type="yes"/>
+      <supports element="stem" type="yes"/>
+    </encoding>
+  </identification>
+  <defaults>
+    <scaling>
+      <millimeters>7.2319</millimeters>
+      <tenths>40</tenths>
+    </scaling>
+    <page-layout>
+      <page-height>1545</page-height>
+      <page-width>1194</page-width>
+      <page-margins type="both">
+        <left-margin>70</left-margin>
+        <right-margin>70</right-margin>
+        <top-margin>88</top-margin>
+        <bottom-margin>88</bottom-margin>
+      </page-margins>
+    </page-layout>
+    <system-layout>
+      <system-margins>
+        <left-margin>0</left-margin>
+        <right-margin>0</right-margin>
+      </system-margins>
+      <system-distance>121</system-distance>
+      <top-system-distance>70</top-system-distance>
+    </system-layout>
+    <appearance>
+      <line-width type="stem">0.7487</line-width>
+      <line-width type="beam">5</line-width>
+      <line-width type="staff">0.7487</line-width>
+      <line-width type="light barline">0.7487</line-width>
+      <line-width type="heavy barline">5</line-width>
+      <line-width type="leger">0.7487</line-width>
+      <line-width type="ending">0.7487</line-width>
+      <line-width type="wedge">0.7487</line-width>
+      <line-width type="enclosure">0.7487</line-width>
+      <line-width type="tuplet bracket">0.7487</line-width>
+      <note-size type="grace">60</note-size>
+      <note-size type="cue">60</note-size>
+      <distance type="hyphen">60</distance>
+      <distance type="beam">7.5</distance>
+    </appearance>
+    <music-font font-family="Maestro, engraved" font-size="20.5"/>
+    <word-font font-family="Times New Roman" font-size="10.25"/>
+  </defaults>
+  <part-list>
+    <score-part id="P1">
+      <part-name print-object="no">MusicXML Part</part-name>
+      <score-instrument id="P1-I1">
+        <instrument-name>SmartMusic SoftSynth 1</instrument-name>
+      </score-instrument>
+      <midi-instrument id="P1-I1">
+        <midi-channel>1</midi-channel>
+        <midi-bank>15489</midi-bank>
+        <midi-program>1</midi-program>
+        <volume>80</volume>
+        <pan>0</pan>
+      </midi-instrument>
+    </score-part>
+  </part-list>
+  <!--=========================================================-->
+  <part id="P1">
+    <measure number="1" width="983">
+      <print>
+        <system-layout>
+          <system-margins>
+            <left-margin>70</left-margin>
+            <right-margin>0</right-margin>
+          </system-margins>
+          <top-system-distance>211</top-system-distance>
+        </system-layout>
+        <measure-numbering>system</measure-numbering>
+      </print>
+      <attributes>
+        <divisions>2</divisions>
+        <key>
+          <fifths>0</fifths>
+          <mode>major</mode>
+        </key>
+        <time>
+          <beats>1 + 2.5</beats>
+          <beat-type>2 + 4</beat-type>
+          <beats>3 + 2</beats>
+          <beat-type>16</beat-type>
+          <beats>1.5 + 5</beats>
+          <beat-type>8 + 16</beat-type>
+        </time>
+        <clef>
+          <sign>G</sign>
+          <line>2</line>
+        </clef>
+      </attributes>
+      <sound tempo="96">
+        <swing>
+          <straight/>
+        </swing>
+      </sound>
+      <note>
+        <rest measure="yes"/>
+        <duration>33</duration>
+        <voice>1</voice>
+      </note>
+      <barline location="right">
+        <bar-style>light-heavy</bar-style>
+      </barline>
+    </measure>
+  </part>
+  <!--=========================================================-->
+</score-partwise>

--- a/data/rpatters1/timesigs_composite-ref.musicxml
+++ b/data/rpatters1/timesigs_composite-ref.musicxml
@@ -57,7 +57,6 @@
   <part-list>
     <score-part id="P1">
       <part-name print-object="no">MusicXML Part</part-name>
-      <group>score</group>
       <score-instrument id="P1-I1">
         <instrument-name>SmartMusic SoftSynth 1</instrument-name>
       </score-instrument>

--- a/data/rpatters1/timesigs_composite-ref.musicxml
+++ b/data/rpatters1/timesigs_composite-ref.musicxml
@@ -51,7 +51,7 @@
       <distance type="hyphen">60</distance>
       <distance type="beam">7.5</distance>
     </appearance>
-    <music-font font-family="Maestro,engraved" font-size="20.5"/>
+    <music-font font-family="Maestro, engraved" font-size="20.5"/>
     <word-font font-family="Times New Roman" font-size="10.25"/>
   </defaults>
   <part-list>

--- a/data/rpatters1/timesigs_composite-ref.musicxml
+++ b/data/rpatters1/timesigs_composite-ref.musicxml
@@ -51,12 +51,13 @@
       <distance type="hyphen">60</distance>
       <distance type="beam">7.5</distance>
     </appearance>
-    <music-font font-family="Maestro, engraved" font-size="20.5"/>
+    <music-font font-family="Maestro,engraved" font-size="20.5"/>
     <word-font font-family="Times New Roman" font-size="10.25"/>
   </defaults>
   <part-list>
     <score-part id="P1">
       <part-name print-object="no">MusicXML Part</part-name>
+      <group>score</group>
       <score-instrument id="P1-I1">
         <instrument-name>SmartMusic SoftSynth 1</instrument-name>
       </score-instrument>

--- a/src/include/mx/api/ComplexTimeSignature.h
+++ b/src/include/mx/api/ComplexTimeSignature.h
@@ -138,14 +138,14 @@ class ComplexTimeSignature
 
     // Returns a copy of the internally held MeteredTimeSignature.
     //
-    // Precondition: isMetered(). If !isMetered(), a default constructed MeteredTimeSignature is
-    // returned.
+    // Check isMetered() first. If this is not a metered time signature, a default constructed
+    // MeteredTimeSignature is returned.
     const MeteredTimeSignature metered() const;
 
     // Returns a copy of the senza-misura glyph (which could be an empty string).
     //
-    // Precondition: isSenzaMisura(). If !isSenzaMisura(), a default constructed (empty) string is
-    // returned.
+    // Check isSenzaMisura() first. If this is not a senza-misura time signature, a default
+    // constructed (empty) string is returned.
     const std::string senzaMisura() const;
 
     bool operator==(const ComplexTimeSignature &other) const;

--- a/src/include/mx/api/ComplexTimeSignature.h
+++ b/src/include/mx/api/ComplexTimeSignature.h
@@ -1,0 +1,148 @@
+// MusicXML Class Library
+// Copyright (c) by Matthew James Briggs
+// Distributed under the MIT License
+
+#pragma once
+
+#include "mx/api/ApiCommon.h"
+#include "mx/api/TimeSignatureData.h"
+
+#include <optional>
+#include <string>
+#include <variant>
+#include <vector>
+
+namespace mx
+{
+namespace api
+{
+
+// The full MusicXML time-symbol vocabulary. Used for a complex meter's own symbol and for an
+// interchangeable pair's symbol. Unlike the narrow TimeSignatureSymbol (common/cut only), this
+// includes the unusual display modes that force a signature into the complex arena.
+enum class ComplexTimeSymbol
+{
+    unspecified,  // ordinary fractional display
+    common,       // the C glyph
+    cut,          // the slashed-C glyph
+    singleNumber, // the meter drawn as a single number
+    note,         // the beat-type drawn as a downstem note glyph
+    dottedNote    // the beat-type drawn as a dotted downstem note glyph
+};
+
+// The line drawn between beats and beat-type (MusicXML time-separator). 'unspecified' writes no
+// attribute (the spec default is "none").
+enum class TimeSeparator
+{
+    unspecified,
+    none,
+    horizontal,
+    diagonal,
+    vertical,
+    adjacent
+};
+
+// How a dual/interchangeable pair is visually joined (MusicXML time-relation).
+enum class TimeRelation
+{
+    unspecified,
+    parentheses,
+    bracket,
+    equals,
+    slash,
+    space,
+    hyphen
+};
+
+// The alternate meter of an interchangeable dual pair, e.g. the "(6/8)" of "3/4 (6/8)". It decorates
+// a primary metered signature and carries its own relation, symbol, and separator, independent of
+// the primary's.
+struct InterchangeableTimeSignature
+{
+    // The alternate meter's fractions. One = simple, more than one = composite. Nonempty when used.
+    std::vector<TimeFraction> fractions;
+
+    TimeRelation relation{TimeRelation::unspecified};
+    ComplexTimeSymbol symbol{ComplexTimeSymbol::unspecified};
+    TimeSeparator separator{TimeSeparator::unspecified};
+};
+
+MXAPI_EQUALS_BEGIN(InterchangeableTimeSignature)
+MXAPI_EQUALS_MEMBER(fractions)
+MXAPI_EQUALS_MEMBER(relation)
+MXAPI_EQUALS_MEMBER(symbol)
+MXAPI_EQUALS_MEMBER(separator)
+MXAPI_EQUALS_END;
+MXAPI_NOT_EQUALS_AND_VECTORS(InterchangeableTimeSignature);
+
+// A metered (as opposed to senza-misura) complex time signature: a primary meter of one or more
+// fractions, plus its decorations. A single fraction with no symbol, no separator, and no
+// interchangeable is simple-equivalent and TimeChoice::complex collapses it back to the simple case;
+// so a MeteredTimeSignature that survives as complex always carries at least one of: more than one
+// fraction, an unusual symbol, a separator, or an interchangeable alternate.
+struct MeteredTimeSignature
+{
+    // The primary meter's fractions. One = a single meter (decorated); more than one = composite
+    // (additive), e.g. 2/4 + 3/8. Nonempty in a valid state.
+    std::vector<TimeFraction> fractions{TimeFraction{"4", "4"}};
+
+    ComplexTimeSymbol symbol{ComplexTimeSymbol::unspecified};
+    TimeSeparator separator{TimeSeparator::unspecified};
+    std::optional<InterchangeableTimeSignature> interchangeable;
+};
+
+MXAPI_EQUALS_BEGIN(MeteredTimeSignature)
+MXAPI_EQUALS_MEMBER(fractions)
+MXAPI_EQUALS_MEMBER(symbol)
+MXAPI_EQUALS_MEMBER(separator)
+MXAPI_EQUALS_MEMBER(interchangeable)
+MXAPI_EQUALS_END;
+MXAPI_NOT_EQUALS_AND_VECTORS(MeteredTimeSignature);
+
+// Everything unusual about a time signature, kept out of the way of the simple case. It is itself a
+// choice: either a metered signature (composite meters, unusual symbols, separators, interchangeable
+// dual meters) or senza-misura (unmetered music). The two are mutually exclusive in MusicXML, which
+// this choice makes structurally true: a senza-misura signature cannot carry a symbol or an
+// interchangeable, and a metered one cannot be senza-misura.
+//
+// Reached only through TimeChoice::asComplex(). Constructing one whose metered value is
+// simple-equivalent yields a *simple* TimeChoice instead (auto-collapse), so a plain N/D can never
+// hide in here.
+class ComplexTimeSignature
+{
+  public:
+    enum class Kind
+    {
+        metered,
+        senzaMisura
+    };
+
+    // Defaults to a metered 4/4 (this default is never simple-equivalent-collapsed on its own; that
+    // happens only when handed to TimeChoice::complex).
+    ComplexTimeSignature();
+
+    static ComplexTimeSignature metered(MeteredTimeSignature value);
+
+    // The string is the senza-misura display glyph (often empty, sometimes "X").
+    static ComplexTimeSignature senzaMisura(std::string glyph = {});
+
+    Kind kind() const;
+    bool isMetered() const;
+    bool isSenzaMisura() const;
+
+    // Precondition: isMetered().
+    const MeteredTimeSignature &asMetered() const;
+
+    // Precondition: isSenzaMisura(). The returned string is the display glyph (may be empty).
+    const std::string &asSenzaMisura() const;
+
+    bool operator==(const ComplexTimeSignature &other) const;
+
+  private:
+    std::variant<MeteredTimeSignature, std::string> myValue;
+};
+
+MXAPI_NOT_EQUALS_AND_VECTORS(ComplexTimeSignature);
+
+} // namespace api
+} // namespace mx

--- a/src/include/mx/api/ComplexTimeSignature.h
+++ b/src/include/mx/api/ComplexTimeSignature.h
@@ -77,7 +77,7 @@ MXAPI_NOT_EQUALS_AND_VECTORS(InterchangeableTimeSignature);
 
 // A metered (as opposed to senza-misura) complex time signature: a primary meter of one or more
 // fractions, plus its decorations. A single fraction with no symbol, no separator, and no
-// interchangeable is simple-equivalent and TimeChoice::complex collapses it back to the simple case;
+// interchangeable is simple-equivalent and the TimeChoice constructor collapses it back to the simple case;
 // so a MeteredTimeSignature that survives as complex always carries at least one of: more than one
 // fraction, an unusual symbol, a separator, or an interchangeable alternate.
 struct MeteredTimeSignature
@@ -118,7 +118,7 @@ class ComplexTimeSignature
     };
 
     // Defaults to a metered 4/4 (this default is never simple-equivalent-collapsed on its own; that
-    // happens only when handed to TimeChoice::complex).
+    // happens only when handed to the TimeChoice constructor).
     ComplexTimeSignature();
 
     static ComplexTimeSignature metered(MeteredTimeSignature value);

--- a/src/include/mx/api/ComplexTimeSignature.h
+++ b/src/include/mx/api/ComplexTimeSignature.h
@@ -136,11 +136,17 @@ class ComplexTimeSignature
     bool isMetered() const;
     bool isSenzaMisura() const;
 
-    // Precondition: isMetered()
-    const MeteredTimeSignature &asMetered() const;
+    // Returns a copy of the internally held MeteredTimeSignature.
+    //
+    // Precondition: isMetered(). If !isMetered(), a default constructed MeteredTimeSignature is
+    // returned.
+    const MeteredTimeSignature metered() const;
 
-    // Precondition: isSenzaMisura(). The returned string is the display glyph (may be empty).
-    const std::string &asSenzaMisura() const;
+    // Returns a copy of the senza-misura glyph (which could be an empty string).
+    //
+    // Precondition: isSenzaMisura(). If !isSenzaMisura(), a default constructed (empty) string is
+    // returned.
+    const std::string senzaMisura() const;
 
     bool operator==(const ComplexTimeSignature &other) const;
 

--- a/src/include/mx/api/ComplexTimeSignature.h
+++ b/src/include/mx/api/ComplexTimeSignature.h
@@ -76,10 +76,10 @@ MXAPI_EQUALS_END;
 MXAPI_NOT_EQUALS_AND_VECTORS(InterchangeableTimeSignature);
 
 // A metered (as opposed to senza-misura) complex time signature: a primary meter of one or more
-// fractions, plus its decorations. A single fraction with no symbol, no separator, and no
-// interchangeable is simple-equivalent and the TimeChoice constructor collapses it back to the simple case;
-// so a MeteredTimeSignature that survives as complex always carries at least one of: more than one
-// fraction, an unusual symbol, a separator, or an interchangeable alternate.
+// fractions, plus its decorations.
+//
+// Note: A single fraction with no symbol, no separator, and no interchangeable is simple-equivalent
+// and the TimeChoice constructor collapses it back to the simple case;
 struct MeteredTimeSignature
 {
     // The primary meter's fractions. One = a single meter (decorated); more than one = composite
@@ -99,15 +99,17 @@ MXAPI_EQUALS_MEMBER(interchangeable)
 MXAPI_EQUALS_END;
 MXAPI_NOT_EQUALS_AND_VECTORS(MeteredTimeSignature);
 
-// Everything unusual about a time signature, kept out of the way of the simple case. It is itself a
-// choice: either a metered signature (composite meters, unusual symbols, separators, interchangeable
-// dual meters) or senza-misura (unmetered music). The two are mutually exclusive in MusicXML, which
-// this choice makes structurally true: a senza-misura signature cannot carry a symbol or an
-// interchangeable, and a metered one cannot be senza-misura.
+// Models the full MusicXML time element, except for the most simple cases which are modeled by
+// TimeSignatureData.
 //
-// Reached only through TimeChoice::asComplex(). Constructing one whose metered value is
-// simple-equivalent yields a *simple* TimeChoice instead (auto-collapse), so a plain N/D can never
-// hide in here.
+// Included:
+// - composite meters
+// - symbols
+// - separator selection
+// - interchangeable meters
+// - senza-misura
+//
+// Include a ComplexTimeSignature in your score using TimeChoice{complex};
 class ComplexTimeSignature
 {
   public:
@@ -117,20 +119,24 @@ class ComplexTimeSignature
         senzaMisura
     };
 
-    // Defaults to a metered 4/4 (this default is never simple-equivalent-collapsed on its own; that
-    // happens only when handed to the TimeChoice constructor).
+    // Defaults to a metered 4/4.
+    //
+    // Note: if supplied to a TimeChoice, this would collapse to a simple time signature.
     ComplexTimeSignature();
 
-    static ComplexTimeSignature metered(MeteredTimeSignature value);
+    // Construct a metered time signature.
+    ComplexTimeSignature(MeteredTimeSignature value);
 
-    // The string is the senza-misura display glyph (often empty, sometimes "X").
-    static ComplexTimeSignature senzaMisura(std::string glyph = {});
+    // Construct a senza-misura time signature.
+    //
+    // glyph is free text; MusicXML defines no valid/invalid values beyond xs:string (e.g. "X").
+    ComplexTimeSignature(std::string glyph);
 
     Kind kind() const;
     bool isMetered() const;
     bool isSenzaMisura() const;
 
-    // Precondition: isMetered().
+    // Precondition: isMetered()
     const MeteredTimeSignature &asMetered() const;
 
     // Precondition: isSenzaMisura(). The returned string is the display glyph (may be empty).

--- a/src/include/mx/api/MeasureData.h
+++ b/src/include/mx/api/MeasureData.h
@@ -6,12 +6,9 @@
 
 #include "mx/api/ApiCommon.h"
 #include "mx/api/BarlineData.h"
-#include "mx/api/ClefData.h"
-#include "mx/api/DirectionData.h"
 #include "mx/api/KeyData.h"
 #include "mx/api/PartSymbolData.h"
 #include "mx/api/StaffData.h"
-#include "mx/api/TempoData.h"
 #include "mx/api/TimeChoice.h"
 #include "mx/api/TransposeData.h"
 
@@ -22,7 +19,7 @@ namespace mx
 {
 namespace api
 {
-/// This typedef help readability in a few places such as the layout map in ScoreData.
+// This typedef helps readability in a few places such as the layout map in ScoreData.
 using MeasureIndex = int;
 
 class MeasureData
@@ -31,67 +28,46 @@ class MeasureData
     // this is the notes and other music data
     std::vector<StaffData> staves;
 
-    // The measure's time signature (applies to all staves). A TimeChoice: simple for the ordinary
-    // N/D case, complex for anything unusual.
+    // The measure's time signature (applies to all staves).
+    //
+    // Breaking change: this used to be TimeSignatureData but was changed to TimeChoice
     TimeChoice timeSignature;
 
-    // Only use this if you need different time signatures on different staves. Normally empty; keyed
-    // by staff index, one entry per staff-scoped <time number="N"> override. Effective-time-signature
-    // rule: for a given staff, an entry here whose key matches wins; otherwise fall back to the
-    // singular timeSignature above.
+    // Only use this if you need different time signatures on different staves. Normally empty;
+    // keyed by staff index, one entry per staff-scoped <time number="N"> override.
+    // Effective-time- signature rule: for a given staff, an entry here whose key matches wins;
+    // otherwise fall back to the singular timeSignature above.
     std::map<int, TimeChoice> staffTimeSignatures;
 
-    // an empty measureNumber indicates a normal
-    // measure number (i.e. the measure's
-    // index + 1).  only read or write to
-    // this field when handling overridden
-    // measure numbers
+    // an empty measureNumber indicates a normal measure number (i.e. the measure's index + 1). only
+    // read or write to this field when handling overridden measure numbers
     //
     // MusicXML Documentation:
-    // In partwise files, the number attribute
-    // should be the same for measures in
-    // different parts that share the same left
-    // barline. While the number attribute is
-    // often numeric, it does not have to be.
-    // Non-numeric values are typically used
-    // together with the implicit or non-
-    // controlling attributes being set to "yes".
-    // For a pickup measure, the number attribute
-    // is typically set to "0" and the implicit
-    // attribute is typically set to "yes".
-    // Further details about measure numbering
-    // can be defined using the measure-numbering
-    // element.
+    // In partwise files, the number attribute should be the same for measures in different parts
+    // that share the same left barline. While the number attribute is often numeric, it does not
+    // have to be. Non-numeric values are typically used together with the implicit or
+    // non-controlling attributes being set to "yes".For a pickup measure, the number attribute is
+    // typically set to "0" and the implicit attribute is typically set to "yes".Further details
+    // about measure numbering can be defined using the measure-numbering element.
     std::string number;
 
-    // The measure-numbering-value type
-    // describes how measure numbers are
-    // displayed on this part: no numbers,
-    // numbers every measure, or numbers
-    // every system.
-    //
+    // The measure-numbering-value type describes how measure numbers are displayed on this part:
+    // no numbers, numbers every measure, or numbers every system.
     MeasureNumbering measureNumbering;
 
-    // a number greater than zero indicates that
-    // this measure is the beginning of a mult-
-    // measure rest that will last for the
-    // indicated number of measures. following
-    // measures will be affected by this.
+    // a number greater than zero indicates that this measure is the beginning of a mult-measure
+    // rest that will last for the indicated number of measures. following measures will be affected
+    // by this.
     int multiMeasureRest;
 
-    // The implicit attribute is set to "yes" for
-    // measures where the measure number should
-    // never appear, such as pickup measures and
-    // the last half of mid-measure repeats. The
-    // value is "no" if not specified.
+    // The implicit attribute is set to "yes" for measures where the measure number should never
+    // appear, such as pickup measures and the last half of mid-measure repeats. The value is "no"
+    // if not specified.
     Bool implicit;
 
-    // The non-controlling attribute is intended for
-    // use in multimetric music like the Don Giovanni
-    // minuet. If set to "yes", the left barline in
-    // this measure does not coincide with the left
-    // barline of measures in other parts. The value
-    // is "no" if not specified.
+    // The non-controlling attribute is intended for use in multimetric music like the Don Giovanni
+    // minuet. If set to "yes", the left barline in this measure does not coincide with the left
+    // barline of measures in other parts. The value is "no" if not specified.
     Bool nonControlling;
 
     // a width value less than 0 means 'unspecified'

--- a/src/include/mx/api/MeasureData.h
+++ b/src/include/mx/api/MeasureData.h
@@ -12,7 +12,7 @@
 #include "mx/api/PartSymbolData.h"
 #include "mx/api/StaffData.h"
 #include "mx/api/TempoData.h"
-#include "mx/api/TimeSignatureData.h"
+#include "mx/api/TimeChoice.h"
 #include "mx/api/TransposeData.h"
 
 #include <map>
@@ -31,7 +31,15 @@ class MeasureData
     // this is the notes and other music data
     std::vector<StaffData> staves;
 
-    TimeSignatureData timeSignature;
+    // The measure's time signature (applies to all staves). A TimeChoice: simple for the ordinary
+    // N/D case, complex for anything unusual.
+    TimeChoice timeSignature;
+
+    // Only use this if you need different time signatures on different staves. Normally empty; keyed
+    // by staff index, one entry per staff-scoped <time number="N"> override. Effective-time-signature
+    // rule: for a given staff, an entry here whose key matches wins; otherwise fall back to the
+    // singular timeSignature above.
+    std::map<int, TimeChoice> staffTimeSignatures;
 
     // an empty measureNumber indicates a normal
     // measure number (i.e. the measure's
@@ -110,6 +118,7 @@ class MeasureData
 MXAPI_EQUALS_BEGIN(MeasureData)
 MXAPI_EQUALS_MEMBER(staves)
 MXAPI_EQUALS_MEMBER(timeSignature)
+MXAPI_EQUALS_MEMBER(staffTimeSignatures)
 MXAPI_EQUALS_MEMBER(number)
 MXAPI_EQUALS_MEMBER(measureNumbering)
 MXAPI_EQUALS_MEMBER(multiMeasureRest)

--- a/src/include/mx/api/TimeChoice.h
+++ b/src/include/mx/api/TimeChoice.h
@@ -33,7 +33,7 @@ namespace api
 // signature, then the TimeChoice class will collapse it to a simple time signature.
 //
 // Example (the common case):
-//   measure.timeSignature = TimeChoice(TimeSignatureData{TimeSignatureSymbol::unspecified, TimeFraction{"3", "4"}});
+//   measure.timeSignature = TimeChoice(TimeSignatureData{"3", "4"});
 //   if (measure.timeSignature.isSimple())
 //   {
 //       const TimeSignatureData data = measure.timeSignature.simple();

--- a/src/include/mx/api/TimeChoice.h
+++ b/src/include/mx/api/TimeChoice.h
@@ -1,0 +1,78 @@
+// MusicXML Class Library
+// Copyright (c) by Matthew James Briggs
+// Distributed under the MIT License
+
+#pragma once
+
+#include "mx/api/ApiCommon.h"
+#include "mx/api/ComplexTimeSignature.h"
+#include "mx/api/TimeSignatureData.h"
+
+#include <variant>
+
+namespace mx
+{
+namespace api
+{
+
+// A measure's (or a staff's) time signature. It switches between the simple case -- the ordinary
+// N/D you want 99% of the time -- and the complex case, which quarantines everything unusual
+// (composite meters, senza-misura, interchangeable, unusual display symbols). Read the kind, then
+// reach for asSimple() or asComplex().
+//
+// The whole-<time> attributes that apply regardless of shape live here, not on either leaf:
+// isImplicit (was the signature restated in this measure or carried forward) and display
+// (print-object show/hide).
+//
+// Invariant: a simple-equivalent signature is always held as simple. TimeChoice::complex collapses a
+// complex value whose meter is really just a plain fraction (one fraction, no interchangeable, no
+// separator, and a symbol the simple case can express) down to simple, so there is exactly one
+// canonical representation and the simple case can never hide inside the complex one.
+//
+// Defaults to a simple, implicit 4/4.
+class TimeChoice
+{
+  public:
+    enum class Kind
+    {
+        simple,
+        complex
+    };
+
+    // True when the source did not restate the time signature here (it was carried forward). The
+    // writer emits a <time> only for entries where this is false. Denormalized onto every measure.
+    bool isImplicit{true};
+
+    // Print/hide the time signature (<time print-object=...>). Ignored when isImplicit.
+    Bool display{Bool::unspecified};
+
+    // Defaults to a simple, implicit 4/4.
+    TimeChoice();
+
+    static TimeChoice simple(TimeSignatureData value);
+
+    // Builds a complex time signature, unless the value is simple-equivalent, in which case the
+    // result is a *simple* TimeChoice (auto-collapse). isImplicit/display are left at their defaults;
+    // set them on the returned value.
+    static TimeChoice complex(ComplexTimeSignature value);
+
+    Kind kind() const;
+    bool isSimple() const;
+    bool isComplex() const;
+
+    // Precondition: isSimple().
+    const TimeSignatureData &asSimple() const;
+
+    // Precondition: isComplex().
+    const ComplexTimeSignature &asComplex() const;
+
+    bool operator==(const TimeChoice &other) const;
+
+  private:
+    std::variant<TimeSignatureData, ComplexTimeSignature> myValue;
+};
+
+MXAPI_NOT_EQUALS_AND_VECTORS(TimeChoice);
+
+} // namespace api
+} // namespace mx

--- a/src/include/mx/api/TimeChoice.h
+++ b/src/include/mx/api/TimeChoice.h
@@ -73,14 +73,14 @@ class TimeChoice
 
     // Returns a copy of the internally held TimeSignatureData.
     //
-    // Precondition: isSimple(). If !isSimple(), a default constructed TimeSignatureData is
-    // returned.
+    // Check isSimple() first. If this is not a simple time signature, a default constructed
+    // TimeSignatureData is returned.
     const TimeSignatureData simple() const;
 
     // Returns a copy of the internally held ComplexTimeSignature.
     //
-    // Precondition: isComplex(). If !isComplex(), a default constructed ComplexTimeSignature is
-    // returned.
+    // Check isComplex() first. If this is not a complex time signature, a default constructed
+    // ComplexTimeSignature is returned.
     const ComplexTimeSignature complex() const;
 
     bool operator==(const TimeChoice &other) const;

--- a/src/include/mx/api/TimeChoice.h
+++ b/src/include/mx/api/TimeChoice.h
@@ -36,7 +36,7 @@ namespace api
 //   measure.timeSignature = TimeChoice(TimeSignatureData{TimeSignatureSymbol::unspecified, TimeFraction{"3", "4"}});
 //   if (measure.timeSignature.isSimple())
 //   {
-//       const TimeSignatureData &data = measure.timeSignature.asSimple();
+//       const TimeSignatureData data = measure.timeSignature.simple();
 //       assert(data.fraction.beats == "3" && data.fraction.beatType == "4");
 //   }
 //
@@ -71,11 +71,17 @@ class TimeChoice
     bool isSimple() const;
     bool isComplex() const;
 
-    // Precondition: isSimple().
-    const TimeSignatureData &asSimple() const;
+    // Returns a copy of the internally held TimeSignatureData.
+    //
+    // Precondition: isSimple(). If !isSimple(), a default constructed TimeSignatureData is
+    // returned.
+    const TimeSignatureData simple() const;
 
-    // Precondition: isComplex().
-    const ComplexTimeSignature &asComplex() const;
+    // Returns a copy of the internally held ComplexTimeSignature.
+    //
+    // Precondition: isComplex(). If !isComplex(), a default constructed ComplexTimeSignature is
+    // returned.
+    const ComplexTimeSignature complex() const;
 
     bool operator==(const TimeChoice &other) const;
 

--- a/src/include/mx/api/TimeChoice.h
+++ b/src/include/mx/api/TimeChoice.h
@@ -15,21 +15,32 @@ namespace mx
 namespace api
 {
 
-// A measure's (or a staff's) time signature. It switches between the simple case -- the ordinary
-// N/D you want 99% of the time -- and the complex case, which quarantines everything unusual
-// (composite meters, senza-misura, interchangeable, unusual display symbols). Read the kind, then
-// reach for asSimple() or asComplex().
+// A variant class that switches between a simple (e.g. 3/4 or C) and a complex (e.g. 5/8+3/8) time
+// signature.
 //
-// The whole-<time> attributes that apply regardless of shape live here, not on either leaf:
-// isImplicit (was the signature restated in this measure or carried forward) and display
-// (print-object show/hide).
+// Justification: The simple time signature use case is much more common than the complex one, and
+// MusicXML's time signature model is quite difficult to understand and use properly. In order to
+// simplify the process for the most common use cases, this class offers access to a simple
+// TimeSignatureData struct for simple mode and a ComplexTimeSignature class for complex mode.
 //
-// Invariant: a simple-equivalent signature is always held as simple. TimeChoice::complex collapses a
-// complex value whose meter is really just a plain fraction (one fraction, no interchangeable, no
-// separator, and a symbol the simple case can express) down to simple, so there is exactly one
-// canonical representation and the simple case can never hide inside the complex one.
+// The <time> attributes that apply regardless of shape live here. isImplicit is an `mx::api`
+// invention because, unlike MusicXML, we store a time signature at the beginning of each measure.
+// If it is simply being carried over from the previous measure, then isImplicit is true.
 //
-// Defaults to a simple, implicit 4/4.
+// The display field correlates to <time print-object="yes/no"> and can be absent with unspecified.
+//
+// If a ComplexTimeSignature is used to construct something that can be represented as a simple time
+// signature, then the TimeChoice class will collapse it to a simple time signature.
+//
+// Example (the common case):
+//   measure.timeSignature = TimeChoice(TimeSignatureData{TimeSignatureSymbol::unspecified, TimeFraction{"3", "4"}});
+//   if (measure.timeSignature.isSimple())
+//   {
+//       const TimeSignatureData &data = measure.timeSignature.asSimple();
+//       assert(data.fraction.beats == "3" && data.fraction.beatType == "4");
+//   }
+//
+// Defaults to 4/4.
 class TimeChoice
 {
   public:
@@ -49,12 +60,12 @@ class TimeChoice
     // Defaults to a simple, implicit 4/4.
     TimeChoice();
 
-    static TimeChoice simple(TimeSignatureData value);
+    TimeChoice(TimeSignatureData value);
 
     // Builds a complex time signature, unless the value is simple-equivalent, in which case the
     // result is a *simple* TimeChoice (auto-collapse). isImplicit/display are left at their defaults;
-    // set them on the returned value.
-    static TimeChoice complex(ComplexTimeSignature value);
+    // set them after construction.
+    TimeChoice(ComplexTimeSignature value);
 
     Kind kind() const;
     bool isSimple() const;

--- a/src/include/mx/api/TimeSignatureData.h
+++ b/src/include/mx/api/TimeSignatureData.h
@@ -12,52 +12,56 @@ namespace mx
 {
 namespace api
 {
+
+// The symbol drawn in place of, or alongside, a simple time signature. This is the narrow vocabulary
+// that belongs to the simple case: an ordinary fraction, optionally shown with the C (common) or the
+// slashed-C (cut) glyph. The weirder display modes (single-number, note, dotted-note) live only in
+// the complex arena (see ComplexTimeSignature.h) and are not expressible here on purpose.
 enum class TimeSignatureSymbol
 {
-    unspecified,
-    common,
-    cut,
-    singleNumber
+    unspecified, // ordinary fractional display, e.g. 4/4 drawn as two numbers
+    common,      // the C glyph (4/4)
+    cut          // the slashed-C glyph (2/2)
 };
 
-class TimeSignatureData
+// One beats/beat-type pair. The strings are free-form by design: they may hold compound values
+// ("3+2"), decimals ("1 + 2.5"), or compound denominators ("8 + 16"). This is the shared leaf reused
+// by the simple TimeSignatureData and by the composite/interchangeable meters in the complex arena;
+// it carries no symbol, which is what lets it be shared across arenas whose symbol vocabularies differ.
+struct TimeFraction
 {
-  public:
-    // common, cut
-    TimeSignatureSymbol symbol;
-
-    // the top number of the time signature, e.g. "5" in a "5/4" or "3+2" in a "(3+2)/8"
+    // the top number of the time signature, e.g. "5" in "5/4" or "3+2" in "(3+2)/8"
     std::string beats;
 
-    // the bottom number of the time signature, e.g. "4" in a "5/4"
+    // the bottom number of the time signature, e.g. "4" in "5/4"
     std::string beatType;
+};
 
-    // a time signature is implicit when it is not specified by the musicxml
-    bool isImplicit;
+MXAPI_EQUALS_BEGIN(TimeFraction)
+MXAPI_EQUALS_MEMBER(beats)
+MXAPI_EQUALS_MEMBER(beatType)
+MXAPI_EQUALS_END;
+MXAPI_NOT_EQUALS_AND_VECTORS(TimeFraction);
 
-    // use this to hide a time sigature with Bool::no. If a time signature is
-    // implicit, the 'display' field will be ignored
-    Bool display;
-
-    inline bool isEqualTo(const TimeSignatureData &other) const
-    {
-        return (beats == other.beats) && (beatType == other.beatType) && (symbol == other.symbol);
-    }
-
-    TimeSignatureData()
-        : symbol{TimeSignatureSymbol::unspecified}, beats{"4"}, beatType{"4"}, isImplicit{true},
-          display{Bool::unspecified}
-    {
-    }
+// The simple time signature: the ordinary N/D that you reach for 99% of the time, optionally shown
+// with the common or cut glyph. Everything unusual (composite meters, senza-misura, interchangeable
+// dual meters, and the single-number/note/dotted-note display modes) is quarantined in
+// ComplexTimeSignature. Access a measure's time signature through TimeChoice (TimeChoice.h), which
+// switches between this simple case and the complex one and holds the whole-<time> attributes
+// (isImplicit, display).
+//
+// Defaults to 4/4 with no symbol.
+struct TimeSignatureData
+{
+    TimeSignatureSymbol symbol{TimeSignatureSymbol::unspecified};
+    TimeFraction fraction{"4", "4"};
 };
 
 MXAPI_EQUALS_BEGIN(TimeSignatureData)
 MXAPI_EQUALS_MEMBER(symbol)
-MXAPI_EQUALS_MEMBER(beats)
-MXAPI_EQUALS_MEMBER(beatType)
-MXAPI_EQUALS_MEMBER(isImplicit)
-MXAPI_EQUALS_MEMBER(display)
+MXAPI_EQUALS_MEMBER(fraction)
 MXAPI_EQUALS_END;
 MXAPI_NOT_EQUALS_AND_VECTORS(TimeSignatureData);
+
 } // namespace api
 } // namespace mx

--- a/src/include/mx/api/TimeSignatureData.h
+++ b/src/include/mx/api/TimeSignatureData.h
@@ -43,16 +43,21 @@ MXAPI_EQUALS_MEMBER(beatType)
 MXAPI_EQUALS_END;
 MXAPI_NOT_EQUALS_AND_VECTORS(TimeFraction);
 
-// The simple time signature: the ordinary N/D that you reach for 99% of the time, optionally shown
-// with the common or cut glyph. Everything unusual (composite meters, senza-misura, interchangeable
-// dual meters, and the single-number/note/dotted-note display modes) is quarantined in
-// ComplexTimeSignature. Access a measure's time signature through TimeChoice (TimeChoice.h), which
-// switches between this simple case and the complex one and holds the whole-<time> attributes
-// (isImplicit, display).
+// The simple time signature: the ordinary numerator over denominator that you see most often.
+// Common and cut time are also supported by setting the symbol. (Note it is possible to set the
+// symbol even when the underlying beats and beatType don't match. For example C with 3/4 is not
+// prohibited by the spec or by mx::api.
 //
 // Defaults to 4/4 with no symbol.
 struct TimeSignatureData
 {
+    // TODO: implement these constructors and use the shortest expressions you can with them in tests.
+    // TODO: note these are psuedocode because I have been writing Rust
+    TimeSignatureData{beats: std::string, beatType: std::string};
+    TimeSignatureData{beats: std:string, beatType: std::string, symbol: TimeSignatureSymbol};
+    TimeSignatureData{fraction: TimeFraction}
+    TimeSignatureData{fraction: TimeFraction, symbol: TimeSignatureSymbol};
+
     TimeSignatureSymbol symbol{TimeSignatureSymbol::unspecified};
     TimeFraction fraction{"4", "4"};
 };

--- a/src/include/mx/api/TimeSignatureData.h
+++ b/src/include/mx/api/TimeSignatureData.h
@@ -7,6 +7,7 @@
 #include "mx/api/ApiCommon.h"
 
 #include <string>
+#include <utility>
 
 namespace mx
 {
@@ -51,12 +52,18 @@ MXAPI_NOT_EQUALS_AND_VECTORS(TimeFraction);
 // Defaults to 4/4 with no symbol.
 struct TimeSignatureData
 {
-    // TODO: implement these constructors and use the shortest expressions you can with them in tests.
-    // TODO: note these are psuedocode because I have been writing Rust
-    TimeSignatureData{beats: std::string, beatType: std::string};
-    TimeSignatureData{beats: std:string, beatType: std::string, symbol: TimeSignatureSymbol};
-    TimeSignatureData{fraction: TimeFraction}
-    TimeSignatureData{fraction: TimeFraction, symbol: TimeSignatureSymbol};
+    TimeSignatureData() = default;
+
+    explicit TimeSignatureData(std::string beats, std::string beatType,
+                               TimeSignatureSymbol symbol = TimeSignatureSymbol::unspecified)
+        : symbol{symbol}, fraction{TimeFraction{std::move(beats), std::move(beatType)}}
+    {
+    }
+
+    explicit TimeSignatureData(TimeFraction fraction, TimeSignatureSymbol symbol = TimeSignatureSymbol::unspecified)
+        : symbol{symbol}, fraction{std::move(fraction)}
+    {
+    }
 
     TimeSignatureSymbol symbol{TimeSignatureSymbol::unspecified};
     TimeFraction fraction{"4", "4"};

--- a/src/private/mx/api/ComplexTimeSignature.cpp
+++ b/src/private/mx/api/ComplexTimeSignature.cpp
@@ -4,7 +4,6 @@
 
 #include "mx/api/ComplexTimeSignature.h"
 
-#include <cassert>
 #include <utility>
 
 namespace mx
@@ -39,16 +38,22 @@ bool ComplexTimeSignature::isSenzaMisura() const
     return std::holds_alternative<std::string>(myValue);
 }
 
-const MeteredTimeSignature &ComplexTimeSignature::asMetered() const
+const MeteredTimeSignature ComplexTimeSignature::metered() const
 {
-    assert(isMetered());
-    return *std::get_if<MeteredTimeSignature>(&myValue);
+    if (const auto *value = std::get_if<MeteredTimeSignature>(&myValue))
+    {
+        return *value;
+    }
+    return MeteredTimeSignature{};
 }
 
-const std::string &ComplexTimeSignature::asSenzaMisura() const
+const std::string ComplexTimeSignature::senzaMisura() const
 {
-    assert(isSenzaMisura());
-    return *std::get_if<std::string>(&myValue);
+    if (const auto *value = std::get_if<std::string>(&myValue))
+    {
+        return *value;
+    }
+    return std::string{};
 }
 
 bool ComplexTimeSignature::operator==(const ComplexTimeSignature &other) const

--- a/src/private/mx/api/ComplexTimeSignature.cpp
+++ b/src/private/mx/api/ComplexTimeSignature.cpp
@@ -1,0 +1,66 @@
+// MusicXML Class Library
+// Copyright (c) by Matthew James Briggs
+// Distributed under the MIT License
+
+#include "mx/api/ComplexTimeSignature.h"
+
+#include <cassert>
+#include <utility>
+
+namespace mx
+{
+namespace api
+{
+
+ComplexTimeSignature::ComplexTimeSignature() : myValue{MeteredTimeSignature{}}
+{
+}
+
+ComplexTimeSignature ComplexTimeSignature::metered(MeteredTimeSignature value)
+{
+    ComplexTimeSignature result;
+    result.myValue = std::move(value);
+    return result;
+}
+
+ComplexTimeSignature ComplexTimeSignature::senzaMisura(std::string glyph)
+{
+    ComplexTimeSignature result;
+    result.myValue = std::move(glyph);
+    return result;
+}
+
+ComplexTimeSignature::Kind ComplexTimeSignature::kind() const
+{
+    return std::holds_alternative<MeteredTimeSignature>(myValue) ? Kind::metered : Kind::senzaMisura;
+}
+
+bool ComplexTimeSignature::isMetered() const
+{
+    return std::holds_alternative<MeteredTimeSignature>(myValue);
+}
+
+bool ComplexTimeSignature::isSenzaMisura() const
+{
+    return std::holds_alternative<std::string>(myValue);
+}
+
+const MeteredTimeSignature &ComplexTimeSignature::asMetered() const
+{
+    assert(isMetered());
+    return *std::get_if<MeteredTimeSignature>(&myValue);
+}
+
+const std::string &ComplexTimeSignature::asSenzaMisura() const
+{
+    assert(isSenzaMisura());
+    return *std::get_if<std::string>(&myValue);
+}
+
+bool ComplexTimeSignature::operator==(const ComplexTimeSignature &other) const
+{
+    return myValue == other.myValue;
+}
+
+} // namespace api
+} // namespace mx

--- a/src/private/mx/api/ComplexTimeSignature.cpp
+++ b/src/private/mx/api/ComplexTimeSignature.cpp
@@ -16,18 +16,12 @@ ComplexTimeSignature::ComplexTimeSignature() : myValue{MeteredTimeSignature{}}
 {
 }
 
-ComplexTimeSignature ComplexTimeSignature::metered(MeteredTimeSignature value)
+ComplexTimeSignature::ComplexTimeSignature(MeteredTimeSignature value) : myValue{std::move(value)}
 {
-    ComplexTimeSignature result;
-    result.myValue = std::move(value);
-    return result;
 }
 
-ComplexTimeSignature ComplexTimeSignature::senzaMisura(std::string glyph)
+ComplexTimeSignature::ComplexTimeSignature(std::string glyph) : myValue{std::move(glyph)}
 {
-    ComplexTimeSignature result;
-    result.myValue = std::move(glyph);
-    return result;
 }
 
 ComplexTimeSignature::Kind ComplexTimeSignature::kind() const

--- a/src/private/mx/api/TimeChoice.cpp
+++ b/src/private/mx/api/TimeChoice.cpp
@@ -1,0 +1,115 @@
+// MusicXML Class Library
+// Copyright (c) by Matthew James Briggs
+// Distributed under the MIT License
+
+#include "mx/api/TimeChoice.h"
+
+#include <cassert>
+#include <optional>
+#include <utility>
+
+namespace mx
+{
+namespace api
+{
+
+// Maps a complex symbol to the narrow simple symbol, but only for the three values the simple case
+// can express. The unusual display modes (single-number, note, dotted-note) have no simple
+// equivalent, so they return nullopt and keep the signature complex.
+static std::optional<TimeSignatureSymbol> timeChoiceSimpleSymbol(ComplexTimeSymbol symbol)
+{
+    switch (symbol)
+    {
+    case ComplexTimeSymbol::unspecified:
+        return TimeSignatureSymbol::unspecified;
+    case ComplexTimeSymbol::common:
+        return TimeSignatureSymbol::common;
+    case ComplexTimeSymbol::cut:
+        return TimeSignatureSymbol::cut;
+    case ComplexTimeSymbol::singleNumber:
+    case ComplexTimeSymbol::note:
+    case ComplexTimeSymbol::dottedNote:
+        return std::nullopt;
+    }
+    return std::nullopt;
+}
+
+// A metered signature is simple-equivalent when it is a single plain fraction with no decorations:
+// one fraction, no interchangeable, no separator, and a symbol the simple case can express. Returns
+// the equivalent simple value, or nullopt when the meter is genuinely complex.
+static std::optional<TimeSignatureData> timeChoiceAsSimpleEquivalent(const ComplexTimeSignature &value)
+{
+    if (!value.isMetered())
+    {
+        return std::nullopt;
+    }
+    const auto &metered = value.asMetered();
+    if (metered.fractions.size() != 1 || metered.interchangeable.has_value() ||
+        metered.separator != TimeSeparator::unspecified)
+    {
+        return std::nullopt;
+    }
+    const auto simpleSymbol = timeChoiceSimpleSymbol(metered.symbol);
+    if (!simpleSymbol.has_value())
+    {
+        return std::nullopt;
+    }
+    return TimeSignatureData{*simpleSymbol, metered.fractions.front()};
+}
+
+TimeChoice::TimeChoice() : myValue{TimeSignatureData{}}
+{
+}
+
+TimeChoice TimeChoice::simple(TimeSignatureData value)
+{
+    TimeChoice result;
+    result.myValue = std::move(value);
+    return result;
+}
+
+TimeChoice TimeChoice::complex(ComplexTimeSignature value)
+{
+    if (const auto simpleEquivalent = timeChoiceAsSimpleEquivalent(value); simpleEquivalent.has_value())
+    {
+        return simple(*simpleEquivalent);
+    }
+    TimeChoice result;
+    result.myValue = std::move(value);
+    return result;
+}
+
+TimeChoice::Kind TimeChoice::kind() const
+{
+    return std::holds_alternative<TimeSignatureData>(myValue) ? Kind::simple : Kind::complex;
+}
+
+bool TimeChoice::isSimple() const
+{
+    return std::holds_alternative<TimeSignatureData>(myValue);
+}
+
+bool TimeChoice::isComplex() const
+{
+    return std::holds_alternative<ComplexTimeSignature>(myValue);
+}
+
+const TimeSignatureData &TimeChoice::asSimple() const
+{
+    assert(isSimple());
+    return *std::get_if<TimeSignatureData>(&myValue);
+}
+
+const ComplexTimeSignature &TimeChoice::asComplex() const
+{
+    assert(isComplex());
+    return *std::get_if<ComplexTimeSignature>(&myValue);
+}
+
+bool TimeChoice::operator==(const TimeChoice &other) const
+{
+    return isImplicit == other.isImplicit && display == other.display && myValue == other.myValue;
+}
+
+} // namespace api
+} // namespace mx

--- a/src/private/mx/api/TimeChoice.cpp
+++ b/src/private/mx/api/TimeChoice.cpp
@@ -61,22 +61,20 @@ TimeChoice::TimeChoice() : myValue{TimeSignatureData{}}
 {
 }
 
-TimeChoice TimeChoice::simple(TimeSignatureData value)
+TimeChoice::TimeChoice(TimeSignatureData value) : myValue{std::move(value)}
 {
-    TimeChoice result;
-    result.myValue = std::move(value);
-    return result;
 }
 
-TimeChoice TimeChoice::complex(ComplexTimeSignature value)
+TimeChoice::TimeChoice(ComplexTimeSignature value)
 {
     if (const auto simpleEquivalent = timeChoiceAsSimpleEquivalent(value); simpleEquivalent.has_value())
     {
-        return simple(*simpleEquivalent);
+        myValue = *simpleEquivalent;
     }
-    TimeChoice result;
-    result.myValue = std::move(value);
-    return result;
+    else
+    {
+        myValue = std::move(value);
+    }
 }
 
 TimeChoice::Kind TimeChoice::kind() const

--- a/src/private/mx/api/TimeChoice.cpp
+++ b/src/private/mx/api/TimeChoice.cpp
@@ -4,7 +4,6 @@
 
 #include "mx/api/TimeChoice.h"
 
-#include <cassert>
 #include <optional>
 #include <utility>
 
@@ -43,7 +42,7 @@ static std::optional<TimeSignatureData> timeChoiceAsSimpleEquivalent(const Compl
     {
         return std::nullopt;
     }
-    const auto &metered = value.asMetered();
+    const auto &metered = value.metered();
     if (metered.fractions.size() != 1 || metered.interchangeable.has_value() ||
         metered.separator != TimeSeparator::unspecified)
     {
@@ -92,16 +91,22 @@ bool TimeChoice::isComplex() const
     return std::holds_alternative<ComplexTimeSignature>(myValue);
 }
 
-const TimeSignatureData &TimeChoice::asSimple() const
+const TimeSignatureData TimeChoice::simple() const
 {
-    assert(isSimple());
-    return *std::get_if<TimeSignatureData>(&myValue);
+    if (const auto *value = std::get_if<TimeSignatureData>(&myValue))
+    {
+        return *value;
+    }
+    return TimeSignatureData{};
 }
 
-const ComplexTimeSignature &TimeChoice::asComplex() const
+const ComplexTimeSignature TimeChoice::complex() const
 {
-    assert(isComplex());
-    return *std::get_if<ComplexTimeSignature>(&myValue);
+    if (const auto *value = std::get_if<ComplexTimeSignature>(&myValue))
+    {
+        return *value;
+    }
+    return ComplexTimeSignature{};
 }
 
 bool TimeChoice::operator==(const TimeChoice &other) const

--- a/src/private/mx/api/TimeChoice.cpp
+++ b/src/private/mx/api/TimeChoice.cpp
@@ -53,7 +53,7 @@ static std::optional<TimeSignatureData> timeChoiceAsSimpleEquivalent(const Compl
     {
         return std::nullopt;
     }
-    return TimeSignatureData{*simpleSymbol, metered.fractions.front()};
+    return TimeSignatureData{metered.fractions.front(), *simpleSymbol};
 }
 
 TimeChoice::TimeChoice() : myValue{TimeSignatureData{}}

--- a/src/private/mx/examples/Write.cpp
+++ b/src/private/mx/examples/Write.cpp
@@ -39,7 +39,7 @@ int main(int argc, const char *argv[])
     // add a measure
     part.measures.emplace_back(MeasureData{});
     auto &measure = part.measures.back();
-    measure.timeSignature = TimeChoice::simple(TimeSignatureData{});
+    measure.timeSignature = TimeChoice(TimeSignatureData{});
     measure.timeSignature.isImplicit = false;
 
     // add a staff

--- a/src/private/mx/examples/Write.cpp
+++ b/src/private/mx/examples/Write.cpp
@@ -39,8 +39,7 @@ int main(int argc, const char *argv[])
     // add a measure
     part.measures.emplace_back(MeasureData{});
     auto &measure = part.measures.back();
-    measure.timeSignature.beats = "4";
-    measure.timeSignature.beatType = "4";
+    measure.timeSignature = TimeChoice::simple(TimeSignatureData{});
     measure.timeSignature.isImplicit = false;
 
     // add a staff

--- a/src/private/mx/impl/Converter.cpp
+++ b/src/private/mx/impl/Converter.cpp
@@ -1340,6 +1340,41 @@ const Converter::EnumMap<core::CancelLocation, api::CancelLocation> Converter::c
     {core::CancelLocation::beforeBarline(), api::CancelLocation::beforeBarline},
 };
 
+// core normal() folds into api unspecified: absent and "normal" are the same display.
+// The simple (narrow) symbol vocabulary: common/cut only. core normal() folds into api unspecified.
+const Converter::EnumMap<core::TimeSymbol, api::TimeSignatureSymbol> Converter::simpleTimeSymbolMap = {
+    {core::TimeSymbol::common(), api::TimeSignatureSymbol::common},
+    {core::TimeSymbol::cut(), api::TimeSignatureSymbol::cut},
+    {core::TimeSymbol::normal(), api::TimeSignatureSymbol::unspecified},
+};
+
+// The complex (full) symbol vocabulary. core normal() folds into api unspecified.
+const Converter::EnumMap<core::TimeSymbol, api::ComplexTimeSymbol> Converter::complexTimeSymbolMap = {
+    {core::TimeSymbol::common(), api::ComplexTimeSymbol::common},
+    {core::TimeSymbol::cut(), api::ComplexTimeSymbol::cut},
+    {core::TimeSymbol::singleNumber(), api::ComplexTimeSymbol::singleNumber},
+    {core::TimeSymbol::note(), api::ComplexTimeSymbol::note},
+    {core::TimeSymbol::dottedNote(), api::ComplexTimeSymbol::dottedNote},
+    {core::TimeSymbol::normal(), api::ComplexTimeSymbol::unspecified},
+};
+
+const Converter::EnumMap<core::TimeSeparator, api::TimeSeparator> Converter::timeSeparatorMap = {
+    {core::TimeSeparator::none(), api::TimeSeparator::none},
+    {core::TimeSeparator::horizontal(), api::TimeSeparator::horizontal},
+    {core::TimeSeparator::diagonal(), api::TimeSeparator::diagonal},
+    {core::TimeSeparator::vertical(), api::TimeSeparator::vertical},
+    {core::TimeSeparator::adjacent(), api::TimeSeparator::adjacent},
+};
+
+const Converter::EnumMap<core::TimeRelation, api::TimeRelation> Converter::timeRelationMap = {
+    {core::TimeRelation::parentheses(), api::TimeRelation::parentheses},
+    {core::TimeRelation::bracket(), api::TimeRelation::bracket},
+    {core::TimeRelation::equals(), api::TimeRelation::equals},
+    {core::TimeRelation::slash(), api::TimeRelation::slash},
+    {core::TimeRelation::space(), api::TimeRelation::space},
+    {core::TimeRelation::hyphen(), api::TimeRelation::hyphen},
+};
+
 api::Step Converter::convert(core::Step inStep) const
 {
     return findApiItem(stepMap, api::Step::c, inStep);
@@ -1659,6 +1694,41 @@ core::CancelLocation Converter::convert(api::CancelLocation value) const
 api::CancelLocation Converter::convert(core::CancelLocation value) const
 {
     return findApiItem(cancelLocationMap, api::CancelLocation::unspecified, value);
+}
+
+core::TimeSymbol Converter::convert(api::TimeSignatureSymbol value) const
+{
+    return findCoreItem(simpleTimeSymbolMap, core::TimeSymbol::normal(), value);
+}
+
+core::TimeSymbol Converter::convert(api::ComplexTimeSymbol value) const
+{
+    return findCoreItem(complexTimeSymbolMap, core::TimeSymbol::normal(), value);
+}
+
+api::ComplexTimeSymbol Converter::convert(core::TimeSymbol value) const
+{
+    return findApiItem(complexTimeSymbolMap, api::ComplexTimeSymbol::unspecified, value);
+}
+
+core::TimeSeparator Converter::convert(api::TimeSeparator value) const
+{
+    return findCoreItem(timeSeparatorMap, core::TimeSeparator::none(), value);
+}
+
+api::TimeSeparator Converter::convert(core::TimeSeparator value) const
+{
+    return findApiItem(timeSeparatorMap, api::TimeSeparator::unspecified, value);
+}
+
+core::TimeRelation Converter::convert(api::TimeRelation value) const
+{
+    return findCoreItem(timeRelationMap, core::TimeRelation::parentheses(), value);
+}
+
+api::TimeRelation Converter::convert(core::TimeRelation value) const
+{
+    return findApiItem(timeRelationMap, api::TimeRelation::unspecified, value);
 }
 
 double Converter::convertToAlter(int semitones, double cents)

--- a/src/private/mx/impl/Converter.h
+++ b/src/private/mx/impl/Converter.h
@@ -40,6 +40,9 @@
 #include "mx/core/generated/StemValue.h"
 #include "mx/core/generated/Step.h"
 #include "mx/core/generated/TechnicalChoice.h"
+#include "mx/core/generated/TimeRelation.h"
+#include "mx/core/generated/TimeSeparator.h"
+#include "mx/core/generated/TimeSymbol.h"
 #include "mx/core/generated/Transpose.h"
 #include "mx/core/generated/Valign.h"
 #include "mx/core/generated/WedgeType.h"
@@ -159,6 +162,24 @@ class Converter
     core::CancelLocation convert(api::CancelLocation value) const;
     api::CancelLocation convert(core::CancelLocation value) const;
 
+    // Simple (narrow) symbol: common/cut only. unspecified maps to core normal(); callers skip the
+    // attribute entirely for unspecified (absent and normal mean the same thing on the wire).
+    core::TimeSymbol convert(api::TimeSignatureSymbol value) const;
+
+    // Complex (full) symbol: the whole MusicXML time-symbol vocabulary. The reader always builds a
+    // ComplexTimeSymbol (TimeChoice::complex collapses to simple when possible), so core->api goes
+    // through this one.
+    core::TimeSymbol convert(api::ComplexTimeSymbol value) const;
+    api::ComplexTimeSymbol convert(core::TimeSymbol value) const;
+
+    // api::TimeSeparator::unspecified means "write no attribute"; callers skip it.
+    core::TimeSeparator convert(api::TimeSeparator value) const;
+    api::TimeSeparator convert(core::TimeSeparator value) const;
+
+    // api::TimeRelation::unspecified means "write no element"; callers skip it.
+    core::TimeRelation convert(api::TimeRelation value) const;
+    api::TimeRelation convert(core::TimeRelation value) const;
+
     static double convertToAlter(int semitones, double cents);
     static std::pair<int, double> convertToSemitonesAndCents(double alter);
 
@@ -197,6 +218,10 @@ class Converter
     const static EnumMap<core::SoundID, api::SoundID> instrumentMap;
     const static EnumMap<core::KindValue, api::ChordKind> kindMap;
     const static EnumMap<core::CancelLocation, api::CancelLocation> cancelLocationMap;
+    const static EnumMap<core::TimeSymbol, api::TimeSignatureSymbol> simpleTimeSymbolMap;
+    const static EnumMap<core::TimeSymbol, api::ComplexTimeSymbol> complexTimeSymbolMap;
+    const static EnumMap<core::TimeSeparator, api::TimeSeparator> timeSeparatorMap;
+    const static EnumMap<core::TimeRelation, api::TimeRelation> timeRelationMap;
 
   private:
     template <typename CORE_TYPE, typename API_TYPE>

--- a/src/private/mx/impl/Converter.h
+++ b/src/private/mx/impl/Converter.h
@@ -167,7 +167,7 @@ class Converter
     core::TimeSymbol convert(api::TimeSignatureSymbol value) const;
 
     // Complex (full) symbol: the whole MusicXML time-symbol vocabulary. The reader always builds a
-    // ComplexTimeSymbol (TimeChoice::complex collapses to simple when possible), so core->api goes
+    // ComplexTimeSymbol (the TimeChoice constructor collapses to simple when possible), so core->api goes
     // through this one.
     core::TimeSymbol convert(api::ComplexTimeSymbol value) const;
     api::ComplexTimeSymbol convert(core::TimeSymbol value) const;

--- a/src/private/mx/impl/Cursor.cpp
+++ b/src/private/mx/impl/Cursor.cpp
@@ -12,9 +12,9 @@ namespace mx
 namespace impl
 {
 Cursor::Cursor(int numStaves, int globalTicksPerQuarter)
-    : timeSignature{}, ticksPerQuarter(globalTicksPerQuarter), tickTimePosition(0), voiceIndex(0), staffIndex(0),
-      isBackupInProgress(false), isFirstMeasureInPart(true), isChordActive(false), myNumStaves(numStaves),
-      myGlobalTicksPerQuarter(globalTicksPerQuarter)
+    : timeSignature{}, staffTimeSignatures{}, ticksPerQuarter(globalTicksPerQuarter), tickTimePosition(0),
+      voiceIndex(0), staffIndex(0), isBackupInProgress(false), isFirstMeasureInPart(true), isChordActive(false),
+      myNumStaves(numStaves), myGlobalTicksPerQuarter(globalTicksPerQuarter)
 {
 }
 

--- a/src/private/mx/impl/Cursor.h
+++ b/src/private/mx/impl/Cursor.h
@@ -5,7 +5,9 @@
 #pragma once
 
 #include "mx/api/MeasureData.h"
-#include "mx/api/TimeSignatureData.h"
+#include "mx/api/TimeChoice.h"
+
+#include <map>
 
 namespace mx
 {
@@ -19,7 +21,12 @@ namespace impl
 class Cursor
 {
   public:
-    api::TimeSignatureData timeSignature;
+    api::TimeChoice timeSignature;
+
+    // carried per-staff <time number="N"> overrides, keyed by staff index; persists measure-to-measure
+    // like the singular timeSignature above
+    std::map<int, api::TimeChoice> staffTimeSignatures;
+
     int ticksPerQuarter;
     int tickTimePosition;
     int voiceIndex;

--- a/src/private/mx/impl/MeasureReader.cpp
+++ b/src/private/mx/impl/MeasureReader.cpp
@@ -58,6 +58,9 @@
 #include "mx/utility/Throw.h"
 #include "mx/utility/Unused.h"
 
+#include <algorithm>
+#include <iterator>
+#include <map>
 #include <set>
 
 namespace mx
@@ -215,25 +218,53 @@ impl::MeasureCursor MeasureReader::getCursor() const
 
 void MeasureReader::parseTimeSignature() const
 {
-    TimeReader timeReader{myPartwiseMeasure.musicData()};
-    api::TimeSignatureData timeSignature;
+    // start from the carried-forward state; anything this measure does not restate stays implicit
+    api::TimeChoice timeSignature;
+    std::map<int, api::TimeChoice> staffTimeSignatures;
 
-    if (timeReader.getIsTimeFound())
+    if (myCurrentCursor.measureIndex > 0)
     {
-        timeSignature = timeReader.getTimeSignatureData();
-        timeSignature.isImplicit = false;
+        timeSignature = myPreviousMeasureCursor.timeSignature;
+        staffTimeSignatures = myPreviousMeasureCursor.staffTimeSignatures;
     }
-    else // no time signature was found
+
+    timeSignature.isImplicit = true;
+    for (auto &entry : staffTimeSignatures)
     {
-        if (myCurrentCursor.measureIndex > 0)
+        entry.second.isImplicit = true;
+    }
+
+    TimeReader timeReader{myPartwiseMeasure.musicData()};
+    for (const auto &found : timeReader.getTimeSignatures()) // isImplicit == false on each
+    {
+        int staffIndex = found.staffIndex;
+
+        // clamp an out-of-range staff number to "all staves", mirroring the keys pattern
+        if (staffIndex != api::INDEX_UNSPECIFIED && staffIndex > myCurrentCursor.getNumStaves() - 1)
         {
-            timeSignature = myPreviousMeasureCursor.timeSignature;
+            staffIndex = api::INDEX_UNSPECIFIED;
         }
-        timeSignature.isImplicit = true;
+
+        if (staffIndex == api::INDEX_UNSPECIFIED)
+        {
+            // a restated unscoped time governs all staves: it supersedes carried-forward per-staff
+            // overrides (but not overrides stated explicitly in this same measure)
+            timeSignature = found.timeChoice;
+            for (auto it = staffTimeSignatures.begin(); it != staffTimeSignatures.end();)
+            {
+                it = it->second.isImplicit ? staffTimeSignatures.erase(it) : std::next(it);
+            }
+        }
+        else
+        {
+            staffTimeSignatures[staffIndex] = found.timeChoice;
+        }
     }
 
     myOutMeasureData.timeSignature = timeSignature;
-    myCurrentCursor.timeSignature = timeSignature;
+    myOutMeasureData.staffTimeSignatures = staffTimeSignatures;
+    myCurrentCursor.timeSignature = std::move(timeSignature);
+    myCurrentCursor.staffTimeSignatures = std::move(staffTimeSignatures);
     advanceTickTimePosition(0, "parseTimeSignature");
 }
 

--- a/src/private/mx/impl/MeasureWriter.cpp
+++ b/src/private/mx/impl/MeasureWriter.cpp
@@ -131,7 +131,15 @@ void MeasureWriter::writeMeasureGlobals()
 
     if (!myMeasureData.timeSignature.isImplicit)
     {
-        myPropertiesWriter->writeTime(myMeasureData.timeSignature);
+        myPropertiesWriter->writeTime(myMeasureData.timeSignature, api::INDEX_UNSPECIFIED);
+    }
+
+    for (const auto &[staffIndex, staffTimeSignature] : myMeasureData.staffTimeSignatures)
+    {
+        if (!staffTimeSignature.isImplicit)
+        {
+            myPropertiesWriter->writeTime(staffTimeSignature, staffIndex);
+        }
     }
 
     int localStaffCounter = 0;

--- a/src/private/mx/impl/PartReader.cpp
+++ b/src/private/mx/impl/PartReader.cpp
@@ -125,6 +125,7 @@ api::PartData PartReader::getPartData()
             myOutPartData.transposition = transpositionData;
         }
         myCurrentCursor.timeSignature = measureData.timeSignature;
+        myCurrentCursor.staffTimeSignatures = measureData.staffTimeSignatures;
         myCurrentCursor.ticksPerQuarter = reader.getCursor().ticksPerQuarter;
         myOutPartData.measures.emplace_back(std::move(measureData));
         ++myCurrentCursor.measureIndex;

--- a/src/private/mx/impl/PropertiesWriter.cpp
+++ b/src/private/mx/impl/PropertiesWriter.cpp
@@ -11,6 +11,7 @@
 #include "mx/core/generated/Clef.h"
 #include "mx/core/generated/ClefGroup.h"
 #include "mx/core/generated/Fifths.h"
+#include "mx/core/generated/Interchangeable.h"
 #include "mx/core/generated/Key.h"
 #include "mx/core/generated/KeyAccidental.h"
 #include "mx/core/generated/KeyChoice.h"
@@ -28,6 +29,8 @@
 #include "mx/core/generated/Time.h"
 #include "mx/core/generated/TimeChoice.h"
 #include "mx/core/generated/TimeChoiceGroup.h"
+#include "mx/core/generated/TimeRelation.h"
+#include "mx/core/generated/TimeSeparator.h"
 #include "mx/core/generated/TimeSignatureGroup.h"
 #include "mx/core/generated/TimeSymbol.h"
 #include "mx/core/generated/TraditionalKeyGroup.h"
@@ -140,40 +143,110 @@ void PropertiesWriter::writeTraditionalKey(const api::KeyData &inKeyData, core::
     ioKey.setChoice(core::KeyChoice::traditionalKey(tkg));
 }
 
-void PropertiesWriter::writeTime(const api::TimeSignatureData &value)
+// converts a list of api fractions (a primary or interchangeable meter) to a core OneOrMore;
+// an (invalid) empty meter falls back to a single 4/4 pair
+static core::OneOrMore<core::TimeSignatureGroup> propertiesWriterTimeSignatureGroups(
+    const std::vector<api::TimeFraction> &inFractions)
 {
+    std::vector<core::TimeSignatureGroup> groups;
+    for (const auto &fraction : inFractions)
+    {
+        core::TimeSignatureGroup tsg{};
+        tsg.setBeats(fraction.beats);
+        tsg.setBeatType(fraction.beatType);
+        groups.push_back(std::move(tsg));
+    }
+    if (groups.empty())
+    {
+        core::TimeSignatureGroup tsg{};
+        tsg.setBeats("4");
+        tsg.setBeatType("4");
+        groups.push_back(std::move(tsg));
+    }
+    core::OneOrMore<core::TimeSignatureGroup> result{};
+    result.setItems(std::move(groups));
+    return result;
+}
+
+// builds the metered (group) TimeChoice from an api MeteredTimeSignature, and sets the meter's own
+// symbol/separator on the <time> element
+static void propertiesWriterSetMetered(core::Time &ioTime, const api::MeteredTimeSignature &inMetered,
+                                       const Converter &converter)
+{
+    core::TimeChoiceGroup tcg{};
+    tcg.setTimeSignature(propertiesWriterTimeSignatureGroups(inMetered.fractions));
+
+    if (inMetered.interchangeable.has_value())
+    {
+        const auto &alternate = *inMetered.interchangeable;
+        core::Interchangeable interchangeable{};
+        interchangeable.setTimeSignature(propertiesWriterTimeSignatureGroups(alternate.fractions));
+        if (alternate.relation != api::TimeRelation::unspecified)
+        {
+            interchangeable.setTimeRelation(converter.convert(alternate.relation));
+        }
+        if (alternate.symbol != api::ComplexTimeSymbol::unspecified)
+        {
+            interchangeable.setSymbol(converter.convert(alternate.symbol));
+        }
+        if (alternate.separator != api::TimeSeparator::unspecified)
+        {
+            interchangeable.setSeparator(converter.convert(alternate.separator));
+        }
+        tcg.setInterchangeable(std::move(interchangeable));
+    }
+
+    ioTime.setChoice(core::TimeChoice::group(std::move(tcg)));
+
+    if (inMetered.symbol != api::ComplexTimeSymbol::unspecified)
+    {
+        ioTime.setSymbol(converter.convert(inMetered.symbol));
+    }
+    if (inMetered.separator != api::TimeSeparator::unspecified)
+    {
+        ioTime.setSeparator(converter.convert(inMetered.separator));
+    }
+}
+
+void PropertiesWriter::writeTime(const api::TimeChoice &value, int staffIndex)
+{
+    Converter converter;
     core::Time time{};
 
-    core::TimeSignatureGroup tsg{};
-    tsg.setBeats(value.beats);
-    tsg.setBeatType(value.beatType);
-
-    core::TimeChoiceGroup tcg{};
-    tcg.setTimeSignature(core::OneOrMore<core::TimeSignatureGroup>{tsg});
-
-    time.setChoice(core::TimeChoice::group(tcg));
-
-    const auto symbol = value.symbol;
-    if (symbol != api::TimeSignatureSymbol::unspecified)
+    if (value.isSimple())
     {
-        if (symbol == api::TimeSignatureSymbol::common)
+        const auto &simple = value.asSimple();
+        core::TimeChoiceGroup tcg{};
+        std::vector<api::TimeFraction> fractions{simple.fraction};
+        tcg.setTimeSignature(propertiesWriterTimeSignatureGroups(fractions));
+        time.setChoice(core::TimeChoice::group(std::move(tcg)));
+        if (simple.symbol != api::TimeSignatureSymbol::unspecified)
         {
-            time.setSymbol(core::TimeSymbol::common());
+            time.setSymbol(converter.convert(simple.symbol));
         }
-        else if (symbol == api::TimeSignatureSymbol::cut)
+    }
+    else
+    {
+        const auto &complex = value.asComplex();
+        if (complex.isSenzaMisura())
         {
-            time.setSymbol(core::TimeSymbol::cut());
+            // the symbol attribute is not used with senza-misura
+            time.setChoice(core::TimeChoice::senzaMisura(complex.asSenzaMisura()));
         }
-        else if (symbol == api::TimeSignatureSymbol::singleNumber)
+        else
         {
-            time.setSymbol(core::TimeSymbol::singleNumber());
+            propertiesWriterSetMetered(time, complex.asMetered(), converter);
         }
     }
 
-    Converter converter;
     if (value.display != api::Bool::unspecified)
     {
         time.setPrintObject(converter.convert(value.display));
+    }
+
+    if (staffIndex != api::INDEX_UNSPECIFIED)
+    {
+        time.setNumber(core::StaffNumber{staffIndex + 1});
     }
 
     myAttributes.addTime(time);

--- a/src/private/mx/impl/PropertiesWriter.cpp
+++ b/src/private/mx/impl/PropertiesWriter.cpp
@@ -215,7 +215,7 @@ void PropertiesWriter::writeTime(const api::TimeChoice &value, int staffIndex)
 
     if (value.isSimple())
     {
-        const auto &simple = value.asSimple();
+        const auto &simple = value.simple();
         core::TimeChoiceGroup tcg{};
         std::vector<api::TimeFraction> fractions{simple.fraction};
         tcg.setTimeSignature(propertiesWriterTimeSignatureGroups(fractions));
@@ -227,15 +227,15 @@ void PropertiesWriter::writeTime(const api::TimeChoice &value, int staffIndex)
     }
     else
     {
-        const auto &complex = value.asComplex();
+        const auto &complex = value.complex();
         if (complex.isSenzaMisura())
         {
             // the symbol attribute is not used with senza-misura
-            time.setChoice(core::TimeChoice::senzaMisura(complex.asSenzaMisura()));
+            time.setChoice(core::TimeChoice::senzaMisura(complex.senzaMisura()));
         }
         else
         {
-            propertiesWriterSetMetered(time, complex.asMetered(), converter);
+            propertiesWriterSetMetered(time, complex.metered(), converter);
         }
     }
 

--- a/src/private/mx/impl/PropertiesWriter.h
+++ b/src/private/mx/impl/PropertiesWriter.h
@@ -7,7 +7,7 @@
 #include "mx/api/ClefData.h"
 #include "mx/api/KeyData.h"
 #include "mx/api/PartSymbolData.h"
-#include "mx/api/TimeSignatureData.h"
+#include "mx/api/TimeChoice.h"
 #include "mx/api/TransposeData.h"
 #include "mx/core/generated/Attributes.h"
 #include "mx/core/generated/Key.h"
@@ -49,7 +49,9 @@ class PropertiesWriter
     void writeKey(int staffIndex, const api::KeyData &inKeyData);
     static void writeTraditionalKey(const api::KeyData &inKeyData, core::Key &ioKey);
     static void writeNonTraditionalKey(const api::KeyData &inKeyData, core::Key &ioKey);
-    void writeTime(const api::TimeSignatureData &value);
+    // staffIndex is INDEX_UNSPECIFIED for the unscoped <time>, else the zero-based staff index of a
+    // <time number="N"> override.
+    void writeTime(const api::TimeChoice &value, int staffIndex);
     void writeNumStaves(int value);
     void writeStaffDetails(int staffIndex, int staffLines);
     void writeStaffDetails(int staffIndex, int staffLines, double staffSize);

--- a/src/private/mx/impl/TimeReader.cpp
+++ b/src/private/mx/impl/TimeReader.cpp
@@ -58,7 +58,7 @@ TimeReaderResult TimeReader::createTimeChoice(const core::Time &inTime)
     if (choice.kind() == core::TimeChoice::Kind::senzaMisura)
     {
         // the string content is the display glyph (often empty); a senza-misura carries no symbol
-        timeChoice = api::TimeChoice::complex(api::ComplexTimeSignature::senzaMisura(choice.asSenzaMisura()));
+        timeChoice = api::TimeChoice(api::ComplexTimeSignature::senzaMisura(choice.asSenzaMisura()));
     }
     else
     {
@@ -96,7 +96,7 @@ TimeReaderResult TimeReader::createTimeChoice(const core::Time &inTime)
         }
 
         // complex() collapses back to simple when the meter is really just a plain fraction
-        timeChoice = api::TimeChoice::complex(api::ComplexTimeSignature::metered(std::move(metered)));
+        timeChoice = api::TimeChoice(api::ComplexTimeSignature::metered(std::move(metered)));
     }
 
     timeChoice.isImplicit = false;

--- a/src/private/mx/impl/TimeReader.cpp
+++ b/src/private/mx/impl/TimeReader.cpp
@@ -3,115 +3,115 @@
 // Distributed under the MIT License
 
 #include "mx/impl/TimeReader.h"
+#include "mx/api/ComplexTimeSignature.h"
 #include "mx/core/generated/Attributes.h"
+#include "mx/core/generated/Interchangeable.h"
 #include "mx/core/generated/Time.h"
 #include "mx/core/generated/TimeChoice.h"
 #include "mx/core/generated/TimeChoiceGroup.h"
 #include "mx/core/generated/TimeSignatureGroup.h"
-#include "mx/utility/Throw.h"
+#include "mx/impl/Converter.h"
 
-#include <cmath>
-#include <set>
-#include <string>
+#include <utility>
+#include <vector>
 
 namespace mx
 {
 namespace impl
 {
 
-TimeReader::TimeReader(std::span<const core::MusicDataChoice> inMusicDataChoices)
-    : myMusicDataChoiceSet{inMusicDataChoices}, myTime{nullptr}, myIsTimeFound{false}, myTimeSignatureData{}
+static std::vector<api::TimeFraction> timeReaderFractions(std::span<const core::TimeSignatureGroup> inGroups)
 {
-    myIsTimeFound = initialize();
+    std::vector<api::TimeFraction> fractions;
+    for (const auto &pair : inGroups)
+    {
+        fractions.push_back(api::TimeFraction{pair.beats(), pair.beatType()});
+    }
+    return fractions;
 }
 
-bool TimeReader::getIsTimeFound() const
+TimeReader::TimeReader(std::span<const core::MusicDataChoice> inMusicDataChoices) : myTimeSignatures{}
 {
-    return myIsTimeFound;
-}
-
-mx::api::TimeSignatureData TimeReader::getTimeSignatureData() const
-{
-    return myTimeSignatureData;
-}
-
-bool TimeReader::initialize()
-{
-    for (const auto &mdc : myMusicDataChoiceSet)
+    for (const auto &mdc : inMusicDataChoices)
     {
         if (mdc.kind() == core::MusicDataChoice::Kind::attributes)
         {
-            const auto &props = mdc.asAttributes();
-            if (props.time().size() > 0)
+            for (const auto &time : mdc.asAttributes().time())
             {
-                myTime = &props.time().front();
-                return parseTime();
+                myTimeSignatures.push_back(createTimeChoice(time));
             }
         }
     }
-    return false;
 }
 
-bool TimeReader::parseTime()
+const std::vector<TimeReaderResult> &TimeReader::getTimeSignatures() const
 {
-    const auto &timeChoice = myTime->choice();
+    return myTimeSignatures;
+}
 
-    if (timeChoice.kind() == core::TimeChoice::Kind::group)
+TimeReaderResult TimeReader::createTimeChoice(const core::Time &inTime)
+{
+    Converter converter;
+    api::TimeChoice timeChoice;
+
+    const auto &choice = inTime.choice();
+    if (choice.kind() == core::TimeChoice::Kind::senzaMisura)
     {
-        const auto sigGroupSet = timeChoice.asGroup().timeSignature();
-        MX_ASSERT(sigGroupSet.size() > 0);
-        return parseTimeSignatureGroup(sigGroupSet.front());
+        // the string content is the display glyph (often empty); a senza-misura carries no symbol
+        timeChoice = api::TimeChoice::complex(api::ComplexTimeSignature::senzaMisura(choice.asSenzaMisura()));
     }
     else
     {
-        return false;
-        // MX_THROW( "TODO - other time signature stuff" );
+        const auto &group = choice.asGroup();
+        api::MeteredTimeSignature metered;
+        metered.fractions = timeReaderFractions(group.timeSignature());
+
+        if (inTime.symbol().has_value())
+        {
+            metered.symbol = converter.convert(*inTime.symbol());
+        }
+        if (inTime.separator().has_value())
+        {
+            metered.separator = converter.convert(*inTime.separator());
+        }
+
+        if (group.interchangeable().has_value())
+        {
+            const auto &core = *group.interchangeable();
+            api::InterchangeableTimeSignature alternate;
+            alternate.fractions = timeReaderFractions(core.timeSignature());
+            if (core.timeRelation().has_value())
+            {
+                alternate.relation = converter.convert(*core.timeRelation());
+            }
+            if (core.symbol().has_value())
+            {
+                alternate.symbol = converter.convert(*core.symbol());
+            }
+            if (core.separator().has_value())
+            {
+                alternate.separator = converter.convert(*core.separator());
+            }
+            metered.interchangeable = std::move(alternate);
+        }
+
+        // complex() collapses back to simple when the meter is really just a plain fraction
+        timeChoice = api::TimeChoice::complex(api::ComplexTimeSignature::metered(std::move(metered)));
     }
-}
 
-bool TimeReader::parseTimeSignatureGroup(const core::TimeSignatureGroup &timeSig)
-{
-    myTimeSignatureData.beats = timeSig.beats();
-    myTimeSignatureData.beatType = timeSig.beatType();
-
-    if (myTime->symbol().has_value())
+    timeChoice.isImplicit = false;
+    if (inTime.printObject().has_value())
     {
-        if (*myTime->symbol() == core::TimeSymbol::common())
-        {
-            myTimeSignatureData.symbol = api::TimeSignatureSymbol::common;
-        }
-        else if (*myTime->symbol() == core::TimeSymbol::cut())
-        {
-            myTimeSignatureData.symbol = api::TimeSignatureSymbol::cut;
-        }
-        else if (*myTime->symbol() == core::TimeSymbol::singleNumber())
-        {
-            myTimeSignatureData.symbol = api::TimeSignatureSymbol::singleNumber;
-        }
+        timeChoice.display = converter.convert(*inTime.printObject());
     }
-    else
+
+    int staffIndex = api::INDEX_UNSPECIFIED;
+    if (inTime.number().has_value())
     {
-        myTimeSignatureData.symbol = api::TimeSignatureSymbol::unspecified;
+        staffIndex = static_cast<int>(inTime.number()->value()) - 1;
     }
 
-    myTimeSignatureData.display = api::Bool::unspecified;
-    if (myTime->printObject().has_value())
-    {
-        bool isPrint = *myTime->printObject() == core::YesNo::yes();
-
-        if (isPrint)
-        {
-            myTimeSignatureData.display = api::Bool::yes;
-        }
-        else
-        {
-            myTimeSignatureData.display = api::Bool::no;
-        }
-    }
-
-    myTimeSignatureData.isImplicit = false;
-
-    return true;
+    return TimeReaderResult{std::move(timeChoice), staffIndex};
 }
 } // namespace impl
 } // namespace mx

--- a/src/private/mx/impl/TimeReader.cpp
+++ b/src/private/mx/impl/TimeReader.cpp
@@ -58,7 +58,7 @@ TimeReaderResult TimeReader::createTimeChoice(const core::Time &inTime)
     if (choice.kind() == core::TimeChoice::Kind::senzaMisura)
     {
         // the string content is the display glyph (often empty); a senza-misura carries no symbol
-        timeChoice = api::TimeChoice(api::ComplexTimeSignature::senzaMisura(choice.asSenzaMisura()));
+        timeChoice = api::TimeChoice(api::ComplexTimeSignature(choice.asSenzaMisura()));
     }
     else
     {
@@ -96,7 +96,7 @@ TimeReaderResult TimeReader::createTimeChoice(const core::Time &inTime)
         }
 
         // complex() collapses back to simple when the meter is really just a plain fraction
-        timeChoice = api::TimeChoice(api::ComplexTimeSignature::metered(std::move(metered)));
+        timeChoice = api::TimeChoice(api::ComplexTimeSignature(std::move(metered)));
     }
 
     timeChoice.isImplicit = false;

--- a/src/private/mx/impl/TimeReader.h
+++ b/src/private/mx/impl/TimeReader.h
@@ -4,37 +4,42 @@
 
 #pragma once
 
-#include "mx/api/TimeSignatureData.h"
+#include "mx/api/TimeChoice.h"
 #include "mx/core/generated/MusicDataChoice.h"
-#include "mx/impl/Cursor.h"
+#include "mx/core/generated/Time.h"
 
 #include <span>
+#include <vector>
 
 namespace mx
 {
 namespace impl
 {
+// A single translated <time>: the resulting TimeChoice plus the staff it is scoped to
+// (INDEX_UNSPECIFIED for an unscoped <time> that applies to all staves).
+struct TimeReaderResult
+{
+    api::TimeChoice timeChoice;
+    int staffIndex;
+};
+
+// Finds every <time> element in a measure's <attributes> (there can be several: one unscoped plus
+// per-staff <time number="N"> overrides) and translates each to a TimeChoice. The constructor does
+// all of the work; query the results with getTimeSignatures().
 class TimeReader
 {
   public:
-    // The constructor will do all of the parsing
-    // after that you can query the discovered time
-    // element properties using accessors on the
-    // cached data
-    TimeReader(std::span<const core::MusicDataChoice> inMusicDataChoices);
-    bool getIsTimeFound() const;
-    mx::api::TimeSignatureData getTimeSignatureData() const;
+    explicit TimeReader(std::span<const core::MusicDataChoice> inMusicDataChoices);
+
+    // Every translated <time>, in document order. Each TimeChoice has isImplicit == false.
+    const std::vector<TimeReaderResult> &getTimeSignatures() const;
+
+    // Translates one core::Time to one TimeChoice (all shapes: simple, composite, senza-misura,
+    // interchangeable). isImplicit is left false; staff scoping is returned separately.
+    static TimeReaderResult createTimeChoice(const core::Time &inTime);
 
   private:
-    std::span<const core::MusicDataChoice> myMusicDataChoiceSet;
-    const core::Time *myTime;
-    bool myIsTimeFound;
-    mx::api::TimeSignatureData myTimeSignatureData;
-
-  private:
-    bool initialize();
-    bool parseTime();
-    bool parseTimeSignatureGroup(const core::TimeSignatureGroup &timeSig);
+    std::vector<TimeReaderResult> myTimeSignatures;
 };
 } // namespace impl
 } // namespace mx

--- a/src/private/mxtest/api/ApiK007aScoreData.h
+++ b/src/private/mxtest/api/ApiK007aScoreData.h
@@ -50,7 +50,7 @@ inline void addFirstMeasureWithNote(mx::api::MarkType markType, mx::api::PartDat
     using namespace mx::api;
     outPartData.measures.emplace_back(MeasureData{});
     auto measureP = &outPartData.measures.front();
-    measureP->timeSignature = TimeChoice::simple(TimeSignatureData{});
+    measureP->timeSignature = TimeChoice(TimeSignatureData{});
     measureP->timeSignature.isImplicit = false;
     measureP->staves.emplace_back(StaffData{});
     auto staffP = &measureP->staves.at(0);

--- a/src/private/mxtest/api/ApiK007aScoreData.h
+++ b/src/private/mxtest/api/ApiK007aScoreData.h
@@ -50,8 +50,8 @@ inline void addFirstMeasureWithNote(mx::api::MarkType markType, mx::api::PartDat
     using namespace mx::api;
     outPartData.measures.emplace_back(MeasureData{});
     auto measureP = &outPartData.measures.front();
+    measureP->timeSignature = TimeChoice::simple(TimeSignatureData{});
     measureP->timeSignature.isImplicit = false;
-    measureP->timeSignature.symbol = TimeSignatureSymbol::unspecified;
     measureP->staves.emplace_back(StaffData{});
     auto staffP = &measureP->staves.at(0);
     staffP->clefs.emplace_back(ClefData{});

--- a/src/private/mxtest/api/ApiK007cScoreData.h
+++ b/src/private/mxtest/api/ApiK007cScoreData.h
@@ -54,7 +54,7 @@ inline void addFirstMeasureWithNote(mx::api::MarkType markType, mx::api::PartDat
     using namespace mx::api;
     outPartData.measures.emplace_back(MeasureData{});
     auto measureP = &outPartData.measures.front();
-    measureP->timeSignature = TimeChoice::simple(TimeSignatureData{});
+    measureP->timeSignature = TimeChoice(TimeSignatureData{});
     measureP->timeSignature.isImplicit = false;
     measureP->staves.emplace_back(StaffData{});
     auto staffP = &measureP->staves.at(0);

--- a/src/private/mxtest/api/ApiK007cScoreData.h
+++ b/src/private/mxtest/api/ApiK007cScoreData.h
@@ -54,8 +54,8 @@ inline void addFirstMeasureWithNote(mx::api::MarkType markType, mx::api::PartDat
     using namespace mx::api;
     outPartData.measures.emplace_back(MeasureData{});
     auto measureP = &outPartData.measures.front();
+    measureP->timeSignature = TimeChoice::simple(TimeSignatureData{});
     measureP->timeSignature.isImplicit = false;
-    measureP->timeSignature.symbol = TimeSignatureSymbol::unspecified;
     measureP->staves.emplace_back(StaffData{});
     auto staffP = &measureP->staves.at(0);
     staffP->clefs.emplace_back(ClefData{});

--- a/src/private/mxtest/api/ApiK009bSlurScoreData.h
+++ b/src/private/mxtest/api/ApiK009bSlurScoreData.h
@@ -29,8 +29,7 @@ inline mx::api::ScoreData apiK009bSlurAttributesScoreData()
     // 1
     part.measures.emplace_back(MeasureData{});
     auto measure = &part.measures.back();
-    measure->timeSignature.beats = "4";
-    measure->timeSignature.beatType = "4";
+    measure->timeSignature = TimeChoice::simple(TimeSignatureData{});
     measure->timeSignature.isImplicit = false;
     measure->staves.emplace_back(StaffData{});
     auto staff = &measure->staves.back();

--- a/src/private/mxtest/api/ApiK009bSlurScoreData.h
+++ b/src/private/mxtest/api/ApiK009bSlurScoreData.h
@@ -29,7 +29,7 @@ inline mx::api::ScoreData apiK009bSlurAttributesScoreData()
     // 1
     part.measures.emplace_back(MeasureData{});
     auto measure = &part.measures.back();
-    measure->timeSignature = TimeChoice::simple(TimeSignatureData{});
+    measure->timeSignature = TimeChoice(TimeSignatureData{});
     measure->timeSignature.isImplicit = false;
     measure->staves.emplace_back(StaffData{});
     auto staff = &measure->staves.back();

--- a/src/private/mxtest/api/ApiK014aFermatasScoreData.h
+++ b/src/private/mxtest/api/ApiK014aFermatasScoreData.h
@@ -25,8 +25,7 @@ inline mx::api::ScoreData apiK014aFermatasScoreData()
     // 1
     part.measures.emplace_back(MeasureData{});
     auto measure = &part.measures.back();
-    measure->timeSignature.beats = "4";
-    measure->timeSignature.beatType = "4";
+    measure->timeSignature = TimeChoice::simple(TimeSignatureData{});
     measure->timeSignature.isImplicit = false;
     measure->staves.emplace_back(StaffData{});
     auto staff = &measure->staves.back();

--- a/src/private/mxtest/api/ApiK014aFermatasScoreData.h
+++ b/src/private/mxtest/api/ApiK014aFermatasScoreData.h
@@ -25,7 +25,7 @@ inline mx::api::ScoreData apiK014aFermatasScoreData()
     // 1
     part.measures.emplace_back(MeasureData{});
     auto measure = &part.measures.back();
-    measure->timeSignature = TimeChoice::simple(TimeSignatureData{});
+    measure->timeSignature = TimeChoice(TimeSignatureData{});
     measure->timeSignature.isImplicit = false;
     measure->staves.emplace_back(StaffData{});
     auto staff = &measure->staves.back();

--- a/src/private/mxtest/api/ApiK015aLayoutScoreData.h
+++ b/src/private/mxtest/api/ApiK015aLayoutScoreData.h
@@ -60,7 +60,7 @@ inline mx::api::ScoreData apiK015aLayoutScoreData()
     part.measures.emplace_back(MeasureData{});
     auto measure = &part.measures.back();
     measure->width = 0.0;
-    measure->timeSignature = TimeChoice::simple(TimeSignatureData{});
+    measure->timeSignature = TimeChoice(TimeSignatureData{});
     measure->timeSignature.isImplicit = false;
     measure->staves.emplace_back(StaffData{});
     auto staff = &measure->staves.back();

--- a/src/private/mxtest/api/ApiK015aLayoutScoreData.h
+++ b/src/private/mxtest/api/ApiK015aLayoutScoreData.h
@@ -60,8 +60,7 @@ inline mx::api::ScoreData apiK015aLayoutScoreData()
     part.measures.emplace_back(MeasureData{});
     auto measure = &part.measures.back();
     measure->width = 0.0;
-    measure->timeSignature.beats = "4";
-    measure->timeSignature.beatType = "4";
+    measure->timeSignature = TimeChoice::simple(TimeSignatureData{});
     measure->timeSignature.isImplicit = false;
     measure->staves.emplace_back(StaffData{});
     auto staff = &measure->staves.back();

--- a/src/private/mxtest/api/ApiLy43eScoreData.h
+++ b/src/private/mxtest/api/ApiLy43eScoreData.h
@@ -28,7 +28,7 @@ inline mx::api::ScoreData apiLy43eScoreData()
     measureP->keys.emplace_back(KeyData{});
     auto keyP = &measureP->keys.back();
     keyP->mode = KeyMode::major;
-    measureP->timeSignature = TimeChoice(TimeSignatureData{TimeSignatureSymbol::common});
+    measureP->timeSignature = TimeChoice(TimeSignatureData{"4", "4", TimeSignatureSymbol::common});
     measureP->timeSignature.isImplicit = false;
     measureP->staves.emplace_back(StaffData{});
     measureP->staves.emplace_back(StaffData{});
@@ -180,7 +180,7 @@ inline mx::api::ScoreData apiLy43eScoreData()
     // measure 2 - setup
     part.measures.emplace_back(MeasureData{});
     measureP = &part.measures.back();
-    measureP->timeSignature = TimeChoice(TimeSignatureData{TimeSignatureSymbol::common});
+    measureP->timeSignature = TimeChoice(TimeSignatureData{"4", "4", TimeSignatureSymbol::common});
     measureP->timeSignature.isImplicit = true;
     measureP->keys.emplace_back(KeyData{});
     keyP = &measureP->keys.back();
@@ -291,7 +291,7 @@ inline mx::api::ScoreData apiLy43eScoreData()
     // measure 3 - setup
     part.measures.emplace_back(MeasureData{});
     measureP = &part.measures.back();
-    measureP->timeSignature = TimeChoice(TimeSignatureData{TimeSignatureSymbol::common});
+    measureP->timeSignature = TimeChoice(TimeSignatureData{"4", "4", TimeSignatureSymbol::common});
     measureP->timeSignature.isImplicit = true;
     measureP->staves.emplace_back(StaffData{});
     measureP->staves.emplace_back(StaffData{});
@@ -397,7 +397,7 @@ inline mx::api::ScoreData apiLy43eScoreData()
     // measure 4 - setup
     part.measures.emplace_back(MeasureData{});
     measureP = &part.measures.back();
-    measureP->timeSignature = TimeChoice(TimeSignatureData{TimeSignatureSymbol::common});
+    measureP->timeSignature = TimeChoice(TimeSignatureData{"4", "4", TimeSignatureSymbol::common});
     measureP->timeSignature.isImplicit = true;
     measureP->staves.emplace_back(StaffData{});
     measureP->staves.emplace_back(StaffData{});
@@ -409,7 +409,7 @@ inline mx::api::ScoreData apiLy43eScoreData()
     staff1P = &measureP->staves.at(0);
     staff1P->voices[voice].notes.emplace_back(NoteData{});
     noteP = &staff1P->voices[voice].notes.back();
-    measureP->timeSignature = TimeChoice(TimeSignatureData{TimeSignatureSymbol::common});
+    measureP->timeSignature = TimeChoice(TimeSignatureData{"4", "4", TimeSignatureSymbol::common});
     measureP->timeSignature.isImplicit = true;
     noteP->userRequestedVoiceNumber = voice + 1;
     noteP->tickTimePosition = 0;

--- a/src/private/mxtest/api/ApiLy43eScoreData.h
+++ b/src/private/mxtest/api/ApiLy43eScoreData.h
@@ -28,8 +28,8 @@ inline mx::api::ScoreData apiLy43eScoreData()
     measureP->keys.emplace_back(KeyData{});
     auto keyP = &measureP->keys.back();
     keyP->mode = KeyMode::major;
+    measureP->timeSignature = TimeChoice::simple(TimeSignatureData{TimeSignatureSymbol::common});
     measureP->timeSignature.isImplicit = false;
-    measureP->timeSignature.symbol = TimeSignatureSymbol::common;
     measureP->staves.emplace_back(StaffData{});
     measureP->staves.emplace_back(StaffData{});
     auto staff1P = &measureP->staves.at(0);
@@ -180,8 +180,8 @@ inline mx::api::ScoreData apiLy43eScoreData()
     // measure 2 - setup
     part.measures.emplace_back(MeasureData{});
     measureP = &part.measures.back();
+    measureP->timeSignature = TimeChoice::simple(TimeSignatureData{TimeSignatureSymbol::common});
     measureP->timeSignature.isImplicit = true;
-    measureP->timeSignature.symbol = TimeSignatureSymbol::common;
     measureP->keys.emplace_back(KeyData{});
     keyP = &measureP->keys.back();
     keyP->fifths = 2;
@@ -291,8 +291,8 @@ inline mx::api::ScoreData apiLy43eScoreData()
     // measure 3 - setup
     part.measures.emplace_back(MeasureData{});
     measureP = &part.measures.back();
+    measureP->timeSignature = TimeChoice::simple(TimeSignatureData{TimeSignatureSymbol::common});
     measureP->timeSignature.isImplicit = true;
-    measureP->timeSignature.symbol = TimeSignatureSymbol::common;
     measureP->staves.emplace_back(StaffData{});
     measureP->staves.emplace_back(StaffData{});
     staff1P = &measureP->staves.at(0);
@@ -397,8 +397,8 @@ inline mx::api::ScoreData apiLy43eScoreData()
     // measure 4 - setup
     part.measures.emplace_back(MeasureData{});
     measureP = &part.measures.back();
+    measureP->timeSignature = TimeChoice::simple(TimeSignatureData{TimeSignatureSymbol::common});
     measureP->timeSignature.isImplicit = true;
-    measureP->timeSignature.symbol = TimeSignatureSymbol::common;
     measureP->staves.emplace_back(StaffData{});
     measureP->staves.emplace_back(StaffData{});
     staff1P = &measureP->staves.at(0);
@@ -409,8 +409,8 @@ inline mx::api::ScoreData apiLy43eScoreData()
     staff1P = &measureP->staves.at(0);
     staff1P->voices[voice].notes.emplace_back(NoteData{});
     noteP = &staff1P->voices[voice].notes.back();
+    measureP->timeSignature = TimeChoice::simple(TimeSignatureData{TimeSignatureSymbol::common});
     measureP->timeSignature.isImplicit = true;
-    measureP->timeSignature.symbol = TimeSignatureSymbol::common;
     noteP->userRequestedVoiceNumber = voice + 1;
     noteP->tickTimePosition = 0;
     noteP->pitchData.step = Step::c;

--- a/src/private/mxtest/api/ApiLy43eScoreData.h
+++ b/src/private/mxtest/api/ApiLy43eScoreData.h
@@ -28,7 +28,7 @@ inline mx::api::ScoreData apiLy43eScoreData()
     measureP->keys.emplace_back(KeyData{});
     auto keyP = &measureP->keys.back();
     keyP->mode = KeyMode::major;
-    measureP->timeSignature = TimeChoice::simple(TimeSignatureData{TimeSignatureSymbol::common});
+    measureP->timeSignature = TimeChoice(TimeSignatureData{TimeSignatureSymbol::common});
     measureP->timeSignature.isImplicit = false;
     measureP->staves.emplace_back(StaffData{});
     measureP->staves.emplace_back(StaffData{});
@@ -180,7 +180,7 @@ inline mx::api::ScoreData apiLy43eScoreData()
     // measure 2 - setup
     part.measures.emplace_back(MeasureData{});
     measureP = &part.measures.back();
-    measureP->timeSignature = TimeChoice::simple(TimeSignatureData{TimeSignatureSymbol::common});
+    measureP->timeSignature = TimeChoice(TimeSignatureData{TimeSignatureSymbol::common});
     measureP->timeSignature.isImplicit = true;
     measureP->keys.emplace_back(KeyData{});
     keyP = &measureP->keys.back();
@@ -291,7 +291,7 @@ inline mx::api::ScoreData apiLy43eScoreData()
     // measure 3 - setup
     part.measures.emplace_back(MeasureData{});
     measureP = &part.measures.back();
-    measureP->timeSignature = TimeChoice::simple(TimeSignatureData{TimeSignatureSymbol::common});
+    measureP->timeSignature = TimeChoice(TimeSignatureData{TimeSignatureSymbol::common});
     measureP->timeSignature.isImplicit = true;
     measureP->staves.emplace_back(StaffData{});
     measureP->staves.emplace_back(StaffData{});
@@ -397,7 +397,7 @@ inline mx::api::ScoreData apiLy43eScoreData()
     // measure 4 - setup
     part.measures.emplace_back(MeasureData{});
     measureP = &part.measures.back();
-    measureP->timeSignature = TimeChoice::simple(TimeSignatureData{TimeSignatureSymbol::common});
+    measureP->timeSignature = TimeChoice(TimeSignatureData{TimeSignatureSymbol::common});
     measureP->timeSignature.isImplicit = true;
     measureP->staves.emplace_back(StaffData{});
     measureP->staves.emplace_back(StaffData{});
@@ -409,7 +409,7 @@ inline mx::api::ScoreData apiLy43eScoreData()
     staff1P = &measureP->staves.at(0);
     staff1P->voices[voice].notes.emplace_back(NoteData{});
     noteP = &staff1P->voices[voice].notes.back();
-    measureP->timeSignature = TimeChoice::simple(TimeSignatureData{TimeSignatureSymbol::common});
+    measureP->timeSignature = TimeChoice(TimeSignatureData{TimeSignatureSymbol::common});
     measureP->timeSignature.isImplicit = true;
     noteP->userRequestedVoiceNumber = voice + 1;
     noteP->tickTimePosition = 0;

--- a/src/private/mxtest/api/ApiMuAccidentals1ScoreData.h
+++ b/src/private/mxtest/api/ApiMuAccidentals1ScoreData.h
@@ -38,7 +38,7 @@ inline mx::api::ScoreData apiMuAccidentals1ScoreData()
     part.measures.emplace_back(MeasureData{});
     auto measure = &part.measures.back();
     measure->timeSignature =
-        TimeChoice::simple(TimeSignatureData{TimeSignatureSymbol::unspecified, TimeFraction{"3", "4"}});
+        TimeChoice(TimeSignatureData{TimeSignatureSymbol::unspecified, TimeFraction{"3", "4"}});
     measure->timeSignature.isImplicit = false;
     measure->staves.emplace_back(StaffData{});
     measure->keys.emplace_back(KeyData{});
@@ -87,7 +87,7 @@ inline mx::api::ScoreData apiMuAccidentals1ScoreData()
     part.measures.emplace_back(MeasureData{});
     measure = &part.measures.back();
     measure->timeSignature =
-        TimeChoice::simple(TimeSignatureData{TimeSignatureSymbol::unspecified, TimeFraction{"3", "4"}});
+        TimeChoice(TimeSignatureData{TimeSignatureSymbol::unspecified, TimeFraction{"3", "4"}});
     measure->timeSignature.isImplicit = true;
     measure->staves.emplace_back(StaffData{});
     staff = &measure->staves.back();

--- a/src/private/mxtest/api/ApiMuAccidentals1ScoreData.h
+++ b/src/private/mxtest/api/ApiMuAccidentals1ScoreData.h
@@ -37,8 +37,7 @@ inline mx::api::ScoreData apiMuAccidentals1ScoreData()
 
     part.measures.emplace_back(MeasureData{});
     auto measure = &part.measures.back();
-    measure->timeSignature =
-        TimeChoice(TimeSignatureData{TimeSignatureSymbol::unspecified, TimeFraction{"3", "4"}});
+    measure->timeSignature = TimeChoice(TimeSignatureData{"3", "4"});
     measure->timeSignature.isImplicit = false;
     measure->staves.emplace_back(StaffData{});
     measure->keys.emplace_back(KeyData{});
@@ -86,8 +85,7 @@ inline mx::api::ScoreData apiMuAccidentals1ScoreData()
 
     part.measures.emplace_back(MeasureData{});
     measure = &part.measures.back();
-    measure->timeSignature =
-        TimeChoice(TimeSignatureData{TimeSignatureSymbol::unspecified, TimeFraction{"3", "4"}});
+    measure->timeSignature = TimeChoice(TimeSignatureData{"3", "4"});
     measure->timeSignature.isImplicit = true;
     measure->staves.emplace_back(StaffData{});
     staff = &measure->staves.back();

--- a/src/private/mxtest/api/ApiMuAccidentals1ScoreData.h
+++ b/src/private/mxtest/api/ApiMuAccidentals1ScoreData.h
@@ -37,8 +37,8 @@ inline mx::api::ScoreData apiMuAccidentals1ScoreData()
 
     part.measures.emplace_back(MeasureData{});
     auto measure = &part.measures.back();
-    measure->timeSignature.beats = "3";
-    measure->timeSignature.beatType = "4";
+    measure->timeSignature =
+        TimeChoice::simple(TimeSignatureData{TimeSignatureSymbol::unspecified, TimeFraction{"3", "4"}});
     measure->timeSignature.isImplicit = false;
     measure->staves.emplace_back(StaffData{});
     measure->keys.emplace_back(KeyData{});
@@ -86,8 +86,8 @@ inline mx::api::ScoreData apiMuAccidentals1ScoreData()
 
     part.measures.emplace_back(MeasureData{});
     measure = &part.measures.back();
-    measure->timeSignature.beats = "3";
-    measure->timeSignature.beatType = "4";
+    measure->timeSignature =
+        TimeChoice::simple(TimeSignatureData{TimeSignatureSymbol::unspecified, TimeFraction{"3", "4"}});
     measure->timeSignature.isImplicit = true;
     measure->staves.emplace_back(StaffData{});
     staff = &measure->staves.back();

--- a/src/private/mxtest/api/ChordApiTest.cpp
+++ b/src/private/mxtest/api/ChordApiTest.cpp
@@ -209,7 +209,7 @@ TEST(KompChordBug_PIVOTAL_147058063, ChordApi)
     bassClef.tickTimePosition = 0;
     originalStaffPtr->clefs.push_back(bassClef);
 
-    originalMeasure.timeSignature = TimeSignatureData{};
+    originalMeasure.timeSignature = TimeChoice::simple(TimeSignatureData{});
     originalMeasure.timeSignature.isImplicit = false;
 
     originalStaffPtr = &(*originalMeasure.staves.begin());

--- a/src/private/mxtest/api/ChordApiTest.cpp
+++ b/src/private/mxtest/api/ChordApiTest.cpp
@@ -209,7 +209,7 @@ TEST(KompChordBug_PIVOTAL_147058063, ChordApi)
     bassClef.tickTimePosition = 0;
     originalStaffPtr->clefs.push_back(bassClef);
 
-    originalMeasure.timeSignature = TimeChoice::simple(TimeSignatureData{});
+    originalMeasure.timeSignature = TimeChoice(TimeSignatureData{});
     originalMeasure.timeSignature.isImplicit = false;
 
     originalStaffPtr = &(*originalMeasure.staves.begin());

--- a/src/private/mxtest/api/TimeSignatureApiTest.cpp
+++ b/src/private/mxtest/api/TimeSignatureApiTest.cpp
@@ -9,18 +9,64 @@
 #include "mx/api/DocumentManager.h"
 #include "mxtest/file/MxFileRepository.h"
 
+#include <sstream>
+
 using namespace std;
 using namespace mx::api;
 using namespace mxtest;
 
-namespace
+static constexpr const char *const kTimeSignatureApiTestFileName = "testAccidentals1.xml";
+
+// puts the given time signature into a one-part score; extraStaves > 0 adds staves so that per-staff
+// time signatures survive the reader's staff-count sanity check
+static ScoreData timeSignatureApiTestScore(const TimeChoice &inTimeSignature, int extraStaves = 0)
 {
-constexpr const char *const fileName = "testAccidentals1.xml";
+    ScoreData score;
+    score.parts.push_back(PartData{});
+    auto &part = score.parts.back();
+    part.measures.emplace_back();
+    auto &measure = part.measures.back();
+    measure.timeSignature = inTimeSignature;
+    measure.staves.emplace_back(StaffData{});
+    for (int i = 0; i < extraStaves; ++i)
+    {
+        measure.staves.emplace_back(StaffData{});
+    }
+    return score;
+}
+
+// serializes the score and reads it back through the api
+static ScoreData timeSignatureApiTestRoundTrip(const ScoreData &inScore)
+{
+    auto &docMgr = DocumentManager::getInstance();
+    const auto originalIdResult = docMgr.createFromScore(inScore);
+    if (!originalIdResult.ok())
+    {
+        return ScoreData{};
+    }
+    const int originalId = originalIdResult.value();
+    std::stringstream xml;
+    docMgr.writeToStream(originalId, xml);
+    docMgr.destroyDocument(originalId);
+    std::istringstream iss{xml.str()};
+    const auto reloadedIdResult = docMgr.createFromStream(iss);
+    if (!reloadedIdResult.ok())
+    {
+        return ScoreData{};
+    }
+    const int reloadedId = reloadedIdResult.value();
+    const auto reloadedScoreResult = docMgr.getData(reloadedId);
+    docMgr.destroyDocument(reloadedId);
+    if (!reloadedScoreResult.ok())
+    {
+        return ScoreData{};
+    }
+    return reloadedScoreResult.value();
 }
 
 TEST(implicitCarryover, TimeSignatureApi)
 {
-    const auto scoreData = mxtest::MxFileRepository::loadFile(fileName);
+    const auto scoreData = mxtest::MxFileRepository::loadFile(kTimeSignatureApiTestFileName);
     CHECK_EQUAL(1, scoreData.parts.size());
     const auto &part = scoreData.parts.front();
     CHECK_EQUAL(2, part.measures.size())
@@ -28,16 +74,284 @@ TEST(implicitCarryover, TimeSignatureApi)
     auto t = measureIter->timeSignature;
 
     CHECK(!t.isImplicit);
-    CHECK_EQUAL("3", t.beats);
-    CHECK_EQUAL("4", t.beatType);
-    CHECK(t.symbol == TimeSignatureSymbol::unspecified);
+    REQUIRE(t.isSimple());
+    CHECK_EQUAL("3", t.asSimple().fraction.beats);
+    CHECK_EQUAL("4", t.asSimple().fraction.beatType);
+    CHECK(t.asSimple().symbol == TimeSignatureSymbol::unspecified);
 
     ++measureIter;
     t = measureIter->timeSignature;
     CHECK(t.isImplicit);
-    CHECK_EQUAL("3", t.beats);
-    CHECK_EQUAL("4", t.beatType);
-    CHECK(t.symbol == TimeSignatureSymbol::unspecified);
+    REQUIRE(t.isSimple());
+    CHECK_EQUAL("3", t.asSimple().fraction.beats);
+    CHECK_EQUAL("4", t.asSimple().fraction.beatType);
+}
+
+T_END
+
+TEST(defaultIsSimpleImplicitFourFour, TimeSignatureApi)
+{
+    TimeChoice t;
+    CHECK(t.isImplicit);
+    REQUIRE(t.isSimple());
+    CHECK(t.kind() == TimeChoice::Kind::simple);
+    CHECK_EQUAL("4", t.asSimple().fraction.beats);
+    CHECK_EQUAL("4", t.asSimple().fraction.beatType);
+    CHECK(t.asSimple().symbol == TimeSignatureSymbol::unspecified);
+    CHECK(t.display == Bool::unspecified);
+}
+
+T_END
+
+TEST(autoCollapseSimpleEquivalent, TimeSignatureApi)
+{
+    // a plain single-fraction meter with no decorations collapses to simple
+    MeteredTimeSignature plain;
+    plain.fractions = {{"3", "4"}};
+    auto collapsed = TimeChoice::complex(ComplexTimeSignature::metered(plain));
+    REQUIRE(collapsed.isSimple());
+    CHECK_EQUAL("3", collapsed.asSimple().fraction.beats);
+
+    // common/cut collapse too, mapping to the narrow simple symbol
+    MeteredTimeSignature common;
+    common.symbol = ComplexTimeSymbol::common;
+    auto collapsedCommon = TimeChoice::complex(ComplexTimeSignature::metered(common));
+    REQUIRE(collapsedCommon.isSimple());
+    CHECK(collapsedCommon.asSimple().symbol == TimeSignatureSymbol::common);
+}
+
+T_END
+
+TEST(complexStaysComplex, TimeSignatureApi)
+{
+    // more than one fraction -> genuinely composite, stays complex
+    MeteredTimeSignature composite;
+    composite.fractions = {{"2", "4"}, {"3", "8"}};
+    CHECK(TimeChoice::complex(ComplexTimeSignature::metered(composite)).isComplex());
+
+    // an unusual symbol (no simple equivalent) keeps it complex
+    MeteredTimeSignature single;
+    single.fractions = {{"3", "4"}};
+    single.symbol = ComplexTimeSymbol::singleNumber;
+    CHECK(TimeChoice::complex(ComplexTimeSignature::metered(single)).isComplex());
+
+    // a separator keeps it complex
+    MeteredTimeSignature separated;
+    separated.fractions = {{"3", "4"}};
+    separated.separator = TimeSeparator::diagonal;
+    CHECK(TimeChoice::complex(ComplexTimeSignature::metered(separated)).isComplex());
+
+    // an interchangeable alternate keeps it complex
+    MeteredTimeSignature dual;
+    dual.fractions = {{"3", "4"}};
+    InterchangeableTimeSignature alt;
+    alt.fractions = {{"6", "8"}};
+    dual.interchangeable = alt;
+    CHECK(TimeChoice::complex(ComplexTimeSignature::metered(dual)).isComplex());
+
+    // senza-misura is always complex
+    CHECK(TimeChoice::complex(ComplexTimeSignature::senzaMisura("X")).isComplex());
+}
+
+T_END
+
+TEST(equality, TimeSignatureApi)
+{
+    TimeChoice a;
+    TimeChoice b;
+    CHECK(a == b);
+
+    // isImplicit is part of equality
+    b.isImplicit = false;
+    CHECK(a != b);
+    b.isImplicit = true;
+    CHECK(a == b);
+
+    // simple fraction difference
+    a = TimeChoice::simple(TimeSignatureData{TimeSignatureSymbol::unspecified, {"3", "4"}});
+    CHECK(a != b);
+    b = TimeChoice::simple(TimeSignatureData{TimeSignatureSymbol::unspecified, {"3", "4"}});
+    CHECK(a == b);
+
+    // simple vs complex never compare equal
+    MeteredTimeSignature composite;
+    composite.fractions = {{"2", "4"}, {"3", "8"}};
+    a = TimeChoice::complex(ComplexTimeSignature::metered(composite));
+    CHECK(a != b);
+
+    // nested composite second-fraction difference
+    MeteredTimeSignature other;
+    other.fractions = {{"2", "4"}, {"3", "16"}};
+    b = TimeChoice::complex(ComplexTimeSignature::metered(other));
+    CHECK(a != b);
+    b = TimeChoice::complex(ComplexTimeSignature::metered(composite));
+    CHECK(a == b);
+
+    // interchangeable relation-only difference
+    MeteredTimeSignature dualA;
+    dualA.fractions = {{"3", "4"}};
+    InterchangeableTimeSignature altA;
+    altA.fractions = {{"6", "8"}};
+    altA.relation = TimeRelation::parentheses;
+    dualA.interchangeable = altA;
+    a = TimeChoice::complex(ComplexTimeSignature::metered(dualA));
+
+    MeteredTimeSignature dualB = dualA;
+    dualB.interchangeable->relation = TimeRelation::bracket;
+    b = TimeChoice::complex(ComplexTimeSignature::metered(dualB));
+    CHECK(a != b);
+
+    // senza-misura glyph difference
+    a = TimeChoice::complex(ComplexTimeSignature::senzaMisura("X"));
+    b = TimeChoice::complex(ComplexTimeSignature::senzaMisura(""));
+    CHECK(a != b);
+    b = TimeChoice::complex(ComplexTimeSignature::senzaMisura("X"));
+    CHECK(a == b);
+}
+
+T_END
+
+TEST(roundTripComposite, TimeSignatureApi)
+{
+    MeteredTimeSignature composite;
+    composite.fractions = {{"2", "4"}, {"3", "8"}};
+    auto t = TimeChoice::complex(ComplexTimeSignature::metered(composite));
+    t.isImplicit = false;
+
+    const auto reloaded = timeSignatureApiTestRoundTrip(timeSignatureApiTestScore(t));
+    REQUIRE(!reloaded.parts.empty());
+    const auto &actual = reloaded.parts.at(0).measures.at(0).timeSignature;
+    CHECK(!actual.isImplicit);
+    REQUIRE(actual.isComplex());
+    REQUIRE(actual.asComplex().isMetered());
+    const auto &fractions = actual.asComplex().asMetered().fractions;
+    REQUIRE(2 == fractions.size());
+    CHECK_EQUAL("2", fractions.at(0).beats);
+    CHECK_EQUAL("4", fractions.at(0).beatType);
+    CHECK_EQUAL("3", fractions.at(1).beats);
+    CHECK_EQUAL("8", fractions.at(1).beatType);
+}
+
+T_END
+
+TEST(roundTripSenzaMisuraWithGlyph, TimeSignatureApi)
+{
+    auto t = TimeChoice::complex(ComplexTimeSignature::senzaMisura("X"));
+    t.isImplicit = false;
+
+    const auto reloaded = timeSignatureApiTestRoundTrip(timeSignatureApiTestScore(t));
+    REQUIRE(!reloaded.parts.empty());
+    const auto &actual = reloaded.parts.at(0).measures.at(0).timeSignature;
+    CHECK(!actual.isImplicit);
+    REQUIRE(actual.isComplex());
+    REQUIRE(actual.asComplex().isSenzaMisura());
+    CHECK_EQUAL("X", actual.asComplex().asSenzaMisura());
+}
+
+T_END
+
+TEST(roundTripSenzaMisuraWithoutGlyph, TimeSignatureApi)
+{
+    auto t = TimeChoice::complex(ComplexTimeSignature::senzaMisura());
+    t.isImplicit = false;
+
+    const auto reloaded = timeSignatureApiTestRoundTrip(timeSignatureApiTestScore(t));
+    REQUIRE(!reloaded.parts.empty());
+    const auto &actual = reloaded.parts.at(0).measures.at(0).timeSignature;
+    CHECK(!actual.isImplicit);
+    REQUIRE(actual.isComplex());
+    REQUIRE(actual.asComplex().isSenzaMisura());
+    CHECK_EQUAL("", actual.asComplex().asSenzaMisura());
+}
+
+T_END
+
+TEST(roundTripInterchangeable, TimeSignatureApi)
+{
+    MeteredTimeSignature metered;
+    metered.fractions = {{"3", "4"}};
+    InterchangeableTimeSignature alt;
+    alt.fractions = {{"6", "8"}, {"3", "8"}}; // a composite alternate
+    alt.relation = TimeRelation::parentheses;
+    alt.symbol = ComplexTimeSymbol::cut;
+    alt.separator = TimeSeparator::horizontal;
+    metered.interchangeable = alt;
+    auto t = TimeChoice::complex(ComplexTimeSignature::metered(metered));
+    t.isImplicit = false;
+
+    const auto reloaded = timeSignatureApiTestRoundTrip(timeSignatureApiTestScore(t));
+    REQUIRE(!reloaded.parts.empty());
+    const auto &actual = reloaded.parts.at(0).measures.at(0).timeSignature;
+    REQUIRE(actual.isComplex());
+    REQUIRE(actual.asComplex().isMetered());
+    const auto &actualMetered = actual.asComplex().asMetered();
+    CHECK_EQUAL("3", actualMetered.fractions.at(0).beats);
+    REQUIRE(actualMetered.interchangeable.has_value());
+    CHECK(*actualMetered.interchangeable == alt);
+}
+
+T_END
+
+TEST(roundTripWidenedSymbolAndSeparator, TimeSignatureApi)
+{
+    MeteredTimeSignature metered;
+    metered.fractions = {{"3", "4"}};
+    metered.symbol = ComplexTimeSymbol::note;
+    metered.separator = TimeSeparator::diagonal;
+    auto t = TimeChoice::complex(ComplexTimeSignature::metered(metered));
+    t.isImplicit = false;
+
+    const auto reloaded = timeSignatureApiTestRoundTrip(timeSignatureApiTestScore(t));
+    REQUIRE(!reloaded.parts.empty());
+    const auto &actual = reloaded.parts.at(0).measures.at(0).timeSignature;
+    REQUIRE(actual.isComplex());
+    REQUIRE(actual.asComplex().isMetered());
+    CHECK(actual.asComplex().asMetered().symbol == ComplexTimeSymbol::note);
+    CHECK(actual.asComplex().asMetered().separator == TimeSeparator::diagonal);
+}
+
+T_END
+
+TEST(roundTripPerStaff, TimeSignatureApi)
+{
+    // staff 0 (unscoped default) in 4/4; staff 1 overridden to 3/8
+    auto shared = TimeChoice::simple(TimeSignatureData{});
+    shared.isImplicit = false;
+
+    auto score = timeSignatureApiTestScore(shared, 1); // two staves
+
+    auto staffTime = TimeChoice::simple(TimeSignatureData{TimeSignatureSymbol::unspecified, {"3", "8"}});
+    staffTime.isImplicit = false;
+    score.parts.at(0).measures.at(0).staffTimeSignatures[1] = staffTime;
+
+    // add a second measure so we can observe per-staff carry-forward
+    score.parts.at(0).measures.emplace_back();
+    auto &secondMeasure = score.parts.at(0).measures.back();
+    secondMeasure.staves.emplace_back(StaffData{});
+    secondMeasure.staves.emplace_back(StaffData{});
+
+    const auto reloaded = timeSignatureApiTestRoundTrip(score);
+    REQUIRE(!reloaded.parts.empty());
+    REQUIRE(2 == reloaded.parts.at(0).measures.size());
+
+    const auto &firstMeasure = reloaded.parts.at(0).measures.at(0);
+    CHECK(!firstMeasure.timeSignature.isImplicit);
+    CHECK_EQUAL("4", firstMeasure.timeSignature.asSimple().fraction.beats);
+    REQUIRE(1 == firstMeasure.staffTimeSignatures.size());
+    REQUIRE(firstMeasure.staffTimeSignatures.count(1) == 1);
+    const auto &actualStaffTime = firstMeasure.staffTimeSignatures.at(1);
+    CHECK(!actualStaffTime.isImplicit);
+    REQUIRE(actualStaffTime.isSimple());
+    CHECK_EQUAL("3", actualStaffTime.asSimple().fraction.beats);
+    CHECK_EQUAL("8", actualStaffTime.asSimple().fraction.beatType);
+
+    // the override carries forward, implicitly, into the next measure
+    const auto &carried = reloaded.parts.at(0).measures.at(1);
+    CHECK(carried.timeSignature.isImplicit);
+    REQUIRE(1 == carried.staffTimeSignatures.size());
+    REQUIRE(carried.staffTimeSignatures.count(1) == 1);
+    CHECK(carried.staffTimeSignatures.at(1).isImplicit);
+    CHECK_EQUAL("3", carried.staffTimeSignatures.at(1).asSimple().fraction.beats);
 }
 
 T_END

--- a/src/private/mxtest/api/TimeSignatureApiTest.cpp
+++ b/src/private/mxtest/api/TimeSignatureApiTest.cpp
@@ -75,16 +75,16 @@ TEST(implicitCarryover, TimeSignatureApi)
 
     CHECK(!t.isImplicit);
     REQUIRE(t.isSimple());
-    CHECK_EQUAL("3", t.asSimple().fraction.beats);
-    CHECK_EQUAL("4", t.asSimple().fraction.beatType);
-    CHECK(t.asSimple().symbol == TimeSignatureSymbol::unspecified);
+    CHECK_EQUAL("3", t.simple().fraction.beats);
+    CHECK_EQUAL("4", t.simple().fraction.beatType);
+    CHECK(t.simple().symbol == TimeSignatureSymbol::unspecified);
 
     ++measureIter;
     t = measureIter->timeSignature;
     CHECK(t.isImplicit);
     REQUIRE(t.isSimple());
-    CHECK_EQUAL("3", t.asSimple().fraction.beats);
-    CHECK_EQUAL("4", t.asSimple().fraction.beatType);
+    CHECK_EQUAL("3", t.simple().fraction.beats);
+    CHECK_EQUAL("4", t.simple().fraction.beatType);
 }
 
 T_END
@@ -95,9 +95,9 @@ TEST(defaultIsSimpleImplicitFourFour, TimeSignatureApi)
     CHECK(t.isImplicit);
     REQUIRE(t.isSimple());
     CHECK(t.kind() == TimeChoice::Kind::simple);
-    CHECK_EQUAL("4", t.asSimple().fraction.beats);
-    CHECK_EQUAL("4", t.asSimple().fraction.beatType);
-    CHECK(t.asSimple().symbol == TimeSignatureSymbol::unspecified);
+    CHECK_EQUAL("4", t.simple().fraction.beats);
+    CHECK_EQUAL("4", t.simple().fraction.beatType);
+    CHECK(t.simple().symbol == TimeSignatureSymbol::unspecified);
     CHECK(t.display == Bool::unspecified);
 }
 
@@ -110,14 +110,14 @@ TEST(autoCollapseSimpleEquivalent, TimeSignatureApi)
     plain.fractions = {{"3", "4"}};
     auto collapsed = TimeChoice(ComplexTimeSignature(plain));
     REQUIRE(collapsed.isSimple());
-    CHECK_EQUAL("3", collapsed.asSimple().fraction.beats);
+    CHECK_EQUAL("3", collapsed.simple().fraction.beats);
 
     // common/cut collapse too, mapping to the narrow simple symbol
     MeteredTimeSignature common;
     common.symbol = ComplexTimeSymbol::common;
     auto collapsedCommon = TimeChoice(ComplexTimeSignature(common));
     REQUIRE(collapsedCommon.isSimple());
-    CHECK(collapsedCommon.asSimple().symbol == TimeSignatureSymbol::common);
+    CHECK(collapsedCommon.simple().symbol == TimeSignatureSymbol::common);
 }
 
 T_END
@@ -223,8 +223,8 @@ TEST(roundTripComposite, TimeSignatureApi)
     const auto &actual = reloaded.parts.at(0).measures.at(0).timeSignature;
     CHECK(!actual.isImplicit);
     REQUIRE(actual.isComplex());
-    REQUIRE(actual.asComplex().isMetered());
-    const auto &fractions = actual.asComplex().asMetered().fractions;
+    REQUIRE(actual.complex().isMetered());
+    const auto &fractions = actual.complex().metered().fractions;
     REQUIRE(2 == fractions.size());
     CHECK_EQUAL("2", fractions.at(0).beats);
     CHECK_EQUAL("4", fractions.at(0).beatType);
@@ -244,8 +244,8 @@ TEST(roundTripSenzaMisuraWithGlyph, TimeSignatureApi)
     const auto &actual = reloaded.parts.at(0).measures.at(0).timeSignature;
     CHECK(!actual.isImplicit);
     REQUIRE(actual.isComplex());
-    REQUIRE(actual.asComplex().isSenzaMisura());
-    CHECK_EQUAL("X", actual.asComplex().asSenzaMisura());
+    REQUIRE(actual.complex().isSenzaMisura());
+    CHECK_EQUAL("X", actual.complex().senzaMisura());
 }
 
 T_END
@@ -260,8 +260,8 @@ TEST(roundTripSenzaMisuraWithoutGlyph, TimeSignatureApi)
     const auto &actual = reloaded.parts.at(0).measures.at(0).timeSignature;
     CHECK(!actual.isImplicit);
     REQUIRE(actual.isComplex());
-    REQUIRE(actual.asComplex().isSenzaMisura());
-    CHECK_EQUAL("", actual.asComplex().asSenzaMisura());
+    REQUIRE(actual.complex().isSenzaMisura());
+    CHECK_EQUAL("", actual.complex().senzaMisura());
 }
 
 T_END
@@ -283,8 +283,8 @@ TEST(roundTripInterchangeable, TimeSignatureApi)
     REQUIRE(!reloaded.parts.empty());
     const auto &actual = reloaded.parts.at(0).measures.at(0).timeSignature;
     REQUIRE(actual.isComplex());
-    REQUIRE(actual.asComplex().isMetered());
-    const auto &actualMetered = actual.asComplex().asMetered();
+    REQUIRE(actual.complex().isMetered());
+    const auto &actualMetered = actual.complex().metered();
     CHECK_EQUAL("3", actualMetered.fractions.at(0).beats);
     REQUIRE(actualMetered.interchangeable.has_value());
     CHECK(*actualMetered.interchangeable == alt);
@@ -305,9 +305,9 @@ TEST(roundTripWidenedSymbolAndSeparator, TimeSignatureApi)
     REQUIRE(!reloaded.parts.empty());
     const auto &actual = reloaded.parts.at(0).measures.at(0).timeSignature;
     REQUIRE(actual.isComplex());
-    REQUIRE(actual.asComplex().isMetered());
-    CHECK(actual.asComplex().asMetered().symbol == ComplexTimeSymbol::note);
-    CHECK(actual.asComplex().asMetered().separator == TimeSeparator::diagonal);
+    REQUIRE(actual.complex().isMetered());
+    CHECK(actual.complex().metered().symbol == ComplexTimeSymbol::note);
+    CHECK(actual.complex().metered().separator == TimeSeparator::diagonal);
 }
 
 T_END
@@ -336,14 +336,14 @@ TEST(roundTripPerStaff, TimeSignatureApi)
 
     const auto &firstMeasure = reloaded.parts.at(0).measures.at(0);
     CHECK(!firstMeasure.timeSignature.isImplicit);
-    CHECK_EQUAL("4", firstMeasure.timeSignature.asSimple().fraction.beats);
+    CHECK_EQUAL("4", firstMeasure.timeSignature.simple().fraction.beats);
     REQUIRE(1 == firstMeasure.staffTimeSignatures.size());
     REQUIRE(firstMeasure.staffTimeSignatures.count(1) == 1);
     const auto &actualStaffTime = firstMeasure.staffTimeSignatures.at(1);
     CHECK(!actualStaffTime.isImplicit);
     REQUIRE(actualStaffTime.isSimple());
-    CHECK_EQUAL("3", actualStaffTime.asSimple().fraction.beats);
-    CHECK_EQUAL("8", actualStaffTime.asSimple().fraction.beatType);
+    CHECK_EQUAL("3", actualStaffTime.simple().fraction.beats);
+    CHECK_EQUAL("8", actualStaffTime.simple().fraction.beatType);
 
     // the override carries forward, implicitly, into the next measure
     const auto &carried = reloaded.parts.at(0).measures.at(1);
@@ -351,7 +351,7 @@ TEST(roundTripPerStaff, TimeSignatureApi)
     REQUIRE(1 == carried.staffTimeSignatures.size());
     REQUIRE(carried.staffTimeSignatures.count(1) == 1);
     CHECK(carried.staffTimeSignatures.at(1).isImplicit);
-    CHECK_EQUAL("3", carried.staffTimeSignatures.at(1).asSimple().fraction.beats);
+    CHECK_EQUAL("3", carried.staffTimeSignatures.at(1).simple().fraction.beats);
 }
 
 T_END

--- a/src/private/mxtest/api/TimeSignatureApiTest.cpp
+++ b/src/private/mxtest/api/TimeSignatureApiTest.cpp
@@ -108,14 +108,14 @@ TEST(autoCollapseSimpleEquivalent, TimeSignatureApi)
     // a plain single-fraction meter with no decorations collapses to simple
     MeteredTimeSignature plain;
     plain.fractions = {{"3", "4"}};
-    auto collapsed = TimeChoice::complex(ComplexTimeSignature::metered(plain));
+    auto collapsed = TimeChoice(ComplexTimeSignature::metered(plain));
     REQUIRE(collapsed.isSimple());
     CHECK_EQUAL("3", collapsed.asSimple().fraction.beats);
 
     // common/cut collapse too, mapping to the narrow simple symbol
     MeteredTimeSignature common;
     common.symbol = ComplexTimeSymbol::common;
-    auto collapsedCommon = TimeChoice::complex(ComplexTimeSignature::metered(common));
+    auto collapsedCommon = TimeChoice(ComplexTimeSignature::metered(common));
     REQUIRE(collapsedCommon.isSimple());
     CHECK(collapsedCommon.asSimple().symbol == TimeSignatureSymbol::common);
 }
@@ -127,19 +127,19 @@ TEST(complexStaysComplex, TimeSignatureApi)
     // more than one fraction -> genuinely composite, stays complex
     MeteredTimeSignature composite;
     composite.fractions = {{"2", "4"}, {"3", "8"}};
-    CHECK(TimeChoice::complex(ComplexTimeSignature::metered(composite)).isComplex());
+    CHECK(TimeChoice(ComplexTimeSignature::metered(composite)).isComplex());
 
     // an unusual symbol (no simple equivalent) keeps it complex
     MeteredTimeSignature single;
     single.fractions = {{"3", "4"}};
     single.symbol = ComplexTimeSymbol::singleNumber;
-    CHECK(TimeChoice::complex(ComplexTimeSignature::metered(single)).isComplex());
+    CHECK(TimeChoice(ComplexTimeSignature::metered(single)).isComplex());
 
     // a separator keeps it complex
     MeteredTimeSignature separated;
     separated.fractions = {{"3", "4"}};
     separated.separator = TimeSeparator::diagonal;
-    CHECK(TimeChoice::complex(ComplexTimeSignature::metered(separated)).isComplex());
+    CHECK(TimeChoice(ComplexTimeSignature::metered(separated)).isComplex());
 
     // an interchangeable alternate keeps it complex
     MeteredTimeSignature dual;
@@ -147,10 +147,10 @@ TEST(complexStaysComplex, TimeSignatureApi)
     InterchangeableTimeSignature alt;
     alt.fractions = {{"6", "8"}};
     dual.interchangeable = alt;
-    CHECK(TimeChoice::complex(ComplexTimeSignature::metered(dual)).isComplex());
+    CHECK(TimeChoice(ComplexTimeSignature::metered(dual)).isComplex());
 
     // senza-misura is always complex
-    CHECK(TimeChoice::complex(ComplexTimeSignature::senzaMisura("X")).isComplex());
+    CHECK(TimeChoice(ComplexTimeSignature::senzaMisura("X")).isComplex());
 }
 
 T_END
@@ -168,23 +168,23 @@ TEST(equality, TimeSignatureApi)
     CHECK(a == b);
 
     // simple fraction difference
-    a = TimeChoice::simple(TimeSignatureData{TimeSignatureSymbol::unspecified, {"3", "4"}});
+    a = TimeChoice(TimeSignatureData{TimeSignatureSymbol::unspecified, {"3", "4"}});
     CHECK(a != b);
-    b = TimeChoice::simple(TimeSignatureData{TimeSignatureSymbol::unspecified, {"3", "4"}});
+    b = TimeChoice(TimeSignatureData{TimeSignatureSymbol::unspecified, {"3", "4"}});
     CHECK(a == b);
 
     // simple vs complex never compare equal
     MeteredTimeSignature composite;
     composite.fractions = {{"2", "4"}, {"3", "8"}};
-    a = TimeChoice::complex(ComplexTimeSignature::metered(composite));
+    a = TimeChoice(ComplexTimeSignature::metered(composite));
     CHECK(a != b);
 
     // nested composite second-fraction difference
     MeteredTimeSignature other;
     other.fractions = {{"2", "4"}, {"3", "16"}};
-    b = TimeChoice::complex(ComplexTimeSignature::metered(other));
+    b = TimeChoice(ComplexTimeSignature::metered(other));
     CHECK(a != b);
-    b = TimeChoice::complex(ComplexTimeSignature::metered(composite));
+    b = TimeChoice(ComplexTimeSignature::metered(composite));
     CHECK(a == b);
 
     // interchangeable relation-only difference
@@ -194,18 +194,18 @@ TEST(equality, TimeSignatureApi)
     altA.fractions = {{"6", "8"}};
     altA.relation = TimeRelation::parentheses;
     dualA.interchangeable = altA;
-    a = TimeChoice::complex(ComplexTimeSignature::metered(dualA));
+    a = TimeChoice(ComplexTimeSignature::metered(dualA));
 
     MeteredTimeSignature dualB = dualA;
     dualB.interchangeable->relation = TimeRelation::bracket;
-    b = TimeChoice::complex(ComplexTimeSignature::metered(dualB));
+    b = TimeChoice(ComplexTimeSignature::metered(dualB));
     CHECK(a != b);
 
     // senza-misura glyph difference
-    a = TimeChoice::complex(ComplexTimeSignature::senzaMisura("X"));
-    b = TimeChoice::complex(ComplexTimeSignature::senzaMisura(""));
+    a = TimeChoice(ComplexTimeSignature::senzaMisura("X"));
+    b = TimeChoice(ComplexTimeSignature::senzaMisura(""));
     CHECK(a != b);
-    b = TimeChoice::complex(ComplexTimeSignature::senzaMisura("X"));
+    b = TimeChoice(ComplexTimeSignature::senzaMisura("X"));
     CHECK(a == b);
 }
 
@@ -215,7 +215,7 @@ TEST(roundTripComposite, TimeSignatureApi)
 {
     MeteredTimeSignature composite;
     composite.fractions = {{"2", "4"}, {"3", "8"}};
-    auto t = TimeChoice::complex(ComplexTimeSignature::metered(composite));
+    auto t = TimeChoice(ComplexTimeSignature::metered(composite));
     t.isImplicit = false;
 
     const auto reloaded = timeSignatureApiTestRoundTrip(timeSignatureApiTestScore(t));
@@ -236,7 +236,7 @@ T_END
 
 TEST(roundTripSenzaMisuraWithGlyph, TimeSignatureApi)
 {
-    auto t = TimeChoice::complex(ComplexTimeSignature::senzaMisura("X"));
+    auto t = TimeChoice(ComplexTimeSignature::senzaMisura("X"));
     t.isImplicit = false;
 
     const auto reloaded = timeSignatureApiTestRoundTrip(timeSignatureApiTestScore(t));
@@ -252,7 +252,7 @@ T_END
 
 TEST(roundTripSenzaMisuraWithoutGlyph, TimeSignatureApi)
 {
-    auto t = TimeChoice::complex(ComplexTimeSignature::senzaMisura());
+    auto t = TimeChoice(ComplexTimeSignature::senzaMisura());
     t.isImplicit = false;
 
     const auto reloaded = timeSignatureApiTestRoundTrip(timeSignatureApiTestScore(t));
@@ -276,7 +276,7 @@ TEST(roundTripInterchangeable, TimeSignatureApi)
     alt.symbol = ComplexTimeSymbol::cut;
     alt.separator = TimeSeparator::horizontal;
     metered.interchangeable = alt;
-    auto t = TimeChoice::complex(ComplexTimeSignature::metered(metered));
+    auto t = TimeChoice(ComplexTimeSignature::metered(metered));
     t.isImplicit = false;
 
     const auto reloaded = timeSignatureApiTestRoundTrip(timeSignatureApiTestScore(t));
@@ -298,7 +298,7 @@ TEST(roundTripWidenedSymbolAndSeparator, TimeSignatureApi)
     metered.fractions = {{"3", "4"}};
     metered.symbol = ComplexTimeSymbol::note;
     metered.separator = TimeSeparator::diagonal;
-    auto t = TimeChoice::complex(ComplexTimeSignature::metered(metered));
+    auto t = TimeChoice(ComplexTimeSignature::metered(metered));
     t.isImplicit = false;
 
     const auto reloaded = timeSignatureApiTestRoundTrip(timeSignatureApiTestScore(t));
@@ -315,12 +315,12 @@ T_END
 TEST(roundTripPerStaff, TimeSignatureApi)
 {
     // staff 0 (unscoped default) in 4/4; staff 1 overridden to 3/8
-    auto shared = TimeChoice::simple(TimeSignatureData{});
+    auto shared = TimeChoice(TimeSignatureData{});
     shared.isImplicit = false;
 
     auto score = timeSignatureApiTestScore(shared, 1); // two staves
 
-    auto staffTime = TimeChoice::simple(TimeSignatureData{TimeSignatureSymbol::unspecified, {"3", "8"}});
+    auto staffTime = TimeChoice(TimeSignatureData{TimeSignatureSymbol::unspecified, {"3", "8"}});
     staffTime.isImplicit = false;
     score.parts.at(0).measures.at(0).staffTimeSignatures[1] = staffTime;
 

--- a/src/private/mxtest/api/TimeSignatureApiTest.cpp
+++ b/src/private/mxtest/api/TimeSignatureApiTest.cpp
@@ -168,9 +168,9 @@ TEST(equality, TimeSignatureApi)
     CHECK(a == b);
 
     // simple fraction difference
-    a = TimeChoice(TimeSignatureData{TimeSignatureSymbol::unspecified, {"3", "4"}});
+    a = TimeChoice(TimeSignatureData{"3", "4"});
     CHECK(a != b);
-    b = TimeChoice(TimeSignatureData{TimeSignatureSymbol::unspecified, {"3", "4"}});
+    b = TimeChoice(TimeSignatureData{"3", "4"});
     CHECK(a == b);
 
     // simple vs complex never compare equal
@@ -320,7 +320,7 @@ TEST(roundTripPerStaff, TimeSignatureApi)
 
     auto score = timeSignatureApiTestScore(shared, 1); // two staves
 
-    auto staffTime = TimeChoice(TimeSignatureData{TimeSignatureSymbol::unspecified, {"3", "8"}});
+    auto staffTime = TimeChoice(TimeSignatureData{"3", "8"});
     staffTime.isImplicit = false;
     score.parts.at(0).measures.at(0).staffTimeSignatures[1] = staffTime;
 

--- a/src/private/mxtest/api/TimeSignatureApiTest.cpp
+++ b/src/private/mxtest/api/TimeSignatureApiTest.cpp
@@ -108,14 +108,14 @@ TEST(autoCollapseSimpleEquivalent, TimeSignatureApi)
     // a plain single-fraction meter with no decorations collapses to simple
     MeteredTimeSignature plain;
     plain.fractions = {{"3", "4"}};
-    auto collapsed = TimeChoice(ComplexTimeSignature::metered(plain));
+    auto collapsed = TimeChoice(ComplexTimeSignature(plain));
     REQUIRE(collapsed.isSimple());
     CHECK_EQUAL("3", collapsed.asSimple().fraction.beats);
 
     // common/cut collapse too, mapping to the narrow simple symbol
     MeteredTimeSignature common;
     common.symbol = ComplexTimeSymbol::common;
-    auto collapsedCommon = TimeChoice(ComplexTimeSignature::metered(common));
+    auto collapsedCommon = TimeChoice(ComplexTimeSignature(common));
     REQUIRE(collapsedCommon.isSimple());
     CHECK(collapsedCommon.asSimple().symbol == TimeSignatureSymbol::common);
 }
@@ -127,19 +127,19 @@ TEST(complexStaysComplex, TimeSignatureApi)
     // more than one fraction -> genuinely composite, stays complex
     MeteredTimeSignature composite;
     composite.fractions = {{"2", "4"}, {"3", "8"}};
-    CHECK(TimeChoice(ComplexTimeSignature::metered(composite)).isComplex());
+    CHECK(TimeChoice(ComplexTimeSignature(composite)).isComplex());
 
     // an unusual symbol (no simple equivalent) keeps it complex
     MeteredTimeSignature single;
     single.fractions = {{"3", "4"}};
     single.symbol = ComplexTimeSymbol::singleNumber;
-    CHECK(TimeChoice(ComplexTimeSignature::metered(single)).isComplex());
+    CHECK(TimeChoice(ComplexTimeSignature(single)).isComplex());
 
     // a separator keeps it complex
     MeteredTimeSignature separated;
     separated.fractions = {{"3", "4"}};
     separated.separator = TimeSeparator::diagonal;
-    CHECK(TimeChoice(ComplexTimeSignature::metered(separated)).isComplex());
+    CHECK(TimeChoice(ComplexTimeSignature(separated)).isComplex());
 
     // an interchangeable alternate keeps it complex
     MeteredTimeSignature dual;
@@ -147,10 +147,10 @@ TEST(complexStaysComplex, TimeSignatureApi)
     InterchangeableTimeSignature alt;
     alt.fractions = {{"6", "8"}};
     dual.interchangeable = alt;
-    CHECK(TimeChoice(ComplexTimeSignature::metered(dual)).isComplex());
+    CHECK(TimeChoice(ComplexTimeSignature(dual)).isComplex());
 
     // senza-misura is always complex
-    CHECK(TimeChoice(ComplexTimeSignature::senzaMisura("X")).isComplex());
+    CHECK(TimeChoice(ComplexTimeSignature("X")).isComplex());
 }
 
 T_END
@@ -176,15 +176,15 @@ TEST(equality, TimeSignatureApi)
     // simple vs complex never compare equal
     MeteredTimeSignature composite;
     composite.fractions = {{"2", "4"}, {"3", "8"}};
-    a = TimeChoice(ComplexTimeSignature::metered(composite));
+    a = TimeChoice(ComplexTimeSignature(composite));
     CHECK(a != b);
 
     // nested composite second-fraction difference
     MeteredTimeSignature other;
     other.fractions = {{"2", "4"}, {"3", "16"}};
-    b = TimeChoice(ComplexTimeSignature::metered(other));
+    b = TimeChoice(ComplexTimeSignature(other));
     CHECK(a != b);
-    b = TimeChoice(ComplexTimeSignature::metered(composite));
+    b = TimeChoice(ComplexTimeSignature(composite));
     CHECK(a == b);
 
     // interchangeable relation-only difference
@@ -194,18 +194,18 @@ TEST(equality, TimeSignatureApi)
     altA.fractions = {{"6", "8"}};
     altA.relation = TimeRelation::parentheses;
     dualA.interchangeable = altA;
-    a = TimeChoice(ComplexTimeSignature::metered(dualA));
+    a = TimeChoice(ComplexTimeSignature(dualA));
 
     MeteredTimeSignature dualB = dualA;
     dualB.interchangeable->relation = TimeRelation::bracket;
-    b = TimeChoice(ComplexTimeSignature::metered(dualB));
+    b = TimeChoice(ComplexTimeSignature(dualB));
     CHECK(a != b);
 
     // senza-misura glyph difference
-    a = TimeChoice(ComplexTimeSignature::senzaMisura("X"));
-    b = TimeChoice(ComplexTimeSignature::senzaMisura(""));
+    a = TimeChoice(ComplexTimeSignature("X"));
+    b = TimeChoice(ComplexTimeSignature(""));
     CHECK(a != b);
-    b = TimeChoice(ComplexTimeSignature::senzaMisura("X"));
+    b = TimeChoice(ComplexTimeSignature("X"));
     CHECK(a == b);
 }
 
@@ -215,7 +215,7 @@ TEST(roundTripComposite, TimeSignatureApi)
 {
     MeteredTimeSignature composite;
     composite.fractions = {{"2", "4"}, {"3", "8"}};
-    auto t = TimeChoice(ComplexTimeSignature::metered(composite));
+    auto t = TimeChoice(ComplexTimeSignature(composite));
     t.isImplicit = false;
 
     const auto reloaded = timeSignatureApiTestRoundTrip(timeSignatureApiTestScore(t));
@@ -236,7 +236,7 @@ T_END
 
 TEST(roundTripSenzaMisuraWithGlyph, TimeSignatureApi)
 {
-    auto t = TimeChoice(ComplexTimeSignature::senzaMisura("X"));
+    auto t = TimeChoice(ComplexTimeSignature("X"));
     t.isImplicit = false;
 
     const auto reloaded = timeSignatureApiTestRoundTrip(timeSignatureApiTestScore(t));
@@ -252,7 +252,7 @@ T_END
 
 TEST(roundTripSenzaMisuraWithoutGlyph, TimeSignatureApi)
 {
-    auto t = TimeChoice(ComplexTimeSignature::senzaMisura());
+    auto t = TimeChoice(ComplexTimeSignature(std::string{}));
     t.isImplicit = false;
 
     const auto reloaded = timeSignatureApiTestRoundTrip(timeSignatureApiTestScore(t));
@@ -276,7 +276,7 @@ TEST(roundTripInterchangeable, TimeSignatureApi)
     alt.symbol = ComplexTimeSymbol::cut;
     alt.separator = TimeSeparator::horizontal;
     metered.interchangeable = alt;
-    auto t = TimeChoice(ComplexTimeSignature::metered(metered));
+    auto t = TimeChoice(ComplexTimeSignature(metered));
     t.isImplicit = false;
 
     const auto reloaded = timeSignatureApiTestRoundTrip(timeSignatureApiTestScore(t));
@@ -298,7 +298,7 @@ TEST(roundTripWidenedSymbolAndSeparator, TimeSignatureApi)
     metered.fractions = {{"3", "4"}};
     metered.symbol = ComplexTimeSymbol::note;
     metered.separator = TimeSeparator::diagonal;
-    auto t = TimeChoice(ComplexTimeSignature::metered(metered));
+    auto t = TimeChoice(ComplexTimeSignature(metered));
     t.isImplicit = false;
 
     const auto reloaded = timeSignatureApiTestRoundTrip(timeSignatureApiTestScore(t));

--- a/src/private/mxtest/api/roundtrip-baseline.txt
+++ b/src/private/mxtest/api/roundtrip-baseline.txt
@@ -313,8 +313,10 @@ lysuite/ly11h_TimeSignatures_SenzaMisura.xml
 # beats/beat-type pairs (1+2.5 over 2+4, 3+2 over 16, 1.5+5 over 8+16).
 # Added to the repo ahead of the TimeSignatureData redesign as the fixture
 # that motivated it. The original (kept byte-exact, not pinned here) also
-# carries a Finale <score-part>/<group>, unspaced music-font comma list, and
-# <measure-numbering> multiple-rest-* attributes that mx::api doesn't model --
-# unrelated pre-existing gaps. timesigs_composite-ref-modified.musicxml trims
-# just those so the composite time-signature round-trip itself is pinned.
+# carries a Finale <score-part>/<group>, unspaced music-font comma list,
+# <measure-numbering> multiple-rest-* attributes, and a <sound>/<swing> --
+# all things mx::api doesn't model (SoundData.h documents <swing> as
+# intentionally out of scope). timesigs_composite-ref-modified.musicxml
+# trims just those unrelated gaps so the composite time-signature round-trip
+# itself is pinned.
 rpatters1/timesigs_composite-ref-modified.musicxml

--- a/src/private/mxtest/api/roundtrip-baseline.txt
+++ b/src/private/mxtest/api/roundtrip-baseline.txt
@@ -298,3 +298,13 @@ musuite/testAccidentals2.xml
 # MeasureWriter: the field and its Converter existed but neither side ever
 # called it, so <measure-numbering> was silently dropped on round-trip.
 ksuite/k015a_System_Layout.xml
+
+# Unblocked by the TimeSignatureData redesign: <time> now models every spec
+# shape (composite/additive multi-pair meters, senza-misura, interchangeable,
+# per-staff number=, separator, note/dotted-note symbols) instead of reading
+# only the first beats/beat-type pair of the first <time> and dropping the
+# rest on round-trip.
+lysuite/ly11d_TimeSignatures_CompoundMultiple.xml
+lysuite/ly11e_TimeSignatures_CompoundMixed.xml
+lysuite/ly11f_TimeSignatures_SymbolMeaning.xml
+lysuite/ly11h_TimeSignatures_SenzaMisura.xml

--- a/src/private/mxtest/api/roundtrip-baseline.txt
+++ b/src/private/mxtest/api/roundtrip-baseline.txt
@@ -312,5 +312,9 @@ lysuite/ly11h_TimeSignatures_SenzaMisura.xml
 # rpatters1's #268 repro: a single <time> with three composite/additive
 # beats/beat-type pairs (1+2.5 over 2+4, 3+2 over 16, 1.5+5 over 8+16).
 # Added to the repo ahead of the TimeSignatureData redesign as the fixture
-# that motivated it; now round-trips losslessly.
-rpatters1/timesigs_composite-ref.musicxml
+# that motivated it. The original (kept byte-exact, not pinned here) also
+# carries a Finale <score-part>/<group>, unspaced music-font comma list, and
+# <measure-numbering> multiple-rest-* attributes that mx::api doesn't model --
+# unrelated pre-existing gaps. timesigs_composite-ref-modified.musicxml trims
+# just those so the composite time-signature round-trip itself is pinned.
+rpatters1/timesigs_composite-ref-modified.musicxml

--- a/src/private/mxtest/api/roundtrip-baseline.txt
+++ b/src/private/mxtest/api/roundtrip-baseline.txt
@@ -308,3 +308,9 @@ lysuite/ly11d_TimeSignatures_CompoundMultiple.xml
 lysuite/ly11e_TimeSignatures_CompoundMixed.xml
 lysuite/ly11f_TimeSignatures_SymbolMeaning.xml
 lysuite/ly11h_TimeSignatures_SenzaMisura.xml
+
+# rpatters1's #268 repro: a single <time> with three composite/additive
+# beats/beat-type pairs (1+2.5 over 2+4, 3+2 over 16, 1.5+5 over 8+16).
+# Added to the repo ahead of the TimeSignatureData redesign as the fixture
+# that motivated it; now round-trips losslessly.
+rpatters1/timesigs_composite-ref.musicxml

--- a/src/private/mxtest/corert/CoreRoundtripTest.cpp
+++ b/src/private/mxtest/corert/CoreRoundtripTest.cpp
@@ -127,12 +127,12 @@ const CoreRoundtripRegistrar g_coreRoundtripRegistrar;
 
 } // namespace
 
-// Pinned counts: 833 eligible files, none skipped. Count drift is a failure
+// Pinned counts: 834 eligible files, none skipped. Count drift is a failure
 // even with zero individual fails, so a corpus or version-gate change is a
 // conscious decision, not silent decay. Registered last (registration is
 // discovery order; "zz" keeps it last alphabetically for shuffled runs too).
 TEST_CASE("zz-corert-pinned-counts", "[core-roundtrip]")
 {
-    CHECK(mxtest::corert::discoverInputFiles().size() == 833);
+    CHECK(mxtest::corert::discoverInputFiles().size() == 834);
     CHECK(g_skippedCount == 0);
 }


### PR DESCRIPTION
## Human Summary

When @rpatters1 opened #268, my immediate thought was, oh no, we have to support all of the time signature model. My reasoning is that just adding the one case that is needed now will only last so long before a different semantic situation is encountered.

I wanted to preserve some sort of "simple" path, so I created a "choice" class where `TimeSignatureData` used to be. It can be either `simple` or `complex` where simple basically means `numerator/denominator` with or without the `C` or `Cut` symbol.

Anything *beyond* that is shuttled into `ComplexTimeSignature` where, I believe, we have modeled all of what MusicXML supports.

## !!Breaking!!

We use "breaking" somewhat loosely around here, since just about any `mx::api` change introduces some amount of change to the client code, but this one is bigger than the usual breakage. It requires edits anywhere time signatures are involved in client code. As such, I spent some extra time on it and I hope I have a stable design here.

## Summary

Redesigns the time-signature model in `mx::api` to cover the full MusicXML `<time>` element instead of a single beats/beat-type pair with a narrow symbol set.

- `TimeSignatureData` is now built around a shared `TimeFraction` leaf (`beats`/`beatType`); its `TimeSignatureSymbol` is narrowed to `unspecified`/`common`/`cut`.
- New `ComplexTimeSignature` (`ComplexTimeSignature.h`) quarantines everything unusual: composite/additive multi-fraction meters, the full symbol vocabulary (`singleNumber`, `note`, `dottedNote`), separators, interchangeable (dual) meters, and senza-misura.
- New `TimeChoice` (`TimeChoice.h`) is a `{simple, complex}` switch carrying the whole-`<time>` attributes (`isImplicit`, `display`). Building a `TimeChoice` from a `ComplexTimeSignature` that turns out to be simple-equivalent auto-collapses it back to `simple`, so there's always one canonical representation.
- `MeasureData::timeSignature` is now a `TimeChoice`; a new `MeasureData::staffTimeSignatures` (`std::map<int, TimeChoice>`) holds per-staff `<time number="N">` overrides.
- impl: `TimeReader` now translates every `<time>` in a measure (not just the first) into a `TimeChoice` + staff index; `PropertiesWriter::writeTime` regenerates all shapes and writes per-staff `number=`; `MeasureReader`/`MeasureWriter`/`Cursor` carry per-staff overrides forward measure-to-measure; `Converter` gains symbol/separator/relation enum tables.
- Four previously-failing corpus files now round-trip and are pinned in `roundtrip-baseline.txt` (`ly11d`/`ly11e` composite meters, `ly11f` symbols, `ly11h` senza-misura).

This is a breaking change to `mx::api`: `beats`/`beatType` move into `fraction`, `isImplicit`/`display` move from `TimeSignatureData` onto `TimeChoice`, and `TimeSignatureSymbol::singleNumber` moves to the complex-only `ComplexTimeSymbol`.

## Testing

- [x] `TimeSignatureApiTest.cpp`: new cases for default/auto-collapse/stays-complex/equality behavior, plus round-trip coverage for composite meters, senza-misura (with and without glyph), interchangeable pairs, widened symbol+separator, and per-staff overrides with carry-forward
- [x] `roundtrip-baseline.txt`: `ly11d`, `ly11e`, `ly11f`, `ly11h` unpinned (now pass the api round-trip)
- [x] Existing api/impl fixtures updated to the new `TimeChoice` construction (`ApiK007a/c`, `ApiK009bSlur`, `ApiK014aFermatas`, `ApiK015aLayout`, `ApiLy43e`, `ApiMuAccidentals1`, `ChordApiTest`)
- [ ] `timesigs_composite-ref.musicxml` which was submitted by @rpatters1 to cover his use case

## References

- Closes #268
