### PR TITLE
fix: wire up measure-numbering read/write in mx::api

### DIFF
--- a/src/private/mx/impl/MeasureReader.cpp
+++ b/src/private/mx/impl/MeasureReader.cpp
@@ -815,10 +815,13 @@ void MeasureReader::parsePrint(const core::Print &inMxPrint) const
     // Per-measure <print> layout is read at the score level, keyed by
     // measure index, in ScoreReader::scanForSystemInfo and
     // ScoreReader::scanForPageInfo (which capture new-system, new-page,
-    // page-number, system-layout, staff-layout, and page-layout). The
-    // per-measure music-data hook has no api home of its own, so nothing
-    // is captured here.
-    MX_UNUSED(inMxPrint);
+    // page-number, system-layout, staff-layout, and page-layout).
+    // measure-numbering is measure-scoped api state (MeasureData::measureNumbering,
+    // not carried forward like time/key), so it is captured directly here instead.
+    if (inMxPrint.measureNumbering().has_value())
+    {
+        myOutMeasureData.measureNumbering = myConverter.convertMeasureNumbering(inMxPrint.measureNumbering()->value());
+    }
 }
 
 void MeasureReader::parseSound(const core::Sound &inMxSound) const

--- a/src/private/mx/impl/MeasureWriter.cpp
+++ b/src/private/mx/impl/MeasureWriter.cpp
@@ -15,6 +15,7 @@
 #include "mx/core/generated/LayoutGroup.h"
 #include "mx/core/generated/LeftRightMarginsGroup.h"
 #include "mx/core/generated/MarginType.h"
+#include "mx/core/generated/MeasureNumbering.h"
 #include "mx/core/generated/MusicDataChoice.h"
 #include "mx/core/generated/PageLayout.h"
 #include "mx/core/generated/PageLayoutGroup.h"
@@ -106,6 +107,11 @@ void MeasureWriter::writeMeasureGlobals()
     if (pageData)
     {
         writePageInfo(*pageData);
+    }
+
+    if (myMeasureData.measureNumbering != api::MeasureNumbering::unspecified)
+    {
+        writeMeasureNumbering();
     }
 
     if (myHistory.getCursor().isFirstMeasureInPart)
@@ -365,6 +371,51 @@ void MeasureWriter::writePageInfo(const api::PageData &inPageData)
             {
                 newData.push_back(mdc);
             }
+            ++i;
+        }
+        myOutMeasure.setMusicData(std::move(newData));
+    }
+    else
+    {
+        myOutMeasure.addMusicData(core::MusicDataChoice::print(outPrint));
+    }
+}
+
+void MeasureWriter::writeMeasureNumbering()
+{
+    // Same find-or-create <print> merge pattern as writePageInfo(): measure-numbering shares
+    // the <print> element with any system/page layout already written for this measure.
+    const auto existingData = myOutMeasure.musicData();
+    int printIndex = -1;
+    int idx = 0;
+    for (const auto &mdc : existingData)
+    {
+        if (mdc.isPrint())
+        {
+            printIndex = idx;
+            break;
+        }
+        ++idx;
+    }
+
+    core::Print outPrint{};
+    if (printIndex >= 0)
+    {
+        outPrint = existingData[printIndex].asPrint();
+    }
+
+    core::MeasureNumbering outMeasureNumbering{};
+    outMeasureNumbering.setValue(myConverter.convertMeasureNumbering(myMeasureData.measureNumbering));
+    outPrint.setMeasureNumbering(std::move(outMeasureNumbering));
+
+    if (printIndex >= 0)
+    {
+        std::vector<core::MusicDataChoice> newData;
+        newData.reserve(existingData.size());
+        int i = 0;
+        for (const auto &mdc : existingData)
+        {
+            newData.push_back(i == printIndex ? core::MusicDataChoice::print(outPrint) : mdc);
             ++i;
         }
         myOutMeasure.setMusicData(std::move(newData));

--- a/src/private/mx/impl/MeasureWriter.h
+++ b/src/private/mx/impl/MeasureWriter.h
@@ -207,6 +207,7 @@ class MeasureWriter
     void writeMeasureGlobals();
     void writeSystemInfo();
     void writePageInfo(const api::PageData &inNewPageData);
+    void writeMeasureNumbering();
     void writeStaves();
     void writeVoices(const api::StaffData &inStaff);
     void writeForwardOrBackupIfNeeded(const api::NoteData &currentNote);

--- a/src/private/mxtest/api/MeasureDataTest.cpp
+++ b/src/private/mxtest/api/MeasureDataTest.cpp
@@ -262,4 +262,45 @@ TEST(staffLinesAndStaffSizeRoundTrip, MeasureData)
 
 T_END;
 
+TEST(measureNumberingRoundTrip, MeasureData)
+{
+    ScoreData score;
+    score.parts.emplace_back();
+    auto &part = score.parts.back();
+    part.measures.emplace_back();
+    auto &measure = part.measures.back();
+    measure.measureNumbering = MeasureNumbering::system;
+    measure.staves.emplace_back();
+    measure.staves.back().voices[0].notes.emplace_back();
+
+    const auto xml = mxtest::toXml(score);
+    CHECK(xml.find("<measure-numbering>system</measure-numbering>") != std::string::npos);
+
+    const auto outScore = mxtest::fromXml(xml);
+    CHECK_EQUAL(1, outScore.parts.size());
+    CHECK_EQUAL(1, outScore.parts.front().measures.size());
+    CHECK(MeasureNumbering::system == outScore.parts.front().measures.front().measureNumbering);
+}
+
+T_END;
+
+TEST(measureNumberingUnspecifiedOmitsElement, MeasureData)
+{
+    ScoreData score;
+    score.parts.emplace_back();
+    auto &part = score.parts.back();
+    part.measures.emplace_back();
+    auto &measure = part.measures.back();
+    measure.staves.emplace_back();
+    measure.staves.back().voices[0].notes.emplace_back();
+
+    const auto xml = mxtest::toXml(score);
+    CHECK(xml.find("<measure-numbering>") == std::string::npos);
+
+    const auto outScore = mxtest::fromXml(xml);
+    CHECK(MeasureNumbering::unspecified == outScore.parts.front().measures.front().measureNumbering);
+}
+
+T_END;
+
 #endif

--- a/src/private/mxtest/api/roundtrip-baseline.txt
+++ b/src/private/mxtest/api/roundtrip-baseline.txt
@@ -293,3 +293,8 @@ lysuite/ly01a_Pitches_Pitches.xml
 lysuite/ly01e_Pitches_ParenthesizedAccidentals.xml
 lysuite/ly01f_Pitches_ParenthesizedMicrotoneAccidentals.xml
 musuite/testAccidentals2.xml
+
+# Unblocked by wiring MeasureData::measureNumbering through MeasureReader/
+# MeasureWriter: the field and its Converter existed but neither side ever
+# called it, so <measure-numbering> was silently dropped on round-trip.
+ksuite/k015a_System_Layout.xml


### PR DESCRIPTION
## Human Summary

This seems to be wiring up something that was already in the API but missing from the reader and writer. It appears to put the repo in a better state! Gonna merge.

## Summary

`MeasureData::measureNumbering` and `Converter::convertMeasureNumbering` already existed (a
bidirectional core/api enum mapping), but neither `MeasureReader` nor `MeasureWriter` ever called
the converter. A source's `<measure-numbering>` (nested inside a measure's `<print>`) was silently
dropped on round-trip, even though `data/api.features.xml` audits the element as fully supported.

- `MeasureReader::parsePrint` now reads `<print>/<measure-numbering>`'s value directly into
  `MeasureData::measureNumbering`. This is measure-scoped, presence-based state (default
  `unspecified`), not carried forward across measures like time/key.
- `MeasureWriter` gains `writeMeasureNumbering()`, which finds-or-creates the measure's `<print>`
  element the same way `writePageInfo()` already does, so `<measure-numbering>` shares a single
  `<print>` with any system/page layout already written for that measure instead of emitting a
  second one.

## Testing

- [x] New `measureNumberingRoundTrip` / `measureNumberingUnspecifiedOmitsElement` tests
  (`MeasureDataTest.cpp`)
- [x] `make test`: all pass (4734 assertions in 382 test cases, plus the three examples)
- [x] `make test-api-roundtrip`: 158 passed, 0 failed (of 158 pinned; 1 newly unlocked)
- [x] `make fmt` / `make check`: clean

## References

- Closes #279
- Progresses #208, #213
