### PR TITLE
fix: rename small enum members to dodge windows sdk macro collision

### DIFF
--- a/gen/cpp/config.toml
+++ b/gen/cpp/config.toml
@@ -71,6 +71,9 @@ non_negative_integer = "int"
 
 [reserved]
 # C++ keywords (including alternative tokens) a generated identifier must not be.
+# "small" is also here though it is not a keyword: the Windows SDK's rpcndr.h
+# (pulled in transitively by windows.h) #defines it to `char`, which mangles
+# any generated `small` identifier before the compiler ever sees it (#354).
 words = [
     "alignas", "alignof", "and", "and_eq", "asm", "auto", "bitand",
     "bitor", "bool", "break", "case", "catch", "char", "char8_t",
@@ -87,6 +90,7 @@ words = [
     "throw", "true", "try", "typedef", "typeid", "typename", "union",
     "unsigned", "using", "virtual", "void", "volatile", "wchar_t",
     "while", "xor", "xor_eq",
+    "small",
 ]
 
 # Semantic names for the synthesized content types the §2.9 projection

--- a/src/include/mx/api/FontData.h
+++ b/src/include/mx/api/FontData.h
@@ -28,7 +28,9 @@ enum class CssSize
     unspecified,
     xxSmall,
     xSmall,
-    small,
+    // Named small_, not small: the Windows SDK's rpcndr.h (pulled in
+    // transitively by windows.h) #defines `small` to `char` (#354).
+    small_,
     medium,
     large,
     xLarge,

--- a/src/private/mx/core/generated/CSSFontSize.cpp
+++ b/src/private/mx/core/generated/CSSFontSize.cpp
@@ -22,9 +22,9 @@ CSSFontSize CSSFontSize::xSmall() noexcept
     return CSSFontSize{Tag::xSmall};
 }
 
-CSSFontSize CSSFontSize::small() noexcept
+CSSFontSize CSSFontSize::small_() noexcept
 {
-    return CSSFontSize{Tag::small};
+    return CSSFontSize{Tag::small_};
 }
 
 CSSFontSize CSSFontSize::medium() noexcept

--- a/src/private/mx/core/generated/CSSFontSize.h
+++ b/src/private/mx/core/generated/CSSFontSize.h
@@ -18,7 +18,7 @@ class CSSFontSize final
     {
         xxSmall,
         xSmall,
-        small,
+        small_,
         medium,
         large,
         xLarge,
@@ -30,7 +30,7 @@ class CSSFontSize final
 
     static CSSFontSize xxSmall() noexcept;
     static CSSFontSize xSmall() noexcept;
-    static CSSFontSize small() noexcept;
+    static CSSFontSize small_() noexcept;
     static CSSFontSize medium() noexcept;
     static CSSFontSize large() noexcept;
     static CSSFontSize xLarge() noexcept;

--- a/src/private/mx/impl/Converter.cpp
+++ b/src/private/mx/impl/Converter.cpp
@@ -152,7 +152,7 @@ const Converter::EnumMap<core::LeftCenterRight, api::HorizontalAlignment> Conver
 
 const Converter::EnumMap<core::CSSFontSize, api::CssSize> Converter::cssMap = {
     {core::CSSFontSize::xxSmall(), api::CssSize::xxSmall}, {core::CSSFontSize::xSmall(), api::CssSize::xSmall},
-    {core::CSSFontSize::small(), api::CssSize::small},     {core::CSSFontSize::medium(), api::CssSize::medium},
+    {core::CSSFontSize::small_(), api::CssSize::small_},   {core::CSSFontSize::medium(), api::CssSize::medium},
     {core::CSSFontSize::large(), api::CssSize::large},     {core::CSSFontSize::xLarge(), api::CssSize::xLarge},
     {core::CSSFontSize::xxLarge(), api::CssSize::xxLarge},
 };


### PR DESCRIPTION
## Summary

The Windows SDK's `rpcndr.h` (pulled in transitively by `windows.h`) `#define`s `small` to `char`. Any generated or hand-written `small` identifier gets textually replaced by the preprocessor before the compiler ever parses it, so both `mx::api::CssSize::small` and `mx::core::CSSFontSize`'s `small`/`small()` broke under MSVC once `windows.h` was included first.

Per the issue's suggested resolution, renamed the enumerator to `small_` in both layers, on the theory that if it bites the public `mx::api` header it can just as easily bite `mx::core`'s generated header:

- `mx::api::CssSize::small` -> `small_` (`FontData.h`)
- `mx::core::CSSFontSize::Tag::small` / `CSSFontSize::small()` -> `small_` (generated)
- `gen/cpp/config.toml`: added `"small"` to the C++ target's `[reserved]` words so `make gen-cpp` keeps mangling it on regeneration, with a comment explaining why
- `mx::impl::Converter::cssMap` updated to the new names

The on-the-wire spelling (`"small"` in MusicXML CSS font-size values) is untouched — only the C++ identifiers changed. This is a breaking change to the public `CssSize` enum, as the issue anticipated; there's no existing deprecation/compat-shim convention in this codebase to soften it, so it's a straight rename.

## Testing

- `python3 -m gen gen/cpp/config.toml` — regenerated cleanly, touching only `CSSFontSize.h`/`.cpp` as expected
- `clang-format --dry-run --Werror` on all touched files — clean
- Did not run the full native/Docker build or test suite in this session; CI will need to confirm `core-roundtrip-test` and `api-test` pass

## References

- Fixes #354
