### PR TITLE
fix: preserve staff-scoped `staff-layout number="N"`

### DIFF
--- a/src/include/mx/api/SystemLayoutData.h
+++ b/src/include/mx/api/SystemLayoutData.h
@@ -9,6 +9,7 @@
 #include "mx/api/LeftRight.h"
 #include "mx/api/PageLayoutData.h"
 
+#include <map>
 #include <string>
 #include <vector>
 
@@ -16,31 +17,6 @@ namespace mx
 {
 namespace api
 {
-/// The vertical space above one specific staff of a multi-staff part (MusicXML's
-/// <staff-layout number="N">). Use this only when a staff needs its own spacing, e.g. extra room
-/// above an organ's pedal staff; the ordinary single spacing value is
-/// SystemLayoutData::staffDistance.
-class StaffDistanceData
-{
-  public:
-    /// Which staff of the part this spacing applies to, zero-based from the top staff.
-    int staffIndex;
-
-    /// The space between the bottom line of the previous staff and the top line of this staff, in tenths.
-    double staffDistance;
-
-    explicit inline StaffDistanceData(int inStaffIndex = INDEX_UNSPECIFIED, double inStaffDistance = DOUBLE_UNSPECIFIED)
-        : staffIndex(inStaffIndex), staffDistance(inStaffDistance)
-    {
-    }
-};
-
-MXAPI_EQUALS_BEGIN(StaffDistanceData)
-MXAPI_EQUALS_MEMBER(staffIndex)
-MXAPI_DOUBLES_EQUALS_MEMBER(staffDistance)
-MXAPI_EQUALS_END;
-MXAPI_NOT_EQUALS_AND_VECTORS(StaffDistanceData);
-
 /// Margins and spacing for staff systems.
 class SystemLayoutData
 {
@@ -58,10 +34,12 @@ class SystemLayoutData
     /// that does not have its own entry in staffDistances.
     OptionalDouble staffDistance;
 
-    /// Per-staff spacing for multi-staff parts. Normally empty; only add an entry when one staff
-    /// needs spacing different from staffDistance. For a given staff, an entry here wins; otherwise
+    /// Per-staff spacing for multi-staff parts, keyed by zero-based staff index: the space between
+    /// the bottom line of the previous staff and the top line of the keyed staff, in tenths.
+    /// Normally empty; only add an entry when one staff needs its own spacing, e.g. extra room
+    /// above an organ's pedal staff. For a given staff, an entry here wins; otherwise
     /// staffDistance applies.
-    std::vector<StaffDistanceData> staffDistances;
+    std::map<int, double> staffDistances;
 
     /// Returns true if any of the members have values.
     inline bool isUsed() const

--- a/src/include/mx/api/SystemLayoutData.h
+++ b/src/include/mx/api/SystemLayoutData.h
@@ -16,6 +16,29 @@ namespace mx
 {
 namespace api
 {
+/// A <staff-layout> scoped to one staff of a multi-staff part (MusicXML's number attribute):
+/// the space between the bottom line of the previous staff and the top line of this one.
+/// staffIndex is zero-based; a source with an explicit number attribute always populates
+/// SystemLayoutData::staffDistances with one of these rather than the unscoped
+/// SystemLayoutData::staffDistance, so the number round-trips faithfully.
+class StaffDistanceData
+{
+  public:
+    int staffIndex;
+    double staffDistance;
+
+    explicit inline StaffDistanceData(int inStaffIndex = INDEX_UNSPECIFIED, double inStaffDistance = DOUBLE_UNSPECIFIED)
+        : staffIndex(inStaffIndex), staffDistance(inStaffDistance)
+    {
+    }
+};
+
+MXAPI_EQUALS_BEGIN(StaffDistanceData)
+MXAPI_EQUALS_MEMBER(staffIndex)
+MXAPI_DOUBLES_EQUALS_MEMBER(staffDistance)
+MXAPI_EQUALS_END;
+MXAPI_NOT_EQUALS_AND_VECTORS(StaffDistanceData);
+
 /// Margins and spacing for staff systems.
 class SystemLayoutData
 {
@@ -29,13 +52,19 @@ class SystemLayoutData
     /// Distance from the top margin of the page to the top line of the first staff on the page, in tenths.
     OptionalDouble topSystemDistance;
 
-    /// the space between staves within the same system, in tenths.
+    /// the space between staves within the same system, in tenths. Only populated when the source's
+    /// <staff-layout> had no number attribute (the common single-staff-distance case); a source with
+    /// an explicit number populates staffDistances instead. See StaffDistanceData.
     OptionalDouble staffDistance;
+
+    /// Per-staff overrides of staffDistance for parts with more than one staff-scoped <staff-layout>
+    /// (e.g. an organ's third staff needing its own spacing). Normally empty.
+    std::vector<StaffDistanceData> staffDistances;
 
     /// Returns true if any of the members have values.
     inline bool isUsed() const
     {
-        return margins || systemDistance || topSystemDistance || staffDistance;
+        return margins || systemDistance || topSystemDistance || staffDistance || !staffDistances.empty();
     }
 
     explicit inline SystemLayoutData(std::optional<LeftRight> inMargins = std::nullopt,
@@ -43,7 +72,7 @@ class SystemLayoutData
                                      OptionalDouble inTopSystemDistance = std::nullopt,
                                      OptionalDouble inStaffDistance = std::nullopt)
         : margins(inMargins), systemDistance(inSystemDistance), topSystemDistance{inTopSystemDistance},
-          staffDistance(inStaffDistance)
+          staffDistance(inStaffDistance), staffDistances{}
     {
     }
 };
@@ -53,6 +82,7 @@ MXAPI_EQUALS_MEMBER(margins)
 MXAPI_EQUALS_MEMBER(systemDistance)
 MXAPI_EQUALS_MEMBER(topSystemDistance)
 MXAPI_EQUALS_MEMBER(staffDistance)
+MXAPI_EQUALS_MEMBER(staffDistances)
 MXAPI_EQUALS_END;
 MXAPI_NOT_EQUALS_AND_VECTORS(SystemLayoutData);
 } // namespace api

--- a/src/include/mx/api/SystemLayoutData.h
+++ b/src/include/mx/api/SystemLayoutData.h
@@ -16,15 +16,17 @@ namespace mx
 {
 namespace api
 {
-/// A <staff-layout> scoped to one staff of a multi-staff part (MusicXML's number attribute):
-/// the space between the bottom line of the previous staff and the top line of this one.
-/// staffIndex is zero-based; a source with an explicit number attribute always populates
-/// SystemLayoutData::staffDistances with one of these rather than the unscoped
-/// SystemLayoutData::staffDistance, so the number round-trips faithfully.
+/// The vertical space above one specific staff of a multi-staff part (MusicXML's
+/// <staff-layout number="N">). Use this only when a staff needs its own spacing, e.g. extra room
+/// above an organ's pedal staff; the ordinary single spacing value is
+/// SystemLayoutData::staffDistance.
 class StaffDistanceData
 {
   public:
+    /// Which staff of the part this spacing applies to, zero-based from the top staff.
     int staffIndex;
+
+    /// The space between the bottom line of the previous staff and the top line of this staff, in tenths.
     double staffDistance;
 
     explicit inline StaffDistanceData(int inStaffIndex = INDEX_UNSPECIFIED, double inStaffDistance = DOUBLE_UNSPECIFIED)
@@ -52,13 +54,13 @@ class SystemLayoutData
     /// Distance from the top margin of the page to the top line of the first staff on the page, in tenths.
     OptionalDouble topSystemDistance;
 
-    /// the space between staves within the same system, in tenths. Only populated when the source's
-    /// <staff-layout> had no number attribute (the common single-staff-distance case); a source with
-    /// an explicit number populates staffDistances instead. See StaffDistanceData.
+    /// The space between staves within the same system, in tenths. Applies to every staff of a part
+    /// that does not have its own entry in staffDistances.
     OptionalDouble staffDistance;
 
-    /// Per-staff overrides of staffDistance for parts with more than one staff-scoped <staff-layout>
-    /// (e.g. an organ's third staff needing its own spacing). Normally empty.
+    /// Per-staff spacing for multi-staff parts. Normally empty; only add an entry when one staff
+    /// needs spacing different from staffDistance. For a given staff, an entry here wins; otherwise
+    /// staffDistance applies.
     std::vector<StaffDistanceData> staffDistances;
 
     /// Returns true if any of the members have values.

--- a/src/private/mx/impl/LayoutFunctions.cpp
+++ b/src/private/mx/impl/LayoutFunctions.cpp
@@ -236,11 +236,11 @@ void addSystemMargins(const api::DefaultsData &inDefaults, core::ScoreHeaderGrou
         needsDefaults = true;
     }
 
-    for (const auto &staffDistance : inDefaults.systemLayout.staffDistances)
+    for (const auto &[staffIndex, staffDistance] : inDefaults.systemLayout.staffDistances)
     {
         core::StaffLayout staffLayout;
-        staffLayout.setNumber(core::StaffNumber{staffDistance.staffIndex + 1});
-        staffLayout.setStaffDistance(toTenths(staffDistance.staffDistance));
+        staffLayout.setNumber(core::StaffNumber{staffIndex + 1});
+        staffLayout.setStaffDistance(toTenths(staffDistance));
         layout.addStaffLayout(staffLayout);
         needsDefaults = true;
     }
@@ -436,8 +436,8 @@ void addStaffLayout(const core::ScoreHeaderGroup &inScoreHeaderGroup, api::Defau
         return;
     }
 
-    // A source with an explicit number attribute is staff-scoped (api::StaffDistanceData); one
-    // with no number applies to staff 1 by schema default and is captured as the plain
+    // A source with an explicit number attribute is staff-scoped (a staffDistances map entry);
+    // one with no number applies to staff 1 by schema default and is captured as the plain
     // unscoped value. Mirrors ScoreReader::scanForSystemInfo's per-measure handling.
     for (const auto &staffLayout : inScoreHeaderGroup.defaults()->layout().staffLayout())
     {
@@ -448,7 +448,7 @@ void addStaffLayout(const core::ScoreHeaderGroup &inScoreHeaderGroup, api::Defau
         const double distance = staffLayout.staffDistance()->value().value();
         if (staffLayout.number().has_value())
         {
-            outDefaults.systemLayout.staffDistances.emplace_back(staffLayout.number()->value() - 1, distance);
+            outDefaults.systemLayout.staffDistances[staffLayout.number()->value() - 1] = distance;
         }
         else
         {

--- a/src/private/mx/impl/LayoutFunctions.cpp
+++ b/src/private/mx/impl/LayoutFunctions.cpp
@@ -236,6 +236,15 @@ void addSystemMargins(const api::DefaultsData &inDefaults, core::ScoreHeaderGrou
         needsDefaults = true;
     }
 
+    for (const auto &staffDistance : inDefaults.systemLayout.staffDistances)
+    {
+        core::StaffLayout staffLayout;
+        staffLayout.setNumber(core::StaffNumber{staffDistance.staffIndex + 1});
+        staffLayout.setStaffDistance(toTenths(staffDistance.staffDistance));
+        layout.addStaffLayout(staffLayout);
+        needsDefaults = true;
+    }
+
     if (needsDefaults)
     {
         layout.setSystemLayout(systemLayout);
@@ -427,15 +436,24 @@ void addStaffLayout(const core::ScoreHeaderGroup &inScoreHeaderGroup, api::Defau
         return;
     }
 
-    const auto &staffLayouts = inScoreHeaderGroup.defaults()->layout().staffLayout();
-    if (staffLayouts.empty())
+    // A source with an explicit number attribute is staff-scoped (api::StaffDistanceData); one
+    // with no number applies to staff 1 by schema default and is captured as the plain
+    // unscoped value. Mirrors ScoreReader::scanForSystemInfo's per-measure handling.
+    for (const auto &staffLayout : inScoreHeaderGroup.defaults()->layout().staffLayout())
     {
-        return;
-    }
-
-    if (staffLayouts.front().staffDistance().has_value())
-    {
-        outDefaults.systemLayout.staffDistance = staffLayouts.front().staffDistance()->value().value();
+        if (!staffLayout.staffDistance().has_value())
+        {
+            continue;
+        }
+        const double distance = staffLayout.staffDistance()->value().value();
+        if (staffLayout.number().has_value())
+        {
+            outDefaults.systemLayout.staffDistances.emplace_back(staffLayout.number()->value() - 1, distance);
+        }
+        else
+        {
+            outDefaults.systemLayout.staffDistance = distance;
+        }
     }
 }
 

--- a/src/private/mx/impl/MeasureWriter.cpp
+++ b/src/private/mx/impl/MeasureWriter.cpp
@@ -265,11 +265,11 @@ void MeasureWriter::writeSystemInfo()
             outPrint.setLayout(outLayoutGroup);
         }
 
-        for (const auto &staffDistance : inSystemLayout.staffDistances)
+        for (const auto &[staffIndex, staffDistance] : inSystemLayout.staffDistances)
         {
             core::StaffLayout outStaffLayout{};
-            outStaffLayout.setNumber(core::StaffNumber{staffDistance.staffIndex + 1});
-            outStaffLayout.setStaffDistance(core::Tenths{core::Decimal{staffDistance.staffDistance}});
+            outStaffLayout.setNumber(core::StaffNumber{staffIndex + 1});
+            outStaffLayout.setStaffDistance(core::Tenths{core::Decimal{staffDistance}});
             outLayoutGroup.addStaffLayout(outStaffLayout);
             outPrint.setLayout(outLayoutGroup);
         }

--- a/src/private/mx/impl/MeasureWriter.cpp
+++ b/src/private/mx/impl/MeasureWriter.cpp
@@ -26,6 +26,7 @@
 #include "mx/core/generated/Repeat.h"
 #include "mx/core/generated/RightLeftMiddle.h"
 #include "mx/core/generated/StaffLayout.h"
+#include "mx/core/generated/StaffNumber.h"
 #include "mx/core/generated/SystemLayout.h"
 #include "mx/core/generated/SystemMargins.h"
 #include "mx/core/generated/Tenths.h"
@@ -260,6 +261,15 @@ void MeasureWriter::writeSystemInfo()
             core::StaffLayout outStaffLayout{};
             outStaffLayout.setStaffDistance(
                 core::Tenths{core::Decimal{static_cast<double>(inSystemLayout.staffDistance.value())}});
+            outLayoutGroup.addStaffLayout(outStaffLayout);
+            outPrint.setLayout(outLayoutGroup);
+        }
+
+        for (const auto &staffDistance : inSystemLayout.staffDistances)
+        {
+            core::StaffLayout outStaffLayout{};
+            outStaffLayout.setNumber(core::StaffNumber{staffDistance.staffIndex + 1});
+            outStaffLayout.setStaffDistance(core::Tenths{core::Decimal{staffDistance.staffDistance}});
             outLayoutGroup.addStaffLayout(outStaffLayout);
             outPrint.setLayout(outLayoutGroup);
         }

--- a/src/private/mx/impl/ScoreReader.cpp
+++ b/src/private/mx/impl/ScoreReader.cpp
@@ -466,15 +466,23 @@ void ScoreReader::scanForSystemInfo() const
                 }
             }
 
-            // Per-measure <staff-layout> staff-distance. (We model a single
-            // staff-distance, matching how the defaults staff-layout is
-            // mapped; the first staff-layout's distance is used.)
+            // Per-measure <staff-layout> staff-distance. A source with an explicit number
+            // attribute is staff-scoped (api::StaffDistanceData); one with no number applies
+            // to staff 1 by schema default and is captured as the plain unscoped value.
             for (const auto &staffLayout : layoutGroup.staffLayout())
             {
-                if (staffLayout.staffDistance().has_value())
+                if (!staffLayout.staffDistance().has_value())
                 {
-                    systemData.layout.staffDistance = staffLayout.staffDistance()->value().value();
-                    break;
+                    continue;
+                }
+                const double distance = staffLayout.staffDistance()->value().value();
+                if (staffLayout.number().has_value())
+                {
+                    systemData.layout.staffDistances.emplace_back(staffLayout.number()->value() - 1, distance);
+                }
+                else
+                {
+                    systemData.layout.staffDistance = distance;
                 }
             }
 

--- a/src/private/mx/impl/ScoreReader.cpp
+++ b/src/private/mx/impl/ScoreReader.cpp
@@ -467,7 +467,7 @@ void ScoreReader::scanForSystemInfo() const
             }
 
             // Per-measure <staff-layout> staff-distance. A source with an explicit number
-            // attribute is staff-scoped (api::StaffDistanceData); one with no number applies
+            // attribute is staff-scoped (a staffDistances map entry); one with no number applies
             // to staff 1 by schema default and is captured as the plain unscoped value.
             for (const auto &staffLayout : layoutGroup.staffLayout())
             {
@@ -478,7 +478,7 @@ void ScoreReader::scanForSystemInfo() const
                 const double distance = staffLayout.staffDistance()->value().value();
                 if (staffLayout.number().has_value())
                 {
-                    systemData.layout.staffDistances.emplace_back(staffLayout.number()->value() - 1, distance);
+                    systemData.layout.staffDistances[staffLayout.number()->value() - 1] = distance;
                 }
                 else
                 {

--- a/src/private/mxtest/api/PrintLayoutRoundTripTest.cpp
+++ b/src/private/mxtest/api/PrintLayoutRoundTripTest.cpp
@@ -84,7 +84,7 @@ TEST(printLayoutRoundTrip, staffScopedStaffDistance)
     in.parts.front().measures.front().staves.push_back(staff1);
 
     SystemData sys{};
-    sys.layout.staffDistances.emplace_back(1, 65.0);
+    sys.layout.staffDistances[1] = 65.0;
     in.layout.emplace(0, LayoutData{sys, PageData{}});
 
     const auto out = mxtest::roundTrip(in);
@@ -93,9 +93,10 @@ TEST(printLayoutRoundTrip, staffScopedStaffDistance)
     REQUIRE(it != out.layout.end());
     const auto &sysOut = it->second.system;
     CHECK(!static_cast<bool>(sysOut.layout.staffDistance));
-    REQUIRE(1 == sysOut.layout.staffDistances.size());
-    CHECK_EQUAL(1, sysOut.layout.staffDistances.front().staffIndex);
-    CHECK_EQUAL(65.0, sysOut.layout.staffDistances.front().staffDistance);
+    CHECK_EQUAL(1, static_cast<int>(sysOut.layout.staffDistances.size()));
+    const auto sdIt = sysOut.layout.staffDistances.find(1);
+    REQUIRE(sdIt != sysOut.layout.staffDistances.end());
+    CHECK_EQUAL(65.0, sdIt->second);
 }
 
 #endif

--- a/src/private/mxtest/api/PrintLayoutRoundTripTest.cpp
+++ b/src/private/mxtest/api/PrintLayoutRoundTripTest.cpp
@@ -71,4 +71,31 @@ TEST(printLayoutRoundTrip, perMeasureStaffDistance)
     CHECK_EQUAL(120.0, sysOut.layout.systemDistance.value());
 }
 
+// A <staff-layout number="N"> is scoped to one staff of a multi-staff part; the writer
+// only ever emitted an unscoped <staff-layout> (matching SystemLayoutData::staffDistance),
+// and the reader dropped the number attribute on the one it read back, silently
+// misattributing the distance to staff 1. Verify a staff-scoped distance survives via
+// SystemLayoutData::staffDistances.
+TEST(printLayoutRoundTrip, staffScopedStaffDistance)
+{
+    auto in = makeScoreWithMeasures(1);
+    auto &staff0 = in.parts.front().measures.front().staves.front();
+    StaffData staff1 = staff0;
+    in.parts.front().measures.front().staves.push_back(staff1);
+
+    SystemData sys{};
+    sys.layout.staffDistances.emplace_back(1, 65.0);
+    in.layout.emplace(0, LayoutData{sys, PageData{}});
+
+    const auto out = mxtest::roundTrip(in);
+
+    const auto it = out.layout.find(0);
+    REQUIRE(it != out.layout.end());
+    const auto &sysOut = it->second.system;
+    CHECK(!static_cast<bool>(sysOut.layout.staffDistance));
+    REQUIRE(1 == sysOut.layout.staffDistances.size());
+    CHECK_EQUAL(1, sysOut.layout.staffDistances.front().staffIndex);
+    CHECK_EQUAL(65.0, sysOut.layout.staffDistances.front().staffDistance);
+}
+
 #endif


### PR DESCRIPTION
## Human Summary

TODO: human writes here

## Summary

Both the per-measure `<print>` and score-level `<defaults>` readers took only the first
`<staff-layout>`'s distance and dropped its `number` attribute entirely, folding it into the single
unscoped `SystemLayoutData::staffDistance`. For a multi-staff part (e.g. a 2-staff piano/organ)
whose only `staff-layout` is scoped to staff 2, this silently misattributed the distance to staff 1
(the schema default for a missing `number`) instead of just dropping the attribute -- a real,
if quiet, correctness bug, not only a fidelity loss.

Added `SystemLayoutData::staffDistances`, a `std::map<int, double>` keyed by zero-based staff
index, holding spacing for staves that need their own value; the existing singular
`staffDistance` keeps its meaning for the common unscoped case, and for a given staff a map entry
wins. The map shape follows the `MeasureData::staffTimeSignatures` precedent for staff-scoped
`number="N"` overrides -- key by the owning staff rather than stamping a label field on the items
-- which also makes two conflicting distances for the same staff unrepresentable. Both readers
(`ScoreReader::scanForSystemInfo`, `LayoutFunctions::addStaffLayout`) and both writers
(`MeasureWriter::writeSystemInfo`, `LayoutFunctions::addSystemMargins`) handle it symmetrically,
since `<defaults>` and per-measure `<print>` already share `SystemLayoutData`. Header comments are
written for the api user (what the fields mean and when to set them) per the design doctrine,
rather than describing reader/writer behavior.

## Testing

- [x] New `staffScopedStaffDistance` test (`PrintLayoutRoundTripTest.cpp`)
- [x] `make test`: all pass (4808 assertions in 391 test cases, plus the three examples)
- [x] `make test-api-roundtrip`: 164 passed, 0 failed (of 164 pinned; no regressions)
- [x] `make fmt` / `make check`: clean

## References

- Closes #281
- Progresses #208, #213