### PR TITLE
fix: rename PositionData horizontalAlignmnet to horizontalAlignment

### DIFF
--- a/src/include/mx/api/PageTextData.h
+++ b/src/include/mx/api/PageTextData.h
@@ -37,7 +37,7 @@ class PageTextData
 
     // The `justify` attribute of `<credit-words>`. `unspecified` means the
     // attribute is absent. Distinct from the `halign` attribute, which is
-    // carried in `positionData.horizontalAlignmnet`; MusicXML defines both
+    // carried in `positionData.horizontalAlignment`; MusicXML defines both
     // attributes on `<credit-words>`.
     HorizontalAlignment justify = HorizontalAlignment::unspecified;
 };

--- a/src/include/mx/api/PositionData.h
+++ b/src/include/mx/api/PositionData.h
@@ -106,12 +106,12 @@ class PositionData
     bool isRelativeYSpecified;
     Placement placement;
     VerticalAlignment verticalAlignment;
-    HorizontalAlignment horizontalAlignmnet;
+    HorizontalAlignment horizontalAlignment;
 
     PositionData()
         : defaultX(0.0), isDefaultXSpecified(false), defaultY(0.0), isDefaultYSpecified(false), relativeX(0.0),
           isRelativeXSpecified(false), relativeY(0.0), isRelativeYSpecified(false), placement(Placement::unspecified),
-          verticalAlignment(VerticalAlignment::unspecified), horizontalAlignmnet(HorizontalAlignment::unspecified)
+          verticalAlignment(VerticalAlignment::unspecified), horizontalAlignment(HorizontalAlignment::unspecified)
     {
     }
 };
@@ -127,7 +127,7 @@ MXAPI_DOUBLES_EQUALS_MEMBER(relativeY)
 MXAPI_EQUALS_MEMBER(isRelativeYSpecified)
 MXAPI_EQUALS_MEMBER(placement)
 MXAPI_EQUALS_MEMBER(verticalAlignment)
-MXAPI_EQUALS_MEMBER(horizontalAlignmnet)
+MXAPI_EQUALS_MEMBER(horizontalAlignment)
 MXAPI_EQUALS_END;
 MXAPI_NOT_EQUALS_AND_VECTORS(PositionData);
 } // namespace api

--- a/src/private/mx/impl/NoteReader.cpp
+++ b/src/private/mx/impl/NoteReader.cpp
@@ -80,7 +80,7 @@ api::PositionData getLyricPositionData(const core::Lyric &inLyric)
 
     if (inLyric.justify().has_value())
     {
-        outPositionData.horizontalAlignmnet = converter.convert(*inLyric.justify());
+        outPositionData.horizontalAlignment = converter.convert(*inLyric.justify());
     }
 
     return outPositionData;

--- a/src/private/mx/impl/NoteWriter.cpp
+++ b/src/private/mx/impl/NoteWriter.cpp
@@ -514,9 +514,9 @@ void NoteWriter::setLyrics() const
         }
 
         impl::setAttributesFromPositionData(lyricData.positionData, lyric);
-        if (lyricData.positionData.horizontalAlignmnet != api::HorizontalAlignment::unspecified)
+        if (lyricData.positionData.horizontalAlignment != api::HorizontalAlignment::unspecified)
         {
-            lyric.setJustify(myConverter.convert(lyricData.positionData.horizontalAlignmnet));
+            lyric.setJustify(myConverter.convert(lyricData.positionData.horizontalAlignment));
         }
 
         if (lyricData.printData.printObject != api::Bool::unspecified)

--- a/src/private/mx/impl/PositionFunctions.h
+++ b/src/private/mx/impl/PositionFunctions.h
@@ -65,11 +65,11 @@ template <typename ATTRIBUTES_TYPE> api::PositionData getPositionData(const ATTR
 
     if (checkHasHalign<ATTRIBUTES_TYPE>(&inAttributes))
     {
-        outPositionData.horizontalAlignmnet = converter.convert(checkHalign<ATTRIBUTES_TYPE>(&inAttributes));
+        outPositionData.horizontalAlignment = converter.convert(checkHalign<ATTRIBUTES_TYPE>(&inAttributes));
     }
     else
     {
-        outPositionData.horizontalAlignmnet = api::HorizontalAlignment::unspecified;
+        outPositionData.horizontalAlignment = api::HorizontalAlignment::unspecified;
     }
 
     if (checkHasValign<ATTRIBUTES_TYPE>(&inAttributes))
@@ -163,14 +163,14 @@ void setAttributesFromPositionData(const api::PositionData &positionData, ATTRIB
 
     Converter converter;
 
-    if (positionData.horizontalAlignmnet == api::HorizontalAlignment::unspecified)
+    if (positionData.horizontalAlignment == api::HorizontalAlignment::unspecified)
     {
         lookForAndSetHasHalign(false, &outAttributes);
     }
     else
     {
         lookForAndSetHasHalign(true, &outAttributes);
-        lookForAndSetHalign(converter.convert(positionData.horizontalAlignmnet), &outAttributes);
+        lookForAndSetHalign(converter.convert(positionData.horizontalAlignment), &outAttributes);
     }
 
     if (positionData.verticalAlignment == api::VerticalAlignment::unspecified)

--- a/src/private/mxtest/api/LyricDataTest.cpp
+++ b/src/private/mxtest/api/LyricDataTest.cpp
@@ -44,7 +44,7 @@ mx::api::ScoreData makeScoreWithLyrics()
     first.syllabic = LyricSyllabic::begin;
     first.hasExtend = true;
     first.positionData.placement = Placement::below;
-    first.positionData.horizontalAlignmnet = HorizontalAlignment::center;
+    first.positionData.horizontalAlignment = HorizontalAlignment::center;
     first.positionData.isDefaultYSpecified = true;
     first.positionData.defaultY = -40.0;
     first.printData.printObject = Bool::yes;
@@ -114,7 +114,7 @@ TEST(lyricsRoundTripThroughApi, LyricData)
     CHECK(note.lyrics.at(0).syllabic == LyricSyllabic::begin);
     CHECK(note.lyrics.at(0).hasExtend);
     CHECK(note.lyrics.at(0).positionData.placement == Placement::below);
-    CHECK(note.lyrics.at(0).positionData.horizontalAlignmnet == HorizontalAlignment::center);
+    CHECK(note.lyrics.at(0).positionData.horizontalAlignment == HorizontalAlignment::center);
     CHECK(note.lyrics.at(0).printData.printObject == Bool::yes);
     CHECK(note.lyrics.at(0).printData.isColorSpecified);
     CHECK_EQUAL(1, static_cast<int>(note.lyrics.at(0).printData.color.red));

--- a/src/private/mxtest/impl/DirectionWriterTest.cpp
+++ b/src/private/mxtest/impl/DirectionWriterTest.cpp
@@ -72,7 +72,7 @@ TEST(segnoAndCodaRoundTrip, DirectionWriter)
     segno.positionData.relativeX = 3.0;
     segno.positionData.isRelativeYSpecified = true;
     segno.positionData.relativeY = 4.0;
-    segno.positionData.horizontalAlignmnet = api::HorizontalAlignment::left;
+    segno.positionData.horizontalAlignment = api::HorizontalAlignment::left;
     segno.positionData.verticalAlignment = api::VerticalAlignment::top;
     segno.fontData.fontFamily = {"Maestro"};
     segno.fontData.style = api::FontStyle::italic;
@@ -93,7 +93,7 @@ TEST(segnoAndCodaRoundTrip, DirectionWriter)
     api::CodaData coda;
     coda.positionData.isDefaultXSpecified = true;
     coda.positionData.defaultX = 5.0;
-    coda.positionData.horizontalAlignmnet = api::HorizontalAlignment::center;
+    coda.positionData.horizontalAlignment = api::HorizontalAlignment::center;
     coda.positionData.verticalAlignment = api::VerticalAlignment::middle;
     coda.fontData.fontFamily = {"Maestro"};
     coda.fontData.style = api::FontStyle::normal;
@@ -145,7 +145,7 @@ TEST(rehearsalRoundTrip, DirectionWriter)
     rehearsal.positionData.relativeX = 3.0;
     rehearsal.positionData.isRelativeYSpecified = true;
     rehearsal.positionData.relativeY = 4.0;
-    rehearsal.positionData.horizontalAlignmnet = api::HorizontalAlignment::left;
+    rehearsal.positionData.horizontalAlignment = api::HorizontalAlignment::left;
     rehearsal.positionData.verticalAlignment = api::VerticalAlignment::top;
     rehearsal.fontData.fontFamily = {"Maestro"};
     rehearsal.fontData.style = api::FontStyle::italic;


### PR DESCRIPTION
## Human Summary

Just a rename of a misspelled symbol.

## Summary

Mechanical rename of the misspelled `PositionData::horizontalAlignmnet` public field to
`horizontalAlignment`, across the api header, the impl translation layer, a stale comment in
`PageTextData.h`, and the tests. No behavior change.

Breaking for any client code that spelled the typo, so this should land in a version bump that
tolerates a breaking change.

## Testing

- [x] Full mxtest suite passes
- [x] `grep -rn Alignmnet src/` is empty

## References

- Closes #331