### PR TITLE
docs: explain the direction/voice/staff round-trip drop cluster

### DIFF
--- a/src/private/mx/impl/DirectionReader.cpp
+++ b/src/private/mx/impl/DirectionReader.cpp
@@ -682,6 +682,9 @@ void DirectionReader::parsePedal(const core::DirectionType &directionType)
 {
     const auto &pedal = directionType.choice().asPedal();
 
+    // sostenuto/change/continue/discontinue/resume are unmodeled (#324) -- pedalStarts/
+    // pedalStops only model the damper start/stop pair. A <pedal type="change"/> (etc.) is
+    // dropped here rather than misrepresented as a plain start or stop.
     if (pedal.type().tag() != core::PedalType::Tag::start && pedal.type().tag() != core::PedalType::Tag::stop)
     {
         return;
@@ -813,6 +816,15 @@ void DirectionReader::parseOctaveShift(const core::DirectionType &directionType)
                            static_cast<int>(myOutDirectionData.ottavaStarts.size()) - 1);
 }
 
+// The eleven stubs below (harp-pedals, damp, damp-all, eyeglasses, string-mute, scordatura,
+// image, principal-voice, accordion-registration, percussion, other-direction) are genuinely
+// unmodeled direction-type choices, tracked at #324, not a bug in the surrounding dispatch.
+// When a <direction> contains only one of these, the resulting DirectionData carries no
+// content and is correctly left unwritten -- MusicXML requires at least one direction-type
+// child, so there is no schema-valid way to keep the <direction> (and its <voice>/<staff>)
+// without modeling what it actually says. That is why round-trip discovery reports those
+// files as dropping <direction>/<direction-type>/<voice>/<staff> together: it is one gap
+// (the unmodeled content), not four.
 void DirectionReader::parseHarpPedals(const core::DirectionType &directionType)
 {
     MX_UNUSED(directionType);

--- a/src/private/mx/impl/MeasureReader.cpp
+++ b/src/private/mx/impl/MeasureReader.cpp
@@ -545,6 +545,11 @@ void MeasureReader::parseBackup(const core::Backup &inMxBackup) const
 
 void MeasureReader::parseForward(const core::Forward &inMxForward) const
 {
+    // <forward>/<backup> are pure wire cursor mechanics with no api home (design principle:
+    // store absolute tick positions, not running state), so their own optional <voice>/<staff>
+    // children are deliberately not read here either. The writer regenerates whatever
+    // <forward>/<backup> the tick math requires; it never has one to carry a voice/staff value
+    // forward from, so a source's <forward>/<backup> voice/staff is expected to not round-trip.
     // a chord cannot straddle a timeline jump
     myPreviousNoteBucketStaffIndex = -1;
     const int forwardAmount = myCurrentCursor.convertDurationToGlobalTickScale(inMxForward.duration());


### PR DESCRIPTION
## Human Summary

Hmmm, ok, well this adds a couple of stateful comments around directions that are currently unsupported. Seems harmless and perhaps it will help the LLM understand what's going on in the future. Seems like a bit of a cop out from the agent instead of supporting the missing features, but oh well. It opened an issue that likely words what is needed in a way it can understand more clearly.

## Summary

#278 and #280 asked whether the round-trip classifier's `drop:voice` / `drop:staff` /
`drop:direction` / `drop:direction-type` signatures (co-occurring on ~60 corpus files) are a genuine
impl bug or an audit-correction. Investigated with `make dump-api-roundtrip` +
`make classify-api-roundtrip` and by diffing individual dumped files; this is neither -- it's one
already-understood, already-correctly-audited gap wearing four signatures:

- `DirectionReader` dispatches every `direction-type` choice, but eleven of them (`harp-pedals`,
  `damp`, `damp-all`, `eyeglasses`, `string-mute`, `scordatura`, `image`, `principal-voice`,
  `accordion-registration`, `percussion`, `other-direction`) are no-op stubs. A `<direction>`
  containing only one of these produces an empty `DirectionData`, which is correctly left
  unwritten -- MusicXML requires at least one `direction-type` child, so there is no schema-valid
  way to keep the `<direction>` (and its `<voice>`/`<staff>`) without modeling what it actually
  says. `data/api.features.xml` already correctly audits each of these subtypes as
  `support="none"` (only the parent `direction`/`direction-type` container, which does work, is
  `full`) -- so there's no audit to correct either.
- The remaining `<voice>`/`<staff>` drops are `<forward>`/`<backup>`'s own optional children, which
  mx::api does not read: forward/backup are pure wire cursor mechanics with no api representation
  (the writer regenerates whatever the tick math requires), so there's nothing to carry a source's
  forward/backup voice/staff value from.
- Also found the same shape of gap in `DirectionReader::parsePedal`: `sostenuto`/`change`/
  `continue`/`discontinue`/`resume` are unmodeled, only `start`/`stop` (`lysuite/ly33a_Spanners.xml`).

No code behavior changes -- this adds comments at each stub/gap pointing at the finding (and #324,
opened to track actually implementing this worklist) so it doesn't get re-investigated from
scratch.

## Testing

- [x] `make test`: all pass (4724 assertions in 378 test cases, plus the three examples) --
  comments only, no behavior change
- [x] `make fmt` / `make check`: clean

## References

- Closes #278
- Closes #280
- Related: #324 (tracks implementing the unmodeled direction-type subtypes and pedal states)
