### PR TITLE
fix: read the other-appearance value instead of hardcoding 0.0

### DIFF
--- a/src/private/mx/impl/LayoutFunctions.cpp
+++ b/src/private/mx/impl/LayoutFunctions.cpp
@@ -500,7 +500,13 @@ void addAppearance(const core::ScoreHeaderGroup &inScoreHeaderGroup, api::Defaul
         api::AppearanceData data{};
         data.appearanceType = api::AppearanceType::OtherAppearance;
         data.appearanceSubType = oa.type();
-        data.value = 0.0;
+        // <other-appearance> content is free text in MusicXML but numeric in practice;
+        // a non-numeric value reads as 0.0.
+        core::Decimal parsedOtherAppearanceValue{};
+        if (core::Decimal::tryParse(oa.value(), parsedOtherAppearanceValue))
+        {
+            data.value = parsedOtherAppearanceValue.value();
+        }
         outDefaults.appearance.emplace_back(std::move(data));
     }
 }

--- a/src/private/mxtest/api/DefaultsFontsRoundTripTest.cpp
+++ b/src/private/mxtest/api/DefaultsFontsRoundTripTest.cpp
@@ -97,4 +97,22 @@ TEST(defaultsFontsRoundTrip, lyricFonts)
     CHECK(lf2 == out.defaults.lyricFonts.at(1));
 }
 
+TEST(defaultsAppearanceRoundTrip, otherAppearanceValue)
+{
+    // The <other-appearance> content is free text in MusicXML but numeric in practice; the
+    // reader used to discard it and always report 0.0 (#101).
+    auto in = makeMinimalScore();
+
+    AppearanceData oa{};
+    oa.appearanceType = AppearanceType::OtherAppearance;
+    oa.appearanceSubType = "misc-glyph-scale";
+    oa.value = 1.25;
+    in.defaults.appearance.push_back(oa);
+
+    const auto out = mxtest::roundTrip(in);
+
+    REQUIRE(out.defaults.appearance.size() == 1);
+    CHECK(oa == out.defaults.appearance.front());
+}
+
 #endif


### PR DESCRIPTION
## Human Summary

Not sure this ever came up in practice but it sounds like it was a bug and the model was tasked with closing issues! Looks like it did the right thing here.

## Summary

The `<other-appearance>` reader in `LayoutFunctions.cpp` discarded the element's content and
always reported `AppearanceData::value = 0.0` — the long-standing TODO from #101 (the code has
moved since that issue was filed, but the hardcoded 0.0 survived the refactor). The content is
free text in MusicXML but numeric in practice, and the writer already emits
`AppearanceData::value` as formatted text, so the reader now parses it back with
`core::Decimal::tryParse`. Non-numeric content still reads as 0.0.

## Testing

- [x] New `defaultsAppearanceRoundTrip.otherAppearanceValue` round-trip test (fails before, passes after)
- [x] Full mxtest suite passes

## References

- Closes #101
