### PR TITLE
feat: support multi-note tremolos in mx::api

### DIFF
--- a/src/include/mx/api/MarkData.h
+++ b/src/include/mx/api/MarkData.h
@@ -7,6 +7,7 @@
 #include "mx/api/PositionData.h"
 #include "mx/api/PrintData.h"
 
+#include <optional>
 #include <string>
 
 namespace mx
@@ -87,6 +88,8 @@ enum class MarkType
     tremoloSingleThree, ///< A tremolo on a single note (a glyph, not a spanner) with 3 slashes
     tremoloSingleFour,  ///< A tremolo on a single note (a glyph, not a spanner) with 4 slashes
     tremoloSingleFive,  ///< A tremolo on a single note (a glyph, not a spanner) with 5 slashes
+    tremoloStart,       ///< The first note of a measured (two-note) tremolo; slash count is MarkData::tremoloMarks
+    tremoloStop,        ///< The second note of a measured (two-note) tremolo; slash count is MarkData::tremoloMarks
     otherOrnament,      ///< MusicXML's 'other-ornament' value
     unknownOrnament,    ///< Error state
 
@@ -252,6 +255,12 @@ struct MarkData
     Bool fingeringSubstitution;
     Bool fingeringAlternate;
 
+    // The tremolo mark count (MusicXML <tremolo> text value, 0-8 slashes). Only meaningful
+    // when markType is tremoloStart or tremoloStop; absent means "not specified" (the writer
+    // falls back to a default). The tremoloSingle* mark types encode their slash count in the
+    // enumerator itself and leave this absent.
+    std::optional<int> tremoloMarks;
+
     MarkData();
     MarkData(MarkType inMarkType);
     MarkData(Placement inPlacement, MarkType inMarkType);
@@ -271,6 +280,7 @@ MXAPI_EQUALS_MEMBER(mordentDeparture)
 MXAPI_EQUALS_MEMBER(hasMordentDeparture)
 MXAPI_EQUALS_MEMBER(fingeringSubstitution)
 MXAPI_EQUALS_MEMBER(fingeringAlternate)
+MXAPI_EQUALS_MEMBER(tremoloMarks)
 MXAPI_EQUALS_END;
 MXAPI_NOT_EQUALS_AND_VECTORS(MarkData);
 } // namespace api

--- a/src/include/mx/api/MarkData.h
+++ b/src/include/mx/api/MarkData.h
@@ -4,6 +4,7 @@
 
 #pragma once
 
+#include "mx/api/MarkDataChoice.h"
 #include "mx/api/PositionData.h"
 #include "mx/api/PrintData.h"
 
@@ -88,8 +89,8 @@ enum class MarkType
     tremoloSingleThree, ///< A tremolo on a single note (a glyph, not a spanner) with 3 slashes
     tremoloSingleFour,  ///< A tremolo on a single note (a glyph, not a spanner) with 4 slashes
     tremoloSingleFive,  ///< A tremolo on a single note (a glyph, not a spanner) with 5 slashes
-    tremoloStart,       ///< The first note of a measured (two-note) tremolo; slash count is MarkData::tremoloMarks
-    tremoloStop,        ///< The second note of a measured (two-note) tremolo; slash count is MarkData::tremoloMarks
+    tremoloStart,       ///< The first note of a measured (two-note) tremolo; slash count is in MarkData::choice
+    tremoloStop,        ///< The second note of a measured (two-note) tremolo; slash count is in MarkData::choice
     otherOrnament,      ///< MusicXML's 'other-ornament' value
     unknownOrnament,    ///< Error state
 
@@ -238,28 +239,39 @@ int numTremoloSlashes(MarkType);
 
 struct MarkData
 {
+    // Fields common to (nearly) every mark, regardless of markType.
     MarkType markType;
     std::string name;
     int tickTimePosition;
     PrintData printData;
     PositionData positionData;
+
+    // Fields below apply only to specific mark types, kept as direct fields for backward
+    // compatibility (see AGENTS.md "mx::api conventions" / issue #249; these are not migrated to
+    // 'choice'). Do not follow this shape for new mark-specific data -- add a new MarkDataChoice
+    // alternative instead (see 'choice' below).
+
+    // Mordent payload attributes (MusicXML <mordent> 'long', 'approach', 'departure'). Only
+    // meaningful when markType == MarkType::mordent or MarkType::invertedMordent.
     Bool mordentLong;
     bool hasMordentLong;
     Placement mordentApproach;
     bool hasMordentApproach;
     Placement mordentDeparture;
     bool hasMordentDeparture;
+
     // Fingering payload attributes (MusicXML <fingering> 'substitution' and
     // 'alternate'). Only meaningful when markType == MarkType::fingering. The
     // fingering text itself (e.g. "1", "2-3") is carried in 'name'.
     Bool fingeringSubstitution;
     Bool fingeringAlternate;
 
-    // The tremolo mark count (MusicXML <tremolo> text value, 0-8 slashes). Only meaningful
-    // when markType is tremoloStart or tremoloStop; absent means "not specified" (the writer
-    // falls back to a default). The tremoloSingle* mark types encode their slash count in the
-    // enumerator itself and leave this absent.
-    std::optional<int> tremoloMarks;
+    // Payload for mark types whose data does not fit the common fields above. Its Kind SHOULD
+    // correspond to markType (e.g. MarkDataChoice::Kind::tremolo pairs with
+    // MarkType::tremoloStart/tremoloStop), but this is a convention that MarkData does not
+    // enforce. New mark-specific data belongs here, as a new MarkDataChoice alternative -- see
+    // MarkDataChoice.h.
+    MarkDataChoice choice;
 
     MarkData();
     MarkData(MarkType inMarkType);
@@ -280,7 +292,7 @@ MXAPI_EQUALS_MEMBER(mordentDeparture)
 MXAPI_EQUALS_MEMBER(hasMordentDeparture)
 MXAPI_EQUALS_MEMBER(fingeringSubstitution)
 MXAPI_EQUALS_MEMBER(fingeringAlternate)
-MXAPI_EQUALS_MEMBER(tremoloMarks)
+MXAPI_EQUALS_MEMBER(choice)
 MXAPI_EQUALS_END;
 MXAPI_NOT_EQUALS_AND_VECTORS(MarkData);
 } // namespace api

--- a/src/include/mx/api/MarkDataChoice.h
+++ b/src/include/mx/api/MarkDataChoice.h
@@ -1,0 +1,77 @@
+// MusicXML Class Library
+// Copyright (c) by Matthew James Briggs
+// Distributed under the MIT License
+
+#pragma once
+
+#include "mx/api/ApiCommon.h"
+
+#include <optional>
+#include <variant>
+
+namespace mx
+{
+namespace api
+{
+
+// Payload for MarkType::tremoloStart / MarkType::tremoloStop: the measured-tremolo slash count
+// (MusicXML <tremolo> text value, 0-8). Absent means "not specified" (the writer falls back to a
+// default). The tremoloSingle* mark types encode their slash count in the enumerator itself and do
+// not use this payload.
+struct TremoloMarkData
+{
+    std::optional<int> tremoloMarks;
+};
+
+MXAPI_EQUALS_BEGIN(TremoloMarkData)
+MXAPI_EQUALS_MEMBER(tremoloMarks)
+MXAPI_EQUALS_END;
+MXAPI_NOT_EQUALS_AND_VECTORS(TremoloMarkData);
+
+// A variant class that carries data for MarkType values whose payload does not fit MarkData's
+// common fields.
+//
+// Justification: MarkData represents every kind of MusicXML mark (articulation, ornament,
+// technical, fermata, dynamic, ...) with a single struct. Most of MarkData's fields are common to
+// (nearly) every mark. A minority of fields only make sense for one specific mark, or a narrow
+// family of marks; adding those directly to MarkData as ad hoc fields does not scale and leaves it
+// unclear which fields apply to which mark. New mark-specific payloads belong here, as a new
+// alternative, rather than as a new direct field on MarkData.
+//
+// The choice's Kind SHOULD correspond to MarkData::markType (e.g. Kind::tremolo pairs with
+// MarkType::tremoloStart/tremoloStop), but this is a convention that this class does not enforce.
+//
+// Defaults to none (no mark-specific payload).
+class MarkDataChoice
+{
+  public:
+    enum class Kind
+    {
+        none,
+        tremolo
+    };
+
+    MarkDataChoice();
+
+    MarkDataChoice(TremoloMarkData value);
+
+    Kind kind() const;
+    bool isNone() const;
+    bool isTremolo() const;
+
+    // Returns a copy of the internally held TremoloMarkData.
+    //
+    // Check isTremolo() first. If this is not a tremolo payload, a default constructed
+    // TremoloMarkData is returned.
+    const TremoloMarkData tremolo() const;
+
+    bool operator==(const MarkDataChoice &other) const;
+
+  private:
+    std::variant<std::monostate, TremoloMarkData> myValue;
+};
+
+MXAPI_NOT_EQUALS_AND_VECTORS(MarkDataChoice);
+
+} // namespace api
+} // namespace mx

--- a/src/private/mx/api/MarkData.cpp
+++ b/src/private/mx/api/MarkData.cpp
@@ -230,7 +230,7 @@ MarkData::MarkData()
     : markType(MarkType::unspecified), name{}, tickTimePosition{0}, printData{}, positionData{}, mordentLong{Bool::no},
       hasMordentLong{false}, mordentApproach{Placement::unspecified}, hasMordentApproach{false},
       mordentDeparture{Placement::unspecified}, hasMordentDeparture{false}, fingeringSubstitution{Bool::unspecified},
-      fingeringAlternate{Bool::unspecified}, tremoloMarks{}
+      fingeringAlternate{Bool::unspecified}, choice{}
 {
 }
 
@@ -238,7 +238,7 @@ MarkData::MarkData(MarkType inMarkType)
     : markType(inMarkType), name{}, tickTimePosition{0}, printData{}, positionData{}, mordentLong{Bool::no},
       hasMordentLong{false}, mordentApproach{Placement::unspecified}, hasMordentApproach{false},
       mordentDeparture{Placement::unspecified}, hasMordentDeparture{false}, fingeringSubstitution{Bool::unspecified},
-      fingeringAlternate{Bool::unspecified}, tremoloMarks{}
+      fingeringAlternate{Bool::unspecified}, choice{}
 {
     impl::Converter converter;
     if (isMarkDynamic(markType))
@@ -259,7 +259,7 @@ MarkData::MarkData(Placement inPlacement, MarkType inMarkType)
     : markType(inMarkType), name{}, tickTimePosition{0}, printData{}, positionData{}, mordentLong{Bool::no},
       hasMordentLong{false}, mordentApproach{Placement::unspecified}, hasMordentApproach{false},
       mordentDeparture{Placement::unspecified}, hasMordentDeparture{false}, fingeringSubstitution{Bool::unspecified},
-      fingeringAlternate{Bool::unspecified}, tremoloMarks{}
+      fingeringAlternate{Bool::unspecified}, choice{}
 {
     positionData.placement = inPlacement;
     impl::Converter converter;

--- a/src/private/mx/api/MarkData.cpp
+++ b/src/private/mx/api/MarkData.cpp
@@ -119,6 +119,7 @@ bool isMarkOrnament(MarkType markType)
            (markType == MarkType::schleifer) || (markType == MarkType::tremoloSingleOne) ||
            (markType == MarkType::tremoloSingleTwo) || (markType == MarkType::tremoloSingleThree) ||
            (markType == MarkType::tremoloSingleFour) || (markType == MarkType::tremoloSingleFive) ||
+           (markType == MarkType::tremoloStart) || (markType == MarkType::tremoloStop) ||
            (markType == MarkType::otherOrnament) || (markType == MarkType::unknownOrnament);
 }
 
@@ -163,7 +164,8 @@ bool isMarkTremolo(MarkType markType)
 {
     return (markType == MarkType::tremoloSingleOne) || (markType == MarkType::tremoloSingleTwo) ||
            (markType == MarkType::tremoloSingleThree) || (markType == MarkType::tremoloSingleFour) ||
-           (markType == MarkType::tremoloSingleFive);
+           (markType == MarkType::tremoloSingleFive) || (markType == MarkType::tremoloStart) ||
+           (markType == MarkType::tremoloStop);
 }
 
 bool isMarkCustom(MarkType markType)
@@ -228,7 +230,7 @@ MarkData::MarkData()
     : markType(MarkType::unspecified), name{}, tickTimePosition{0}, printData{}, positionData{}, mordentLong{Bool::no},
       hasMordentLong{false}, mordentApproach{Placement::unspecified}, hasMordentApproach{false},
       mordentDeparture{Placement::unspecified}, hasMordentDeparture{false}, fingeringSubstitution{Bool::unspecified},
-      fingeringAlternate{Bool::unspecified}
+      fingeringAlternate{Bool::unspecified}, tremoloMarks{}
 {
 }
 
@@ -236,7 +238,7 @@ MarkData::MarkData(MarkType inMarkType)
     : markType(inMarkType), name{}, tickTimePosition{0}, printData{}, positionData{}, mordentLong{Bool::no},
       hasMordentLong{false}, mordentApproach{Placement::unspecified}, hasMordentApproach{false},
       mordentDeparture{Placement::unspecified}, hasMordentDeparture{false}, fingeringSubstitution{Bool::unspecified},
-      fingeringAlternate{Bool::unspecified}
+      fingeringAlternate{Bool::unspecified}, tremoloMarks{}
 {
     impl::Converter converter;
     if (isMarkDynamic(markType))
@@ -257,7 +259,7 @@ MarkData::MarkData(Placement inPlacement, MarkType inMarkType)
     : markType(inMarkType), name{}, tickTimePosition{0}, printData{}, positionData{}, mordentLong{Bool::no},
       hasMordentLong{false}, mordentApproach{Placement::unspecified}, hasMordentApproach{false},
       mordentDeparture{Placement::unspecified}, hasMordentDeparture{false}, fingeringSubstitution{Bool::unspecified},
-      fingeringAlternate{Bool::unspecified}
+      fingeringAlternate{Bool::unspecified}, tremoloMarks{}
 {
     positionData.placement = inPlacement;
     impl::Converter converter;

--- a/src/private/mx/api/MarkDataChoice.cpp
+++ b/src/private/mx/api/MarkDataChoice.cpp
@@ -1,0 +1,52 @@
+// MusicXML Class Library
+// Copyright (c) by Matthew James Briggs
+// Distributed under the MIT License
+
+#include "mx/api/MarkDataChoice.h"
+
+#include <utility>
+
+namespace mx
+{
+namespace api
+{
+
+MarkDataChoice::MarkDataChoice() : myValue{std::monostate{}}
+{
+}
+
+MarkDataChoice::MarkDataChoice(TremoloMarkData value) : myValue{std::move(value)}
+{
+}
+
+MarkDataChoice::Kind MarkDataChoice::kind() const
+{
+    return std::holds_alternative<TremoloMarkData>(myValue) ? Kind::tremolo : Kind::none;
+}
+
+bool MarkDataChoice::isNone() const
+{
+    return std::holds_alternative<std::monostate>(myValue);
+}
+
+bool MarkDataChoice::isTremolo() const
+{
+    return std::holds_alternative<TremoloMarkData>(myValue);
+}
+
+const TremoloMarkData MarkDataChoice::tremolo() const
+{
+    if (const auto *value = std::get_if<TremoloMarkData>(&myValue))
+    {
+        return *value;
+    }
+    return TremoloMarkData{};
+}
+
+bool MarkDataChoice::operator==(const MarkDataChoice &other) const
+{
+    return myValue == other.myValue;
+}
+
+} // namespace api
+} // namespace mx

--- a/src/private/mx/impl/NotationsWriter.cpp
+++ b/src/private/mx/impl/NotationsWriter.cpp
@@ -619,9 +619,18 @@ void NotationsWriter::addOrnament(const api::MarkData &mark, core::Ornaments &ou
     }
     case core::OrnamentsGroupChoice::Kind::tremolo: {
         core::Tremolo tremolo;
-        tremolo.setType(core::TremoloType::single());
         setAttributesFromPositionData(mark.positionData, tremolo);
-        tremolo.setValue(core::TremoloMarks{api::numTremoloSlashes(mark.markType)});
+        if (mark.markType == api::MarkType::tremoloStart || mark.markType == api::MarkType::tremoloStop)
+        {
+            tremolo.setType(mark.markType == api::MarkType::tremoloStart ? core::TremoloType::start()
+                                                                         : core::TremoloType::stop());
+            tremolo.setValue(core::TremoloMarks{mark.tremoloMarks.value_or(3)});
+        }
+        else
+        {
+            tremolo.setType(core::TremoloType::single());
+            tremolo.setValue(core::TremoloMarks{api::numTremoloSlashes(mark.markType)});
+        }
         group.setChoice(core::OrnamentsGroupChoice::tremolo(tremolo));
         break;
     }

--- a/src/private/mx/impl/NotationsWriter.cpp
+++ b/src/private/mx/impl/NotationsWriter.cpp
@@ -624,7 +624,7 @@ void NotationsWriter::addOrnament(const api::MarkData &mark, core::Ornaments &ou
         {
             tremolo.setType(mark.markType == api::MarkType::tremoloStart ? core::TremoloType::start()
                                                                          : core::TremoloType::stop());
-            tremolo.setValue(core::TremoloMarks{mark.tremoloMarks.value_or(3)});
+            tremolo.setValue(core::TremoloMarks{mark.choice.tremolo().tremoloMarks.value_or(3)});
         }
         else
         {

--- a/src/private/mx/impl/OrnamentsFunctions.cpp
+++ b/src/private/mx/impl/OrnamentsFunctions.cpp
@@ -160,9 +160,21 @@ void OrnamentsFunctions::parseOrnament(const core::OrnamentsGroupChoice &choiceO
     }
     case core::OrnamentsGroupChoice::Kind::tremolo: {
         const auto &tremolo = choiceObj.asTremolo();
-        const bool isSingle = !tremolo.type().has_value() || *tremolo.type() == core::TremoloType::single();
-        if (!isSingle)
+        const auto type = tremolo.type().value_or(core::TremoloType::single()).tag();
+
+        if (type == core::TremoloType::Tag::start || type == core::TremoloType::Tag::stop)
         {
+            outMark.name = "tremolo";
+            parseMarkDataAttributes(tremolo, outMark);
+            outMark.markType =
+                (type == core::TremoloType::Tag::start) ? api::MarkType::tremoloStart : api::MarkType::tremoloStop;
+            outMark.tremoloMarks = tremolo.value().value();
+            break;
+        }
+
+        if (type != core::TremoloType::Tag::single)
+        {
+            // unmeasured tremolo -- not yet representable
             outMark.name = "this tremolo is not a mark";
             outMark.markType = api::MarkType::unknownOrnament;
             return;

--- a/src/private/mx/impl/OrnamentsFunctions.cpp
+++ b/src/private/mx/impl/OrnamentsFunctions.cpp
@@ -168,7 +168,7 @@ void OrnamentsFunctions::parseOrnament(const core::OrnamentsGroupChoice &choiceO
             parseMarkDataAttributes(tremolo, outMark);
             outMark.markType =
                 (type == core::TremoloType::Tag::start) ? api::MarkType::tremoloStart : api::MarkType::tremoloStop;
-            outMark.tremoloMarks = tremolo.value().value();
+            outMark.choice = api::TremoloMarkData{tremolo.value().value()};
             break;
         }
 

--- a/src/private/mxtest/api/NoteDataTest.cpp
+++ b/src/private/mxtest/api/NoteDataTest.cpp
@@ -615,6 +615,80 @@ TEST(tremolos, NoteData)
 
 T_END;
 
+TEST(measuredTremolo, NoteData)
+{
+    ScoreData score;
+    score.ticksPerQuarter = 1;
+    score.parts.emplace_back();
+    auto &part = score.parts.back();
+    part.measures.emplace_back();
+    auto &measure = part.measures.back();
+    measure.staves.emplace_back();
+    auto &staff = measure.staves.back();
+    auto &voice = staff.voices[0];
+
+    voice.notes.emplace_back();
+    auto &firstNote = voice.notes.back();
+    firstNote.durationData.durationName = DurationName::quarter;
+    firstNote.durationData.durationTimeTicks = 1;
+    firstNote.tickTimePosition = 0;
+    MarkData startMark{MarkType::tremoloStart};
+    startMark.tremoloMarks = 3;
+    firstNote.noteAttachmentData.marks.emplace_back(startMark);
+
+    voice.notes.emplace_back();
+    auto &secondNote = voice.notes.back();
+    secondNote.durationData.durationName = DurationName::quarter;
+    secondNote.durationData.durationTimeTicks = 1;
+    secondNote.tickTimePosition = 1;
+    MarkData stopMark{MarkType::tremoloStop};
+    stopMark.tremoloMarks = 3;
+    secondNote.noteAttachmentData.marks.emplace_back(stopMark);
+
+    const auto out = mxtest::roundTrip(score);
+
+    const auto &ovoice = out.parts.back().measures.back().staves.back().voices.at(0);
+    REQUIRE(2 == ovoice.notes.size());
+
+    const auto &oFirstMarks = ovoice.notes.at(0).noteAttachmentData.marks;
+    REQUIRE(1 == oFirstMarks.size());
+    CHECK(MarkType::tremoloStart == oFirstMarks.at(0).markType);
+    REQUIRE(oFirstMarks.at(0).tremoloMarks.has_value());
+    CHECK_EQUAL(3, *oFirstMarks.at(0).tremoloMarks);
+
+    const auto &oSecondMarks = ovoice.notes.at(1).noteAttachmentData.marks;
+    REQUIRE(1 == oSecondMarks.size());
+    CHECK(MarkType::tremoloStop == oSecondMarks.at(0).markType);
+    REQUIRE(oSecondMarks.at(0).tremoloMarks.has_value());
+    CHECK_EQUAL(3, *oSecondMarks.at(0).tremoloMarks);
+}
+
+T_END;
+
+// Parse the synthetic tremolo file (a <tremolo type="start"> with one slash) and confirm mx::api
+// surfaces it as a tremoloStart mark. This pins the core -> api read path for measured tremolos.
+TEST(measuredTremoloFromSyntheticFile, NoteData)
+{
+    const std::string path = mxtest::getResourcesDirectoryPath() + "synthetic/tremolo.3.0.xml";
+    auto &docMgr = DocumentManager::getInstance();
+    const auto docIdResult = docMgr.createFromFile(path);
+    REQUIRE(docIdResult.ok());
+    const int docId = docIdResult.value();
+    const auto scoreResult = docMgr.getData(docId);
+    docMgr.destroyDocument(docId);
+    REQUIRE(scoreResult.ok());
+    const auto &score = scoreResult.value();
+
+    const auto &marks =
+        score.parts.back().measures.back().staves.back().voices.at(0).notes.back().noteAttachmentData.marks;
+    REQUIRE(1 == marks.size());
+    CHECK(MarkType::tremoloStart == marks.at(0).markType);
+    REQUIRE(marks.at(0).tremoloMarks.has_value());
+    CHECK_EQUAL(1, *marks.at(0).tremoloMarks);
+}
+
+T_END;
+
 TEST(miscFields, NoteData)
 {
     ScoreData score;

--- a/src/private/mxtest/api/NoteDataTest.cpp
+++ b/src/private/mxtest/api/NoteDataTest.cpp
@@ -633,7 +633,7 @@ TEST(measuredTremolo, NoteData)
     firstNote.durationData.durationTimeTicks = 1;
     firstNote.tickTimePosition = 0;
     MarkData startMark{MarkType::tremoloStart};
-    startMark.tremoloMarks = 3;
+    startMark.choice = TremoloMarkData{3};
     firstNote.noteAttachmentData.marks.emplace_back(startMark);
 
     voice.notes.emplace_back();
@@ -642,7 +642,7 @@ TEST(measuredTremolo, NoteData)
     secondNote.durationData.durationTimeTicks = 1;
     secondNote.tickTimePosition = 1;
     MarkData stopMark{MarkType::tremoloStop};
-    stopMark.tremoloMarks = 3;
+    stopMark.choice = TremoloMarkData{3};
     secondNote.noteAttachmentData.marks.emplace_back(stopMark);
 
     const auto out = mxtest::roundTrip(score);
@@ -653,14 +653,16 @@ TEST(measuredTremolo, NoteData)
     const auto &oFirstMarks = ovoice.notes.at(0).noteAttachmentData.marks;
     REQUIRE(1 == oFirstMarks.size());
     CHECK(MarkType::tremoloStart == oFirstMarks.at(0).markType);
-    REQUIRE(oFirstMarks.at(0).tremoloMarks.has_value());
-    CHECK_EQUAL(3, *oFirstMarks.at(0).tremoloMarks);
+    REQUIRE(oFirstMarks.at(0).choice.isTremolo());
+    REQUIRE(oFirstMarks.at(0).choice.tremolo().tremoloMarks.has_value());
+    CHECK_EQUAL(3, *oFirstMarks.at(0).choice.tremolo().tremoloMarks);
 
     const auto &oSecondMarks = ovoice.notes.at(1).noteAttachmentData.marks;
     REQUIRE(1 == oSecondMarks.size());
     CHECK(MarkType::tremoloStop == oSecondMarks.at(0).markType);
-    REQUIRE(oSecondMarks.at(0).tremoloMarks.has_value());
-    CHECK_EQUAL(3, *oSecondMarks.at(0).tremoloMarks);
+    REQUIRE(oSecondMarks.at(0).choice.isTremolo());
+    REQUIRE(oSecondMarks.at(0).choice.tremolo().tremoloMarks.has_value());
+    CHECK_EQUAL(3, *oSecondMarks.at(0).choice.tremolo().tremoloMarks);
 }
 
 T_END;
@@ -683,8 +685,9 @@ TEST(measuredTremoloFromSyntheticFile, NoteData)
         score.parts.back().measures.back().staves.back().voices.at(0).notes.back().noteAttachmentData.marks;
     REQUIRE(1 == marks.size());
     CHECK(MarkType::tremoloStart == marks.at(0).markType);
-    REQUIRE(marks.at(0).tremoloMarks.has_value());
-    CHECK_EQUAL(1, *marks.at(0).tremoloMarks);
+    REQUIRE(marks.at(0).choice.isTremolo());
+    REQUIRE(marks.at(0).choice.tremolo().tremoloMarks.has_value());
+    CHECK_EQUAL(1, *marks.at(0).choice.tremolo().tremoloMarks);
 }
 
 T_END;


### PR DESCRIPTION
## Human Summary

I do not love this but I am going to merge it.

`MarkData` and `MarkType` interact in a terrible way. If your `MarkType` is something, like mordent, then `MarkData` might be used to carry some additional information relevant only to mordents. Rather than continue this practice I introduced a MarkDataChoice type for future additions to this pattern, the first of which is multi-note tremolos which, I guess, you can specify the number of tremolo marks for.

This is not a clear API and ultimately it stems from a lack of Rust enums, which are so so wonderful compared to C++. I guess the `std::variant` is C++'s answer to Rust enums, but it's ugly has exceptions and undefined behavior, so I'm hiding it behind these "choice" classes (this started with #321).

Ultimately, I hope this is clear enough for coding agents to understand and use correctly even if it is just, not a great interface.

## Summary

`mx::api` could represent single-note (glyph) tremolos but silently dropped the measured, two-note
form written as `<tremolo type="start">`/`<tremolo type="stop">` on adjacent notes. This adds it.

- `MarkType` gains `tremoloStart` and `tremoloStop`, marking the first and second note of a
  measured tremolo. The existing `tremoloSingleOne..Five` glyph marks are unchanged.
- `MarkData` gains a `choice` field (`MarkDataChoice`), a variant class (mirroring the
  `TimeChoice`/`ComplexTimeSignature` pattern) that carries payloads for mark types whose data
  doesn't fit the common fields. For `tremoloStart`/`tremoloStop` it holds `TremoloMarkData` with
  `tremoloMarks` (`std::optional<int>`), the slash count (0-8). The `tremoloSingle*` marks keep
  encoding their count in the enumerator itself, as before.
- MusicXML's `<tremolo>` has no `number` attribute (unlike slur/tie), so there is nothing to key a
  cross-note match on. Pairing the start on one note with the stop on a later note is left to the
  api consumer via document order, the same way `NoteData::isTieStart`/`isTieStop` already work.
- `OrnamentsFunctions.cpp` (read) and `NotationsWriter.cpp` (write) are updated symmetrically;
  `isMarkTremolo`/`isMarkOrnament` include the two new mark types. Unmeasured tremolos are still
  not representable and continue to be dropped as before.
- Per review, `MarkData.h` now documents which of its fields are common to all marks vs. specific
  to one mark type, and directs future mark-specific additions to a new `MarkDataChoice`
  alternative (`MarkDataChoice.h`) rather than a new ad hoc direct field.

## Testing

- [x] New tests in `NoteDataTest.cpp`: an in-memory round trip of two adjacent notes carrying
      `tremoloStart`/`tremoloStop` marks, and a read test against `data/synthetic/tremolo.3.0.xml`
- [x] `make test`: all pass (4821 assertions in 392 test cases, plus the three examples)
- [x] `make test-api-roundtrip`: 164 passed, 0 failed (of 164 pinned; no regressions)
- [x] `make discover-api-roundtrip`: no newly-attributable passes; the two corpus files with real
      start/stop tremolo content (`musuite/testTremolo.xml`, `lysuite/ly23e_Tuplets_Tremolo.xml`)
      still fail on unrelated pre-existing subset gaps (an `identification`/`rights` mismatch and a
      `time-modification` gap, respectively), so no `roundtrip-baseline.txt` entry was added
- [x] `make fmt` / `make check` clean

## References

- Closes #329
