### PR TITLE
feat: model the percussion direction family

### DIFF
--- a/src/include/mx/api/DirectionData.h
+++ b/src/include/mx/api/DirectionData.h
@@ -16,6 +16,7 @@
 #include "mx/api/MarkData.h"
 #include "mx/api/OtherDirectionData.h"
 #include "mx/api/OttavaData.h"
+#include "mx/api/PercussionData.h"
 #include "mx/api/PrincipalVoiceData.h"
 #include "mx/api/RehearsalData.h"
 #include "mx/api/ScordaturaData.h"
@@ -60,7 +61,8 @@ enum class DirectionComponentKind
     image,
     accordionRegistration,
     harpPedals,
-    scordatura
+    scordatura,
+    percussion
 };
 
 struct DirectionComponent
@@ -152,6 +154,7 @@ struct DirectionData
     std::vector<AccordionRegistrationData> accordionRegistrations;
     std::vector<HarpPedalsData> harpPedals;
     std::vector<ScordaturaData> scordaturas;
+    std::vector<PercussionData> percussions;
     // Preserves the original order of direction-type children from parsed XML
     // for round-trip fidelity. Do NOT populate this when constructing
     // DirectionData programmatically. If empty, the writer uses a default
@@ -184,8 +187,8 @@ inline bool isDirectionDataEmpty(const DirectionData &directionData)
            directionData.principalVoices.size() == 0 && directionData.otherDirections.size() == 0 &&
            directionData.images.size() == 0 && directionData.accordionRegistrations.size() == 0 &&
            directionData.harpPedals.size() == 0 && directionData.scordaturas.size() == 0 &&
-           directionData.figuredBasses.size() == 0 && !directionData.isSoundDataSpecified &&
-           directionData.orderedComponents.size() == 0;
+           directionData.percussions.size() == 0 && directionData.figuredBasses.size() == 0 &&
+           !directionData.isSoundDataSpecified && directionData.orderedComponents.size() == 0;
 }
 
 MXAPI_EQUALS_BEGIN(DirectionData)
@@ -224,6 +227,7 @@ MXAPI_EQUALS_MEMBER(images)
 MXAPI_EQUALS_MEMBER(accordionRegistrations)
 MXAPI_EQUALS_MEMBER(harpPedals)
 MXAPI_EQUALS_MEMBER(scordaturas)
+MXAPI_EQUALS_MEMBER(percussions)
 MXAPI_EQUALS_MEMBER(orderedComponents)
 MXAPI_EQUALS_END;
 MXAPI_NOT_EQUALS_AND_VECTORS(DirectionData);

--- a/src/include/mx/api/PercussionData.h
+++ b/src/include/mx/api/PercussionData.h
@@ -1,0 +1,519 @@
+// MusicXML Class Library
+// Copyright (c) by Matthew James Briggs
+// Distributed under the MIT License
+
+#pragma once
+
+#include "mx/api/ApiCommon.h"
+#include "mx/api/ColorData.h"
+#include "mx/api/FontData.h"
+#include "mx/api/PositionData.h"
+
+#include <optional>
+#include <string>
+#include <variant>
+#include <vector>
+
+namespace mx
+{
+namespace api
+{
+// Glass percussion pictograms (MusicXML's <glass> element).
+enum class GlassInstrument
+{
+    glassHarmonica,
+    glassHarp,
+    windChimes
+};
+
+// Metal percussion pictograms (MusicXML's <metal> element).
+enum class MetalInstrument
+{
+    agogo,
+    almglocken,
+    bell,
+    bellPlate,
+    bellTree,
+    brakeDrum,
+    cencerro,
+    chainRattle,
+    chineseCymbal,
+    cowbell,
+    crashCymbals,
+    crotale,
+    cymbalTongs,
+    domedGong,
+    fingerCymbals,
+    flexatone,
+    gong,
+    hiHat,
+    highHatCymbals,
+    handbell,
+    jawHarp,
+    jingleBells,
+    musicalSaw,
+    shellBells,
+    sistrum,
+    sizzleCymbal,
+    sleighBells,
+    suspendedCymbal,
+    tamTam,
+    tamTamWithBeater,
+    triangle,
+    vietnameseHat
+};
+
+// Wood percussion pictograms (MusicXML's <wood> element).
+enum class WoodInstrument
+{
+    bambooScraper,
+    boardClapper,
+    cabasa,
+    castanets,
+    castanetsWithHandle,
+    claves,
+    footballRattle,
+    guiro,
+    logDrum,
+    maraca,
+    maracas,
+    quijada,
+    rainstick,
+    ratchet,
+    recoReco,
+    sandpaperBlocks,
+    slitDrum,
+    templeBlock,
+    vibraslap,
+    whip,
+    woodBlock
+};
+
+// Pitched percussion pictograms (MusicXML's <pitched> element).
+enum class PitchedInstrument
+{
+    celesta,
+    chimes,
+    glockenspiel,
+    lithophone,
+    mallet,
+    marimba,
+    steelDrums,
+    tubaphone,
+    tubularChimes,
+    vibraphone,
+    xylophone
+};
+
+// Membrane (drum) percussion pictograms (MusicXML's <membrane> element).
+enum class MembraneInstrument
+{
+    bassDrum,
+    bassDrumOnSide,
+    bongos,
+    chineseTomtom,
+    congaDrum,
+    cuica,
+    gobletDrum,
+    indoAmericanTomtom,
+    japaneseTomtom,
+    militaryDrum,
+    snareDrum,
+    snareDrumSnaresOff,
+    tabla,
+    tambourine,
+    tenorDrum,
+    timbales,
+    tomtom
+};
+
+// Effect percussion pictograms (MusicXML's <effect> element).
+enum class EffectInstrument
+{
+    anvil,
+    autoHorn,
+    birdWhistle,
+    cannon,
+    duckCall,
+    gunShot,
+    klaxonHorn,
+    lionsRoar,
+    lotusFlute,
+    megaphone,
+    policeWhistle,
+    siren,
+    slideWhistle,
+    thunderSheet,
+    windMachine,
+    windWhistle
+};
+
+// Beater pictograms for percussion notation (MusicXML's <beater> element).
+enum class BeaterValue
+{
+    bow,
+    chimeHammer,
+    coin,
+    drumStick,
+    finger,
+    fingernail,
+    fist,
+    guiroScraper,
+    hammer,
+    hand,
+    jazzStick,
+    knittingNeedle,
+    metalHammer,
+    slideBrushOnGong,
+    snareStick,
+    spoonMallet,
+    superball,
+    triangleBeater,
+    triangleBeaterPlain,
+    wireBrush
+};
+
+// The direction a beater or stick points in a percussion pictogram.
+enum class TipDirection
+{
+    unspecified,
+    up,
+    down,
+    left,
+    right,
+    northwest,
+    northeast,
+    southeast,
+    southwest
+};
+
+// Stick types for percussion pictograms (MusicXML's <stick-type> element).
+enum class StickType
+{
+    bassDrum,
+    doubleBassDrum,
+    glockenspiel,
+    gum,
+    hammer,
+    superball,
+    timpani,
+    wound,
+    xylophone,
+    yarn
+};
+
+// Stick materials for percussion pictograms (MusicXML's <stick-material> element).
+enum class StickMaterial
+{
+    soft,
+    medium,
+    hard,
+    shaded,
+    x
+};
+
+// Where a stick or beater strikes the instrument (MusicXML's <stick-location> element).
+enum class StickLocation
+{
+    center,
+    rim,
+    cymbalBell,
+    cymbalEdge
+};
+
+// A pictogram identified by its instrument family enum plus an optional SMuFL glyph override.
+// smufl, when present, names the exact SMuFL pictogram glyph to draw instead of the default
+// glyph for the value.
+struct GlassPercussion
+{
+    GlassInstrument value;
+    std::optional<std::string> smufl;
+
+    GlassPercussion() : value{GlassInstrument::glassHarmonica}, smufl{}
+    {
+    }
+};
+
+MXAPI_EQUALS_BEGIN(GlassPercussion)
+MXAPI_EQUALS_MEMBER(value)
+MXAPI_EQUALS_MEMBER(smufl)
+MXAPI_EQUALS_END;
+MXAPI_NOT_EQUALS_AND_VECTORS(GlassPercussion);
+
+struct MetalPercussion
+{
+    MetalInstrument value;
+    std::optional<std::string> smufl;
+
+    MetalPercussion() : value{MetalInstrument::agogo}, smufl{}
+    {
+    }
+};
+
+MXAPI_EQUALS_BEGIN(MetalPercussion)
+MXAPI_EQUALS_MEMBER(value)
+MXAPI_EQUALS_MEMBER(smufl)
+MXAPI_EQUALS_END;
+MXAPI_NOT_EQUALS_AND_VECTORS(MetalPercussion);
+
+struct WoodPercussion
+{
+    WoodInstrument value;
+    std::optional<std::string> smufl;
+
+    WoodPercussion() : value{WoodInstrument::bambooScraper}, smufl{}
+    {
+    }
+};
+
+MXAPI_EQUALS_BEGIN(WoodPercussion)
+MXAPI_EQUALS_MEMBER(value)
+MXAPI_EQUALS_MEMBER(smufl)
+MXAPI_EQUALS_END;
+MXAPI_NOT_EQUALS_AND_VECTORS(WoodPercussion);
+
+struct PitchedPercussion
+{
+    PitchedInstrument value;
+    std::optional<std::string> smufl;
+
+    PitchedPercussion() : value{PitchedInstrument::celesta}, smufl{}
+    {
+    }
+};
+
+MXAPI_EQUALS_BEGIN(PitchedPercussion)
+MXAPI_EQUALS_MEMBER(value)
+MXAPI_EQUALS_MEMBER(smufl)
+MXAPI_EQUALS_END;
+MXAPI_NOT_EQUALS_AND_VECTORS(PitchedPercussion);
+
+struct MembranePercussion
+{
+    MembraneInstrument value;
+    std::optional<std::string> smufl;
+
+    MembranePercussion() : value{MembraneInstrument::bassDrum}, smufl{}
+    {
+    }
+};
+
+MXAPI_EQUALS_BEGIN(MembranePercussion)
+MXAPI_EQUALS_MEMBER(value)
+MXAPI_EQUALS_MEMBER(smufl)
+MXAPI_EQUALS_END;
+MXAPI_NOT_EQUALS_AND_VECTORS(MembranePercussion);
+
+struct EffectPercussion
+{
+    EffectInstrument value;
+    std::optional<std::string> smufl;
+
+    EffectPercussion() : value{EffectInstrument::anvil}, smufl{}
+    {
+    }
+};
+
+MXAPI_EQUALS_BEGIN(EffectPercussion)
+MXAPI_EQUALS_MEMBER(value)
+MXAPI_EQUALS_MEMBER(smufl)
+MXAPI_EQUALS_END;
+MXAPI_NOT_EQUALS_AND_VECTORS(EffectPercussion);
+
+// The timpani pictogram (MusicXML's <timpani> element): an empty element, optionally overridden
+// with a specific SMuFL pictogram glyph.
+struct TimpaniPercussion
+{
+    std::optional<std::string> smufl;
+};
+
+MXAPI_EQUALS_BEGIN(TimpaniPercussion)
+MXAPI_EQUALS_MEMBER(smufl)
+MXAPI_EQUALS_END;
+MXAPI_NOT_EQUALS_AND_VECTORS(TimpaniPercussion);
+
+// A beater pictogram (MusicXML's <beater> element): what strikes the instrument, and which way
+// the tip points.
+struct BeaterPercussion
+{
+    BeaterValue value;
+    TipDirection tip;
+
+    BeaterPercussion() : value{BeaterValue::bow}, tip{TipDirection::unspecified}
+    {
+    }
+};
+
+MXAPI_EQUALS_BEGIN(BeaterPercussion)
+MXAPI_EQUALS_MEMBER(value)
+MXAPI_EQUALS_MEMBER(tip)
+MXAPI_EQUALS_END;
+MXAPI_NOT_EQUALS_AND_VECTORS(BeaterPercussion);
+
+// A stick pictogram (MusicXML's <stick> element): the stick's type and material, which way its
+// tip points, and whether the pictogram is shown in parentheses or a dashed circle (both used
+// for alternate or optional stickings).
+struct StickPercussion
+{
+    StickType stickType;
+    StickMaterial stickMaterial;
+    TipDirection tip;
+    Bool parentheses;
+    Bool dashedCircle;
+
+    StickPercussion()
+        : stickType{StickType::bassDrum}, stickMaterial{StickMaterial::soft}, tip{TipDirection::unspecified},
+          parentheses{Bool::unspecified}, dashedCircle{Bool::unspecified}
+    {
+    }
+};
+
+MXAPI_EQUALS_BEGIN(StickPercussion)
+MXAPI_EQUALS_MEMBER(stickType)
+MXAPI_EQUALS_MEMBER(stickMaterial)
+MXAPI_EQUALS_MEMBER(tip)
+MXAPI_EQUALS_MEMBER(parentheses)
+MXAPI_EQUALS_MEMBER(dashedCircle)
+MXAPI_EQUALS_END;
+MXAPI_NOT_EQUALS_AND_VECTORS(StickPercussion);
+
+// A percussion instrument or technique with no dedicated pictogram element, carried by
+// MusicXML's <other-percussion> catch-all: descriptive text plus an optional SMuFL glyph name.
+struct OtherPercussion
+{
+    std::string text;
+    std::optional<std::string> smufl;
+};
+
+MXAPI_EQUALS_BEGIN(OtherPercussion)
+MXAPI_EQUALS_MEMBER(text)
+MXAPI_EQUALS_MEMBER(smufl)
+MXAPI_EQUALS_END;
+MXAPI_NOT_EQUALS_AND_VECTORS(OtherPercussion);
+
+// The pictogram carried by one PercussionData: exactly one of the instrument-family or
+// beater/stick alternatives. Follows the TimeChoice/MarkDataChoice pattern: a wrong-kind
+// accessor returns a default-constructed copy, never throws.
+class PercussionDataChoice
+{
+  public:
+    enum class Kind
+    {
+        glass,
+        metal,
+        wood,
+        pitched,
+        membrane,
+        effect,
+        timpani,
+        beater,
+        stick,
+        stickLocation,
+        otherPercussion
+    };
+
+    // Defaults to a glass pictogram, the first alternative.
+    PercussionDataChoice();
+
+    PercussionDataChoice(GlassPercussion value);
+    PercussionDataChoice(MetalPercussion value);
+    PercussionDataChoice(WoodPercussion value);
+    PercussionDataChoice(PitchedPercussion value);
+    PercussionDataChoice(MembranePercussion value);
+    PercussionDataChoice(EffectPercussion value);
+    PercussionDataChoice(TimpaniPercussion value);
+    PercussionDataChoice(BeaterPercussion value);
+    PercussionDataChoice(StickPercussion value);
+    PercussionDataChoice(StickLocation value);
+    PercussionDataChoice(OtherPercussion value);
+
+    Kind kind() const;
+    bool isGlass() const;
+    bool isMetal() const;
+    bool isWood() const;
+    bool isPitched() const;
+    bool isMembrane() const;
+    bool isEffect() const;
+    bool isTimpani() const;
+    bool isBeater() const;
+    bool isStick() const;
+    bool isStickLocation() const;
+    bool isOtherPercussion() const;
+
+    // Each accessor returns a copy of the held alternative. Check the matching is...() first;
+    // a wrong-kind access returns a default-constructed value.
+    GlassPercussion glass() const;
+    MetalPercussion metal() const;
+    WoodPercussion wood() const;
+    PitchedPercussion pitched() const;
+    MembranePercussion membrane() const;
+    EffectPercussion effect() const;
+    TimpaniPercussion timpani() const;
+    BeaterPercussion beater() const;
+    StickPercussion stick() const;
+    StickLocation stickLocation() const;
+    OtherPercussion otherPercussion() const;
+
+    bool operator==(const PercussionDataChoice &other) const;
+
+  private:
+    std::variant<GlassPercussion, MetalPercussion, WoodPercussion, PitchedPercussion, MembranePercussion,
+                 EffectPercussion, TimpaniPercussion, BeaterPercussion, StickPercussion, StickLocation, OtherPercussion>
+        myValue;
+};
+
+MXAPI_NOT_EQUALS_AND_VECTORS(PercussionDataChoice);
+
+// How a percussion pictogram is enclosed, MusicXML's enclosure attribute on <percussion>.
+enum class PercussionEnclosure
+{
+    unspecified,
+    rectangle,
+    square,
+    oval,
+    circle,
+    bracket,
+    invertedBracket,
+    triangle,
+    diamond,
+    pentagon,
+    hexagon,
+    heptagon,
+    octagon,
+    nonagon,
+    decagon,
+    none
+};
+
+// A percussion pictogram, MusicXML's <percussion> element: a symbol for an unpitched instrument
+// or the implement striking it, used in percussion parts and legends. Several PercussionData in
+// one direction read as a group (for example a membrane pictogram followed by a beater).
+// positionData captures default/relative x-y plus the horizontal and vertical alignment; its
+// placement member is unused here because <percussion> has no placement attribute (placement
+// lives on the parent <direction>).
+class PercussionData
+{
+  public:
+    PercussionDataChoice choice;
+    PercussionEnclosure enclosure;
+    PositionData positionData;
+    FontData fontData;
+    std::optional<ColorData> color;
+    std::optional<std::string> id;
+
+    PercussionData() : choice{}, enclosure{PercussionEnclosure::unspecified}, positionData{}, fontData{}, color{}, id{}
+    {
+    }
+};
+
+MXAPI_EQUALS_BEGIN(PercussionData)
+MXAPI_EQUALS_MEMBER(choice)
+MXAPI_EQUALS_MEMBER(enclosure)
+MXAPI_EQUALS_MEMBER(positionData)
+MXAPI_EQUALS_MEMBER(fontData)
+MXAPI_EQUALS_MEMBER(color)
+MXAPI_EQUALS_MEMBER(id)
+MXAPI_EQUALS_END;
+MXAPI_NOT_EQUALS_AND_VECTORS(PercussionData);
+} // namespace api
+} // namespace mx

--- a/src/private/mx/api/PercussionData.cpp
+++ b/src/private/mx/api/PercussionData.cpp
@@ -1,0 +1,227 @@
+// MusicXML Class Library
+// Copyright (c) by Matthew James Briggs
+// Distributed under the MIT License
+
+#include "mx/api/PercussionData.h"
+
+#include <utility>
+
+namespace mx
+{
+namespace api
+{
+
+PercussionDataChoice::PercussionDataChoice() : myValue{GlassPercussion{}}
+{
+}
+
+PercussionDataChoice::PercussionDataChoice(GlassPercussion value) : myValue{std::move(value)}
+{
+}
+
+PercussionDataChoice::PercussionDataChoice(MetalPercussion value) : myValue{std::move(value)}
+{
+}
+
+PercussionDataChoice::PercussionDataChoice(WoodPercussion value) : myValue{std::move(value)}
+{
+}
+
+PercussionDataChoice::PercussionDataChoice(PitchedPercussion value) : myValue{std::move(value)}
+{
+}
+
+PercussionDataChoice::PercussionDataChoice(MembranePercussion value) : myValue{std::move(value)}
+{
+}
+
+PercussionDataChoice::PercussionDataChoice(EffectPercussion value) : myValue{std::move(value)}
+{
+}
+
+PercussionDataChoice::PercussionDataChoice(TimpaniPercussion value) : myValue{std::move(value)}
+{
+}
+
+PercussionDataChoice::PercussionDataChoice(BeaterPercussion value) : myValue{std::move(value)}
+{
+}
+
+PercussionDataChoice::PercussionDataChoice(StickPercussion value) : myValue{std::move(value)}
+{
+}
+
+PercussionDataChoice::PercussionDataChoice(StickLocation value) : myValue{std::move(value)}
+{
+}
+
+PercussionDataChoice::PercussionDataChoice(OtherPercussion value) : myValue{std::move(value)}
+{
+}
+
+PercussionDataChoice::Kind PercussionDataChoice::kind() const
+{
+    return static_cast<Kind>(myValue.index());
+}
+
+bool PercussionDataChoice::isGlass() const
+{
+    return std::holds_alternative<GlassPercussion>(myValue);
+}
+
+bool PercussionDataChoice::isMetal() const
+{
+    return std::holds_alternative<MetalPercussion>(myValue);
+}
+
+bool PercussionDataChoice::isWood() const
+{
+    return std::holds_alternative<WoodPercussion>(myValue);
+}
+
+bool PercussionDataChoice::isPitched() const
+{
+    return std::holds_alternative<PitchedPercussion>(myValue);
+}
+
+bool PercussionDataChoice::isMembrane() const
+{
+    return std::holds_alternative<MembranePercussion>(myValue);
+}
+
+bool PercussionDataChoice::isEffect() const
+{
+    return std::holds_alternative<EffectPercussion>(myValue);
+}
+
+bool PercussionDataChoice::isTimpani() const
+{
+    return std::holds_alternative<TimpaniPercussion>(myValue);
+}
+
+bool PercussionDataChoice::isBeater() const
+{
+    return std::holds_alternative<BeaterPercussion>(myValue);
+}
+
+bool PercussionDataChoice::isStick() const
+{
+    return std::holds_alternative<StickPercussion>(myValue);
+}
+
+bool PercussionDataChoice::isStickLocation() const
+{
+    return std::holds_alternative<StickLocation>(myValue);
+}
+
+bool PercussionDataChoice::isOtherPercussion() const
+{
+    return std::holds_alternative<OtherPercussion>(myValue);
+}
+
+GlassPercussion PercussionDataChoice::glass() const
+{
+    if (const auto *value = std::get_if<GlassPercussion>(&myValue))
+    {
+        return *value;
+    }
+    return GlassPercussion{};
+}
+
+MetalPercussion PercussionDataChoice::metal() const
+{
+    if (const auto *value = std::get_if<MetalPercussion>(&myValue))
+    {
+        return *value;
+    }
+    return MetalPercussion{};
+}
+
+WoodPercussion PercussionDataChoice::wood() const
+{
+    if (const auto *value = std::get_if<WoodPercussion>(&myValue))
+    {
+        return *value;
+    }
+    return WoodPercussion{};
+}
+
+PitchedPercussion PercussionDataChoice::pitched() const
+{
+    if (const auto *value = std::get_if<PitchedPercussion>(&myValue))
+    {
+        return *value;
+    }
+    return PitchedPercussion{};
+}
+
+MembranePercussion PercussionDataChoice::membrane() const
+{
+    if (const auto *value = std::get_if<MembranePercussion>(&myValue))
+    {
+        return *value;
+    }
+    return MembranePercussion{};
+}
+
+EffectPercussion PercussionDataChoice::effect() const
+{
+    if (const auto *value = std::get_if<EffectPercussion>(&myValue))
+    {
+        return *value;
+    }
+    return EffectPercussion{};
+}
+
+TimpaniPercussion PercussionDataChoice::timpani() const
+{
+    if (const auto *value = std::get_if<TimpaniPercussion>(&myValue))
+    {
+        return *value;
+    }
+    return TimpaniPercussion{};
+}
+
+BeaterPercussion PercussionDataChoice::beater() const
+{
+    if (const auto *value = std::get_if<BeaterPercussion>(&myValue))
+    {
+        return *value;
+    }
+    return BeaterPercussion{};
+}
+
+StickPercussion PercussionDataChoice::stick() const
+{
+    if (const auto *value = std::get_if<StickPercussion>(&myValue))
+    {
+        return *value;
+    }
+    return StickPercussion{};
+}
+
+StickLocation PercussionDataChoice::stickLocation() const
+{
+    if (const auto *value = std::get_if<StickLocation>(&myValue))
+    {
+        return *value;
+    }
+    return StickLocation{};
+}
+
+OtherPercussion PercussionDataChoice::otherPercussion() const
+{
+    if (const auto *value = std::get_if<OtherPercussion>(&myValue))
+    {
+        return *value;
+    }
+    return OtherPercussion{};
+}
+
+bool PercussionDataChoice::operator==(const PercussionDataChoice &other) const
+{
+    return myValue == other.myValue;
+}
+
+} // namespace api
+} // namespace mx

--- a/src/private/mx/impl/Converter.cpp
+++ b/src/private/mx/impl/Converter.cpp
@@ -1388,6 +1388,204 @@ const Converter::EnumMap<core::TimeRelation, api::TimeRelation> Converter::timeR
     {core::TimeRelation::hyphen(), api::TimeRelation::hyphen},
 };
 
+const Converter::EnumMap<core::GlassValue, api::GlassInstrument> Converter::glassMap = {
+    {core::GlassValue::glassHarmonica(), api::GlassInstrument::glassHarmonica},
+    {core::GlassValue::glassHarp(), api::GlassInstrument::glassHarp},
+    {core::GlassValue::windChimes(), api::GlassInstrument::windChimes},
+};
+
+const Converter::EnumMap<core::MetalValue, api::MetalInstrument> Converter::metalMap = {
+    {core::MetalValue::agogo(), api::MetalInstrument::agogo},
+    {core::MetalValue::almglocken(), api::MetalInstrument::almglocken},
+    {core::MetalValue::bell(), api::MetalInstrument::bell},
+    {core::MetalValue::bellPlate(), api::MetalInstrument::bellPlate},
+    {core::MetalValue::bellTree(), api::MetalInstrument::bellTree},
+    {core::MetalValue::brakeDrum(), api::MetalInstrument::brakeDrum},
+    {core::MetalValue::cencerro(), api::MetalInstrument::cencerro},
+    {core::MetalValue::chainRattle(), api::MetalInstrument::chainRattle},
+    {core::MetalValue::chineseCymbal(), api::MetalInstrument::chineseCymbal},
+    {core::MetalValue::cowbell(), api::MetalInstrument::cowbell},
+    {core::MetalValue::crashCymbals(), api::MetalInstrument::crashCymbals},
+    {core::MetalValue::crotale(), api::MetalInstrument::crotale},
+    {core::MetalValue::cymbalTongs(), api::MetalInstrument::cymbalTongs},
+    {core::MetalValue::domedGong(), api::MetalInstrument::domedGong},
+    {core::MetalValue::fingerCymbals(), api::MetalInstrument::fingerCymbals},
+    {core::MetalValue::flexatone(), api::MetalInstrument::flexatone},
+    {core::MetalValue::gong(), api::MetalInstrument::gong},
+    {core::MetalValue::hiHat(), api::MetalInstrument::hiHat},
+    {core::MetalValue::highHatCymbals(), api::MetalInstrument::highHatCymbals},
+    {core::MetalValue::handbell(), api::MetalInstrument::handbell},
+    {core::MetalValue::jawHarp(), api::MetalInstrument::jawHarp},
+    {core::MetalValue::jingleBells(), api::MetalInstrument::jingleBells},
+    {core::MetalValue::musicalSaw(), api::MetalInstrument::musicalSaw},
+    {core::MetalValue::shellBells(), api::MetalInstrument::shellBells},
+    {core::MetalValue::sistrum(), api::MetalInstrument::sistrum},
+    {core::MetalValue::sizzleCymbal(), api::MetalInstrument::sizzleCymbal},
+    {core::MetalValue::sleighBells(), api::MetalInstrument::sleighBells},
+    {core::MetalValue::suspendedCymbal(), api::MetalInstrument::suspendedCymbal},
+    {core::MetalValue::tamTam(), api::MetalInstrument::tamTam},
+    {core::MetalValue::tamTamWithBeater(), api::MetalInstrument::tamTamWithBeater},
+    {core::MetalValue::triangle(), api::MetalInstrument::triangle},
+    {core::MetalValue::vietnameseHat(), api::MetalInstrument::vietnameseHat},
+};
+
+const Converter::EnumMap<core::WoodValue, api::WoodInstrument> Converter::woodMap = {
+    {core::WoodValue::bambooScraper(), api::WoodInstrument::bambooScraper},
+    {core::WoodValue::boardClapper(), api::WoodInstrument::boardClapper},
+    {core::WoodValue::cabasa(), api::WoodInstrument::cabasa},
+    {core::WoodValue::castanets(), api::WoodInstrument::castanets},
+    {core::WoodValue::castanetsWithHandle(), api::WoodInstrument::castanetsWithHandle},
+    {core::WoodValue::claves(), api::WoodInstrument::claves},
+    {core::WoodValue::footballRattle(), api::WoodInstrument::footballRattle},
+    {core::WoodValue::guiro(), api::WoodInstrument::guiro},
+    {core::WoodValue::logDrum(), api::WoodInstrument::logDrum},
+    {core::WoodValue::maraca(), api::WoodInstrument::maraca},
+    {core::WoodValue::maracas(), api::WoodInstrument::maracas},
+    {core::WoodValue::quijada(), api::WoodInstrument::quijada},
+    {core::WoodValue::rainstick(), api::WoodInstrument::rainstick},
+    {core::WoodValue::ratchet(), api::WoodInstrument::ratchet},
+    {core::WoodValue::recoReco(), api::WoodInstrument::recoReco},
+    {core::WoodValue::sandpaperBlocks(), api::WoodInstrument::sandpaperBlocks},
+    {core::WoodValue::slitDrum(), api::WoodInstrument::slitDrum},
+    {core::WoodValue::templeBlock(), api::WoodInstrument::templeBlock},
+    {core::WoodValue::vibraslap(), api::WoodInstrument::vibraslap},
+    {core::WoodValue::whip(), api::WoodInstrument::whip},
+    {core::WoodValue::woodBlock(), api::WoodInstrument::woodBlock},
+};
+
+const Converter::EnumMap<core::PitchedValue, api::PitchedInstrument> Converter::pitchedMap = {
+    {core::PitchedValue::celesta(), api::PitchedInstrument::celesta},
+    {core::PitchedValue::chimes(), api::PitchedInstrument::chimes},
+    {core::PitchedValue::glockenspiel(), api::PitchedInstrument::glockenspiel},
+    {core::PitchedValue::lithophone(), api::PitchedInstrument::lithophone},
+    {core::PitchedValue::mallet(), api::PitchedInstrument::mallet},
+    {core::PitchedValue::marimba(), api::PitchedInstrument::marimba},
+    {core::PitchedValue::steelDrums(), api::PitchedInstrument::steelDrums},
+    {core::PitchedValue::tubaphone(), api::PitchedInstrument::tubaphone},
+    {core::PitchedValue::tubularChimes(), api::PitchedInstrument::tubularChimes},
+    {core::PitchedValue::vibraphone(), api::PitchedInstrument::vibraphone},
+    {core::PitchedValue::xylophone(), api::PitchedInstrument::xylophone},
+};
+
+const Converter::EnumMap<core::MembraneValue, api::MembraneInstrument> Converter::membraneMap = {
+    {core::MembraneValue::bassDrum(), api::MembraneInstrument::bassDrum},
+    {core::MembraneValue::bassDrumOnSide(), api::MembraneInstrument::bassDrumOnSide},
+    {core::MembraneValue::bongos(), api::MembraneInstrument::bongos},
+    {core::MembraneValue::chineseTomtom(), api::MembraneInstrument::chineseTomtom},
+    {core::MembraneValue::congaDrum(), api::MembraneInstrument::congaDrum},
+    {core::MembraneValue::cuica(), api::MembraneInstrument::cuica},
+    {core::MembraneValue::gobletDrum(), api::MembraneInstrument::gobletDrum},
+    {core::MembraneValue::indoAmericanTomtom(), api::MembraneInstrument::indoAmericanTomtom},
+    {core::MembraneValue::japaneseTomtom(), api::MembraneInstrument::japaneseTomtom},
+    {core::MembraneValue::militaryDrum(), api::MembraneInstrument::militaryDrum},
+    {core::MembraneValue::snareDrum(), api::MembraneInstrument::snareDrum},
+    {core::MembraneValue::snareDrumSnaresOff(), api::MembraneInstrument::snareDrumSnaresOff},
+    {core::MembraneValue::tabla(), api::MembraneInstrument::tabla},
+    {core::MembraneValue::tambourine(), api::MembraneInstrument::tambourine},
+    {core::MembraneValue::tenorDrum(), api::MembraneInstrument::tenorDrum},
+    {core::MembraneValue::timbales(), api::MembraneInstrument::timbales},
+    {core::MembraneValue::tomtom(), api::MembraneInstrument::tomtom},
+};
+
+const Converter::EnumMap<core::EffectValue, api::EffectInstrument> Converter::effectMap = {
+    {core::EffectValue::anvil(), api::EffectInstrument::anvil},
+    {core::EffectValue::autoHorn(), api::EffectInstrument::autoHorn},
+    {core::EffectValue::birdWhistle(), api::EffectInstrument::birdWhistle},
+    {core::EffectValue::cannon(), api::EffectInstrument::cannon},
+    {core::EffectValue::duckCall(), api::EffectInstrument::duckCall},
+    {core::EffectValue::gunShot(), api::EffectInstrument::gunShot},
+    {core::EffectValue::klaxonHorn(), api::EffectInstrument::klaxonHorn},
+    {core::EffectValue::lionsRoar(), api::EffectInstrument::lionsRoar},
+    {core::EffectValue::lotusFlute(), api::EffectInstrument::lotusFlute},
+    {core::EffectValue::megaphone(), api::EffectInstrument::megaphone},
+    {core::EffectValue::policeWhistle(), api::EffectInstrument::policeWhistle},
+    {core::EffectValue::siren(), api::EffectInstrument::siren},
+    {core::EffectValue::slideWhistle(), api::EffectInstrument::slideWhistle},
+    {core::EffectValue::thunderSheet(), api::EffectInstrument::thunderSheet},
+    {core::EffectValue::windMachine(), api::EffectInstrument::windMachine},
+    {core::EffectValue::windWhistle(), api::EffectInstrument::windWhistle},
+};
+
+const Converter::EnumMap<core::BeaterValue, api::BeaterValue> Converter::beaterMap = {
+    {core::BeaterValue::bow(), api::BeaterValue::bow},
+    {core::BeaterValue::chimeHammer(), api::BeaterValue::chimeHammer},
+    {core::BeaterValue::coin(), api::BeaterValue::coin},
+    {core::BeaterValue::drumStick(), api::BeaterValue::drumStick},
+    {core::BeaterValue::finger(), api::BeaterValue::finger},
+    {core::BeaterValue::fingernail(), api::BeaterValue::fingernail},
+    {core::BeaterValue::fist(), api::BeaterValue::fist},
+    {core::BeaterValue::guiroScraper(), api::BeaterValue::guiroScraper},
+    {core::BeaterValue::hammer(), api::BeaterValue::hammer},
+    {core::BeaterValue::hand(), api::BeaterValue::hand},
+    {core::BeaterValue::jazzStick(), api::BeaterValue::jazzStick},
+    {core::BeaterValue::knittingNeedle(), api::BeaterValue::knittingNeedle},
+    {core::BeaterValue::metalHammer(), api::BeaterValue::metalHammer},
+    {core::BeaterValue::slideBrushOnGong(), api::BeaterValue::slideBrushOnGong},
+    {core::BeaterValue::snareStick(), api::BeaterValue::snareStick},
+    {core::BeaterValue::spoonMallet(), api::BeaterValue::spoonMallet},
+    {core::BeaterValue::superball(), api::BeaterValue::superball},
+    {core::BeaterValue::triangleBeater(), api::BeaterValue::triangleBeater},
+    {core::BeaterValue::triangleBeaterPlain(), api::BeaterValue::triangleBeaterPlain},
+    {core::BeaterValue::wireBrush(), api::BeaterValue::wireBrush},
+};
+
+const Converter::EnumMap<core::StickType, api::StickType> Converter::stickTypeMap = {
+    {core::StickType::bassDrum(), api::StickType::bassDrum},
+    {core::StickType::doubleBassDrum(), api::StickType::doubleBassDrum},
+    {core::StickType::glockenspiel(), api::StickType::glockenspiel},
+    {core::StickType::gum(), api::StickType::gum},
+    {core::StickType::hammer(), api::StickType::hammer},
+    {core::StickType::superball(), api::StickType::superball},
+    {core::StickType::timpani(), api::StickType::timpani},
+    {core::StickType::wound(), api::StickType::wound},
+    {core::StickType::xylophone(), api::StickType::xylophone},
+    {core::StickType::yarn(), api::StickType::yarn},
+};
+
+const Converter::EnumMap<core::StickMaterial, api::StickMaterial> Converter::stickMaterialMap = {
+    {core::StickMaterial::soft(), api::StickMaterial::soft},
+    {core::StickMaterial::medium(), api::StickMaterial::medium},
+    {core::StickMaterial::hard(), api::StickMaterial::hard},
+    {core::StickMaterial::shaded(), api::StickMaterial::shaded},
+    {core::StickMaterial::x(), api::StickMaterial::x},
+};
+
+const Converter::EnumMap<core::StickLocation, api::StickLocation> Converter::stickLocationMap = {
+    {core::StickLocation::center(), api::StickLocation::center},
+    {core::StickLocation::rim(), api::StickLocation::rim},
+    {core::StickLocation::cymbalBell(), api::StickLocation::cymbalBell},
+    {core::StickLocation::cymbalEdge(), api::StickLocation::cymbalEdge},
+};
+
+const Converter::EnumMap<core::TipDirection, api::TipDirection> Converter::tipDirectionMap = {
+    {core::TipDirection::up(), api::TipDirection::up},
+    {core::TipDirection::down(), api::TipDirection::down},
+    {core::TipDirection::left(), api::TipDirection::left},
+    {core::TipDirection::right(), api::TipDirection::right},
+    {core::TipDirection::northwest(), api::TipDirection::northwest},
+    {core::TipDirection::northeast(), api::TipDirection::northeast},
+    {core::TipDirection::southeast(), api::TipDirection::southeast},
+    {core::TipDirection::southwest(), api::TipDirection::southwest},
+};
+
+const Converter::EnumMap<core::EnclosureShape, api::PercussionEnclosure> Converter::percussionEnclosureMap = {
+    {core::EnclosureShape::rectangle(), api::PercussionEnclosure::rectangle},
+    {core::EnclosureShape::square(), api::PercussionEnclosure::square},
+    {core::EnclosureShape::oval(), api::PercussionEnclosure::oval},
+    {core::EnclosureShape::circle(), api::PercussionEnclosure::circle},
+    {core::EnclosureShape::bracket(), api::PercussionEnclosure::bracket},
+    {core::EnclosureShape::invertedBracket(), api::PercussionEnclosure::invertedBracket},
+    {core::EnclosureShape::triangle(), api::PercussionEnclosure::triangle},
+    {core::EnclosureShape::diamond(), api::PercussionEnclosure::diamond},
+    {core::EnclosureShape::pentagon(), api::PercussionEnclosure::pentagon},
+    {core::EnclosureShape::hexagon(), api::PercussionEnclosure::hexagon},
+    {core::EnclosureShape::heptagon(), api::PercussionEnclosure::heptagon},
+    {core::EnclosureShape::octagon(), api::PercussionEnclosure::octagon},
+    {core::EnclosureShape::nonagon(), api::PercussionEnclosure::nonagon},
+    {core::EnclosureShape::decagon(), api::PercussionEnclosure::decagon},
+    {core::EnclosureShape::none(), api::PercussionEnclosure::none},
+};
+
 api::Step Converter::convert(core::Step inStep) const
 {
     return findApiItem(stepMap, api::Step::c, inStep);
@@ -1752,6 +1950,126 @@ core::TimeRelation Converter::convert(api::TimeRelation value) const
 api::TimeRelation Converter::convert(core::TimeRelation value) const
 {
     return findApiItem(timeRelationMap, api::TimeRelation::unspecified, value);
+}
+
+api::GlassInstrument Converter::convert(core::GlassValue value) const
+{
+    return findApiItem(glassMap, api::GlassInstrument::glassHarmonica, value);
+}
+
+core::GlassValue Converter::convert(api::GlassInstrument value) const
+{
+    return findCoreItem(glassMap, core::GlassValue::glassHarmonica(), value);
+}
+
+api::MetalInstrument Converter::convert(core::MetalValue value) const
+{
+    return findApiItem(metalMap, api::MetalInstrument::agogo, value);
+}
+
+core::MetalValue Converter::convert(api::MetalInstrument value) const
+{
+    return findCoreItem(metalMap, core::MetalValue::agogo(), value);
+}
+
+api::WoodInstrument Converter::convert(core::WoodValue value) const
+{
+    return findApiItem(woodMap, api::WoodInstrument::bambooScraper, value);
+}
+
+core::WoodValue Converter::convert(api::WoodInstrument value) const
+{
+    return findCoreItem(woodMap, core::WoodValue::bambooScraper(), value);
+}
+
+api::PitchedInstrument Converter::convert(core::PitchedValue value) const
+{
+    return findApiItem(pitchedMap, api::PitchedInstrument::celesta, value);
+}
+
+core::PitchedValue Converter::convert(api::PitchedInstrument value) const
+{
+    return findCoreItem(pitchedMap, core::PitchedValue::celesta(), value);
+}
+
+api::MembraneInstrument Converter::convert(core::MembraneValue value) const
+{
+    return findApiItem(membraneMap, api::MembraneInstrument::bassDrum, value);
+}
+
+core::MembraneValue Converter::convert(api::MembraneInstrument value) const
+{
+    return findCoreItem(membraneMap, core::MembraneValue::bassDrum(), value);
+}
+
+api::EffectInstrument Converter::convert(core::EffectValue value) const
+{
+    return findApiItem(effectMap, api::EffectInstrument::anvil, value);
+}
+
+core::EffectValue Converter::convert(api::EffectInstrument value) const
+{
+    return findCoreItem(effectMap, core::EffectValue::anvil(), value);
+}
+
+api::BeaterValue Converter::convert(core::BeaterValue value) const
+{
+    return findApiItem(beaterMap, api::BeaterValue::bow, value);
+}
+
+core::BeaterValue Converter::convert(api::BeaterValue value) const
+{
+    return findCoreItem(beaterMap, core::BeaterValue::bow(), value);
+}
+
+api::StickType Converter::convert(core::StickType value) const
+{
+    return findApiItem(stickTypeMap, api::StickType::bassDrum, value);
+}
+
+core::StickType Converter::convert(api::StickType value) const
+{
+    return findCoreItem(stickTypeMap, core::StickType::bassDrum(), value);
+}
+
+api::StickMaterial Converter::convert(core::StickMaterial value) const
+{
+    return findApiItem(stickMaterialMap, api::StickMaterial::soft, value);
+}
+
+core::StickMaterial Converter::convert(api::StickMaterial value) const
+{
+    return findCoreItem(stickMaterialMap, core::StickMaterial::soft(), value);
+}
+
+api::StickLocation Converter::convert(core::StickLocation value) const
+{
+    return findApiItem(stickLocationMap, api::StickLocation::center, value);
+}
+
+core::StickLocation Converter::convert(api::StickLocation value) const
+{
+    return findCoreItem(stickLocationMap, core::StickLocation::center(), value);
+}
+
+api::TipDirection Converter::convert(core::TipDirection value) const
+{
+    return findApiItem(tipDirectionMap, api::TipDirection::unspecified, value);
+}
+
+core::TipDirection Converter::convert(api::TipDirection value) const
+{
+    return findCoreItem(tipDirectionMap, core::TipDirection::up(), value);
+}
+
+api::PercussionEnclosure Converter::convert(core::EnclosureShape value) const
+{
+    return findApiItem(percussionEnclosureMap, api::PercussionEnclosure::unspecified, value);
+}
+
+core::EnclosureShape Converter::convert(api::PercussionEnclosure value) const
+{
+    return findCoreItem(percussionEnclosureMap, core::EnclosureShape::none(), value);
 }
 
 double Converter::convertToAlter(int semitones, double cents)

--- a/src/private/mx/impl/Converter.h
+++ b/src/private/mx/impl/Converter.h
@@ -9,6 +9,7 @@
 #include "mx/api/KeyData.h"
 #include "mx/api/MarkData.h"
 #include "mx/api/NoteData.h"
+#include "mx/api/PercussionData.h"
 #include "mx/api/PositionData.h"
 #include "mx/api/ScoreData.h"
 #include "mx/api/SoundID.h"
@@ -17,13 +18,17 @@
 #include "mx/core/generated/ArticulationsChoice.h"
 #include "mx/core/generated/BarStyle.h"
 #include "mx/core/generated/BeamValue.h"
+#include "mx/core/generated/BeaterValue.h"
 #include "mx/core/generated/CSSFontSize.h"
 #include "mx/core/generated/CancelLocation.h"
 #include "mx/core/generated/ClefSign.h"
 #include "mx/core/generated/DynamicsChoice.h"
+#include "mx/core/generated/EffectValue.h"
+#include "mx/core/generated/EnclosureShape.h"
 #include "mx/core/generated/FermataShape.h"
 #include "mx/core/generated/FontStyle.h"
 #include "mx/core/generated/FontWeight.h"
+#include "mx/core/generated/GlassValue.h"
 #include "mx/core/generated/GroupBarlineValue.h"
 #include "mx/core/generated/GroupSymbolValue.h"
 #include "mx/core/generated/KindValue.h"
@@ -31,22 +36,30 @@
 #include "mx/core/generated/LineEnd.h"
 #include "mx/core/generated/LineType.h"
 #include "mx/core/generated/MeasureNumberingValue.h"
+#include "mx/core/generated/MembraneValue.h"
+#include "mx/core/generated/MetalValue.h"
 #include "mx/core/generated/NoteTypeValue.h"
 #include "mx/core/generated/NoteheadValue.h"
 #include "mx/core/generated/OrnamentsGroupChoice.h"
+#include "mx/core/generated/PitchedValue.h"
 #include "mx/core/generated/RightLeftMiddle.h"
 #include "mx/core/generated/SoundID.h"
 #include "mx/core/generated/StartStopDiscontinue.h"
 #include "mx/core/generated/StemValue.h"
 #include "mx/core/generated/Step.h"
+#include "mx/core/generated/StickLocation.h"
+#include "mx/core/generated/StickMaterial.h"
+#include "mx/core/generated/StickType.h"
 #include "mx/core/generated/SystemRelationNumber.h"
 #include "mx/core/generated/TechnicalChoice.h"
 #include "mx/core/generated/TimeRelation.h"
 #include "mx/core/generated/TimeSeparator.h"
 #include "mx/core/generated/TimeSymbol.h"
+#include "mx/core/generated/TipDirection.h"
 #include "mx/core/generated/Transpose.h"
 #include "mx/core/generated/Valign.h"
 #include "mx/core/generated/WedgeType.h"
+#include "mx/core/generated/WoodValue.h"
 #include "mx/core/generated/YesNo.h"
 
 #include <algorithm>
@@ -184,6 +197,31 @@ class Converter
     core::TimeRelation convert(api::TimeRelation value) const;
     api::TimeRelation convert(core::TimeRelation value) const;
 
+    api::GlassInstrument convert(core::GlassValue value) const;
+    core::GlassValue convert(api::GlassInstrument value) const;
+    api::MetalInstrument convert(core::MetalValue value) const;
+    core::MetalValue convert(api::MetalInstrument value) const;
+    api::WoodInstrument convert(core::WoodValue value) const;
+    core::WoodValue convert(api::WoodInstrument value) const;
+    api::PitchedInstrument convert(core::PitchedValue value) const;
+    core::PitchedValue convert(api::PitchedInstrument value) const;
+    api::MembraneInstrument convert(core::MembraneValue value) const;
+    core::MembraneValue convert(api::MembraneInstrument value) const;
+    api::EffectInstrument convert(core::EffectValue value) const;
+    core::EffectValue convert(api::EffectInstrument value) const;
+    api::BeaterValue convert(core::BeaterValue value) const;
+    core::BeaterValue convert(api::BeaterValue value) const;
+    api::StickType convert(core::StickType value) const;
+    core::StickType convert(api::StickType value) const;
+    api::StickMaterial convert(core::StickMaterial value) const;
+    core::StickMaterial convert(api::StickMaterial value) const;
+    api::StickLocation convert(core::StickLocation value) const;
+    core::StickLocation convert(api::StickLocation value) const;
+    api::TipDirection convert(core::TipDirection value) const;
+    core::TipDirection convert(api::TipDirection value) const;
+    api::PercussionEnclosure convert(core::EnclosureShape value) const;
+    core::EnclosureShape convert(api::PercussionEnclosure value) const;
+
     static double convertToAlter(int semitones, double cents);
     static std::pair<int, double> convertToSemitonesAndCents(double alter);
 
@@ -227,6 +265,18 @@ class Converter
     const static EnumMap<core::TimeSymbol, api::ComplexTimeSymbol> complexTimeSymbolMap;
     const static EnumMap<core::TimeSeparator, api::TimeSeparator> timeSeparatorMap;
     const static EnumMap<core::TimeRelation, api::TimeRelation> timeRelationMap;
+    const static EnumMap<core::GlassValue, api::GlassInstrument> glassMap;
+    const static EnumMap<core::MetalValue, api::MetalInstrument> metalMap;
+    const static EnumMap<core::WoodValue, api::WoodInstrument> woodMap;
+    const static EnumMap<core::PitchedValue, api::PitchedInstrument> pitchedMap;
+    const static EnumMap<core::MembraneValue, api::MembraneInstrument> membraneMap;
+    const static EnumMap<core::EffectValue, api::EffectInstrument> effectMap;
+    const static EnumMap<core::BeaterValue, api::BeaterValue> beaterMap;
+    const static EnumMap<core::StickType, api::StickType> stickTypeMap;
+    const static EnumMap<core::StickMaterial, api::StickMaterial> stickMaterialMap;
+    const static EnumMap<core::StickLocation, api::StickLocation> stickLocationMap;
+    const static EnumMap<core::TipDirection, api::TipDirection> tipDirectionMap;
+    const static EnumMap<core::EnclosureShape, api::PercussionEnclosure> percussionEnclosureMap;
 
   private:
     template <typename CORE_TYPE, typename API_TYPE>

--- a/src/private/mx/impl/DirectionReader.cpp
+++ b/src/private/mx/impl/DirectionReader.cpp
@@ -9,6 +9,7 @@
 #include "mx/core/generated/Barre.h"
 #include "mx/core/generated/Bass.h"
 #include "mx/core/generated/BassStep.h"
+#include "mx/core/generated/Beater.h"
 #include "mx/core/generated/Bracket.h"
 #include "mx/core/generated/Coda.h"
 #include "mx/core/generated/Dashes.h"
@@ -21,12 +22,14 @@
 #include "mx/core/generated/DirectionType.h"
 #include "mx/core/generated/DirectionTypeChoice.h"
 #include "mx/core/generated/Dynamics.h"
+#include "mx/core/generated/Effect.h"
 #include "mx/core/generated/EmptyPrintStyleAlignID.h"
 #include "mx/core/generated/Fingering.h"
 #include "mx/core/generated/FirstFret.h"
 #include "mx/core/generated/Frame.h"
 #include "mx/core/generated/FrameNote.h"
 #include "mx/core/generated/Fret.h"
+#include "mx/core/generated/Glass.h"
 #include "mx/core/generated/HarmonyAlter.h"
 #include "mx/core/generated/HarmonyChordGroup.h"
 #include "mx/core/generated/HarmonyChordGroupChoice.h"
@@ -35,6 +38,8 @@
 #include "mx/core/generated/Inversion.h"
 #include "mx/core/generated/Kind.h"
 #include "mx/core/generated/KindValue.h"
+#include "mx/core/generated/Membrane.h"
+#include "mx/core/generated/Metal.h"
 #include "mx/core/generated/Metronome.h"
 #include "mx/core/generated/Numeral.h"
 #include "mx/core/generated/NumeralKey.h"
@@ -46,10 +51,13 @@
 #include "mx/core/generated/Offset.h"
 #include "mx/core/generated/OnOff.h"
 #include "mx/core/generated/OtherDirection.h"
+#include "mx/core/generated/OtherText.h"
 #include "mx/core/generated/Pedal.h"
 #include "mx/core/generated/PedalTuning.h"
 #include "mx/core/generated/PedalType.h"
 #include "mx/core/generated/Percussion.h"
+#include "mx/core/generated/PercussionChoice.h"
+#include "mx/core/generated/Pitched.h"
 #include "mx/core/generated/PrincipalVoice.h"
 #include "mx/core/generated/PrincipalVoiceSymbol.h"
 #include "mx/core/generated/Root.h"
@@ -63,10 +71,12 @@
 #include "mx/core/generated/StartStop.h"
 #include "mx/core/generated/StartStopContinue.h"
 #include "mx/core/generated/Step.h"
+#include "mx/core/generated/Stick.h"
 #include "mx/core/generated/String.h"
 #include "mx/core/generated/StringMute.h"
 #include "mx/core/generated/StringNumber.h"
 #include "mx/core/generated/StyleText.h"
+#include "mx/core/generated/Timpani.h"
 #include "mx/core/generated/TuningGroup.h"
 #include "mx/core/generated/UpDownStopContinue.h"
 #include "mx/core/generated/ValignImage.h"
@@ -1109,14 +1119,141 @@ void DirectionReader::parseAccordionRegistration(const core::DirectionType &dire
                            static_cast<int>(myOutDirectionData.accordionRegistrations.size()) - 1);
 }
 
-// The percussion stub below is the last genuinely unmodeled direction-type choice, tracked at
-// #324, not a bug in the surrounding dispatch. When a <direction> contains only percussion
-// content, the resulting DirectionData carries no content and is correctly left unwritten --
-// MusicXML requires at least one direction-type child, so there is no schema-valid way to
-// keep the <direction> (and its <voice>/<staff>) without modeling what it actually says.
+api::PercussionDataChoice DirectionReader::getPercussionChoice(const core::PercussionChoice &choice) const
+{
+    using K = core::PercussionChoice::Kind;
+    switch (choice.kind())
+    {
+    case K::glass: {
+        api::GlassPercussion glass;
+        glass.value = myConverter.convert(choice.asGlass().value());
+        if (choice.asGlass().smufl().has_value())
+        {
+            glass.smufl = choice.asGlass().smufl()->toString();
+        }
+        return api::PercussionDataChoice{glass};
+    }
+    case K::metal: {
+        api::MetalPercussion metal;
+        metal.value = myConverter.convert(choice.asMetal().value());
+        if (choice.asMetal().smufl().has_value())
+        {
+            metal.smufl = choice.asMetal().smufl()->toString();
+        }
+        return api::PercussionDataChoice{metal};
+    }
+    case K::wood: {
+        api::WoodPercussion wood;
+        wood.value = myConverter.convert(choice.asWood().value());
+        if (choice.asWood().smufl().has_value())
+        {
+            wood.smufl = choice.asWood().smufl()->toString();
+        }
+        return api::PercussionDataChoice{wood};
+    }
+    case K::pitched: {
+        api::PitchedPercussion pitched;
+        pitched.value = myConverter.convert(choice.asPitched().value());
+        if (choice.asPitched().smufl().has_value())
+        {
+            pitched.smufl = choice.asPitched().smufl()->toString();
+        }
+        return api::PercussionDataChoice{pitched};
+    }
+    case K::membrane: {
+        api::MembranePercussion membrane;
+        membrane.value = myConverter.convert(choice.asMembrane().value());
+        if (choice.asMembrane().smufl().has_value())
+        {
+            membrane.smufl = choice.asMembrane().smufl()->toString();
+        }
+        return api::PercussionDataChoice{membrane};
+    }
+    case K::effect: {
+        api::EffectPercussion effect;
+        effect.value = myConverter.convert(choice.asEffect().value());
+        if (choice.asEffect().smufl().has_value())
+        {
+            effect.smufl = choice.asEffect().smufl()->toString();
+        }
+        return api::PercussionDataChoice{effect};
+    }
+    case K::timpani: {
+        api::TimpaniPercussion timpani;
+        if (choice.asTimpani().smufl().has_value())
+        {
+            timpani.smufl = choice.asTimpani().smufl()->toString();
+        }
+        return api::PercussionDataChoice{timpani};
+    }
+    case K::beater: {
+        api::BeaterPercussion beater;
+        beater.value = myConverter.convert(choice.asBeater().value());
+        if (choice.asBeater().tip().has_value())
+        {
+            beater.tip = myConverter.convert(*choice.asBeater().tip());
+        }
+        return api::PercussionDataChoice{beater};
+    }
+    case K::stick: {
+        api::StickPercussion stick;
+        stick.stickType = myConverter.convert(choice.asStick().stickType());
+        stick.stickMaterial = myConverter.convert(choice.asStick().stickMaterial());
+        if (choice.asStick().tip().has_value())
+        {
+            stick.tip = myConverter.convert(*choice.asStick().tip());
+        }
+        if (choice.asStick().parentheses().has_value())
+        {
+            stick.parentheses = myConverter.convert(*choice.asStick().parentheses());
+        }
+        if (choice.asStick().dashedCircle().has_value())
+        {
+            stick.dashedCircle = myConverter.convert(*choice.asStick().dashedCircle());
+        }
+        return api::PercussionDataChoice{stick};
+    }
+    case K::stickLocation: {
+        return api::PercussionDataChoice{myConverter.convert(choice.asStickLocation())};
+    }
+    case K::otherPercussion:
+    default: {
+        api::OtherPercussion other;
+        other.text = choice.asOtherPercussion().value();
+        if (choice.asOtherPercussion().smufl().has_value())
+        {
+            other.smufl = choice.asOtherPercussion().smufl()->toString();
+        }
+        return api::PercussionDataChoice{other};
+    }
+    }
+}
+
 void DirectionReader::parsePercussion(const core::DirectionType &directionType)
 {
-    MX_UNUSED(directionType);
+    const auto &percussionSet = directionType.choice().asPercussion();
+    for (const auto &percussion : percussionSet.items())
+    {
+        api::PercussionData outPercussion;
+        outPercussion.choice = getPercussionChoice(percussion.choice());
+        if (percussion.enclosure().has_value())
+        {
+            outPercussion.enclosure = myConverter.convert(*percussion.enclosure());
+        }
+        outPercussion.positionData = getPositionData(percussion);
+        outPercussion.fontData = getFontData(percussion);
+        if (percussion.color().has_value())
+        {
+            outPercussion.color = getColor(percussion);
+        }
+        if (percussion.id().has_value())
+        {
+            outPercussion.id = percussion.id()->value();
+        }
+        myOutDirectionData.percussions.emplace_back(std::move(outPercussion));
+        appendOrderedComponent(api::DirectionComponentKind::percussion,
+                               static_cast<int>(myOutDirectionData.percussions.size()) - 1);
+    }
 }
 
 void DirectionReader::parseOtherDirection(const core::DirectionType &directionType)

--- a/src/private/mx/impl/DirectionReader.h
+++ b/src/private/mx/impl/DirectionReader.h
@@ -10,6 +10,7 @@
 #include "mx/core/generated/Dynamics.h"
 #include "mx/core/generated/Harmony.h"
 #include "mx/core/generated/HarmonyChordGroup.h"
+#include "mx/core/generated/PercussionChoice.h"
 #include "mx/impl/Converter.h"
 #include "mx/impl/Cursor.h"
 #include "mx/impl/PositionFunctions.h"
@@ -67,6 +68,7 @@ class DirectionReader
     void parseImage(const core::DirectionType &directionType);
     void parsePrincipalVoice(const core::DirectionType &directionType);
     void parseAccordionRegistration(const core::DirectionType &directionType);
+    api::PercussionDataChoice getPercussionChoice(const core::PercussionChoice &choice) const;
     void parsePercussion(const core::DirectionType &directionType);
     void parseOtherDirection(const core::DirectionType &directionType);
     void parseHarmony(const core::Harmony &inHarmony, const core::HarmonyChordGroup &inGrp);

--- a/src/private/mx/impl/DirectionWriter.cpp
+++ b/src/private/mx/impl/DirectionWriter.cpp
@@ -10,6 +10,7 @@
 #include "mx/core/generated/Bass.h"
 #include "mx/core/generated/BassStep.h"
 #include "mx/core/generated/BeatUnitGroup.h"
+#include "mx/core/generated/Beater.h"
 #include "mx/core/generated/Bracket.h"
 #include "mx/core/generated/Coda.h"
 #include "mx/core/generated/Dashes.h"
@@ -25,6 +26,7 @@
 #include "mx/core/generated/Divisions.h"
 #include "mx/core/generated/Dynamics.h"
 #include "mx/core/generated/EditorialVoiceDirectionGroup.h"
+#include "mx/core/generated/Effect.h"
 #include "mx/core/generated/Empty.h"
 #include "mx/core/generated/EmptyPrintStyleAlignID.h"
 #include "mx/core/generated/Figure.h"
@@ -34,6 +36,7 @@
 #include "mx/core/generated/Frame.h"
 #include "mx/core/generated/FrameNote.h"
 #include "mx/core/generated/Fret.h"
+#include "mx/core/generated/Glass.h"
 #include "mx/core/generated/Harmony.h"
 #include "mx/core/generated/HarmonyAlter.h"
 #include "mx/core/generated/HarmonyChordGroup.h"
@@ -42,6 +45,8 @@
 #include "mx/core/generated/Image.h"
 #include "mx/core/generated/Inversion.h"
 #include "mx/core/generated/Kind.h"
+#include "mx/core/generated/Membrane.h"
+#include "mx/core/generated/Metal.h"
 #include "mx/core/generated/Metronome.h"
 #include "mx/core/generated/MetronomeChoice.h"
 #include "mx/core/generated/MetronomeChoiceGroup.h"
@@ -58,10 +63,14 @@
 #include "mx/core/generated/Offset.h"
 #include "mx/core/generated/OnOff.h"
 #include "mx/core/generated/OtherDirection.h"
+#include "mx/core/generated/OtherText.h"
 #include "mx/core/generated/Pedal.h"
 #include "mx/core/generated/PedalTuning.h"
 #include "mx/core/generated/PedalType.h"
 #include "mx/core/generated/PerMinute.h"
+#include "mx/core/generated/Percussion.h"
+#include "mx/core/generated/PercussionChoice.h"
+#include "mx/core/generated/Pitched.h"
 #include "mx/core/generated/PositiveDivisions.h"
 #include "mx/core/generated/PrincipalVoice.h"
 #include "mx/core/generated/PrincipalVoiceSymbol.h"
@@ -71,15 +80,18 @@
 #include "mx/core/generated/Segno.h"
 #include "mx/core/generated/Semitones.h"
 #include "mx/core/generated/SmuflGlyphName.h"
+#include "mx/core/generated/SmuflPictogramGlyphName.h"
 #include "mx/core/generated/Sound.h"
 #include "mx/core/generated/StaffDivide.h"
 #include "mx/core/generated/StaffDivideSymbol.h"
 #include "mx/core/generated/StartStop.h"
 #include "mx/core/generated/StartStopContinue.h"
+#include "mx/core/generated/Stick.h"
 #include "mx/core/generated/String.h"
 #include "mx/core/generated/StringMute.h"
 #include "mx/core/generated/StringNumber.h"
 #include "mx/core/generated/StyleText.h"
+#include "mx/core/generated/Timpani.h"
 #include "mx/core/generated/TuningGroup.h"
 #include "mx/core/generated/ValignImage.h"
 #include "mx/core/generated/Wedge.h"
@@ -937,6 +949,139 @@ void DirectionWriter::emitScordatura(const api::ScordaturaData &item, core::Dire
     addDirectionType(std::move(dt), direction);
 }
 
+core::PercussionChoice DirectionWriter::createPercussionChoice(const api::PercussionDataChoice &choice)
+{
+    using Kind = api::PercussionDataChoice::Kind;
+    switch (choice.kind())
+    {
+    case Kind::metal: {
+        core::Metal metal{};
+        metal.setValue(myConverter.convert(choice.metal().value));
+        if (choice.metal().smufl.has_value())
+        {
+            metal.setSmufl(core::SmuflPictogramGlyphName::parse(*choice.metal().smufl));
+        }
+        return core::PercussionChoice::metal(std::move(metal));
+    }
+    case Kind::wood: {
+        core::Wood wood{};
+        wood.setValue(myConverter.convert(choice.wood().value));
+        if (choice.wood().smufl.has_value())
+        {
+            wood.setSmufl(core::SmuflPictogramGlyphName::parse(*choice.wood().smufl));
+        }
+        return core::PercussionChoice::wood(std::move(wood));
+    }
+    case Kind::pitched: {
+        core::Pitched pitched{};
+        pitched.setValue(myConverter.convert(choice.pitched().value));
+        if (choice.pitched().smufl.has_value())
+        {
+            pitched.setSmufl(core::SmuflPictogramGlyphName::parse(*choice.pitched().smufl));
+        }
+        return core::PercussionChoice::pitched(std::move(pitched));
+    }
+    case Kind::membrane: {
+        core::Membrane membrane{};
+        membrane.setValue(myConverter.convert(choice.membrane().value));
+        if (choice.membrane().smufl.has_value())
+        {
+            membrane.setSmufl(core::SmuflPictogramGlyphName::parse(*choice.membrane().smufl));
+        }
+        return core::PercussionChoice::membrane(std::move(membrane));
+    }
+    case Kind::effect: {
+        core::Effect effect{};
+        effect.setValue(myConverter.convert(choice.effect().value));
+        if (choice.effect().smufl.has_value())
+        {
+            effect.setSmufl(core::SmuflPictogramGlyphName::parse(*choice.effect().smufl));
+        }
+        return core::PercussionChoice::effect(std::move(effect));
+    }
+    case Kind::timpani: {
+        core::Timpani timpani{};
+        if (choice.timpani().smufl.has_value())
+        {
+            timpani.setSmufl(core::SmuflPictogramGlyphName::parse(*choice.timpani().smufl));
+        }
+        return core::PercussionChoice::timpani(std::move(timpani));
+    }
+    case Kind::beater: {
+        core::Beater beater{};
+        beater.setValue(myConverter.convert(choice.beater().value));
+        if (choice.beater().tip != api::TipDirection::unspecified)
+        {
+            beater.setTip(myConverter.convert(choice.beater().tip));
+        }
+        return core::PercussionChoice::beater(std::move(beater));
+    }
+    case Kind::stick: {
+        core::Stick stick{};
+        stick.setStickType(myConverter.convert(choice.stick().stickType));
+        stick.setStickMaterial(myConverter.convert(choice.stick().stickMaterial));
+        if (choice.stick().tip != api::TipDirection::unspecified)
+        {
+            stick.setTip(myConverter.convert(choice.stick().tip));
+        }
+        if (choice.stick().parentheses != api::Bool::unspecified)
+        {
+            stick.setParentheses(myConverter.convert(choice.stick().parentheses));
+        }
+        if (choice.stick().dashedCircle != api::Bool::unspecified)
+        {
+            stick.setDashedCircle(myConverter.convert(choice.stick().dashedCircle));
+        }
+        return core::PercussionChoice::stick(std::move(stick));
+    }
+    case Kind::stickLocation: {
+        return core::PercussionChoice::stickLocation(myConverter.convert(choice.stickLocation()));
+    }
+    case Kind::otherPercussion: {
+        core::OtherText other{};
+        other.setValue(choice.otherPercussion().text);
+        if (choice.otherPercussion().smufl.has_value())
+        {
+            other.setSmufl(core::SmuflGlyphName{*choice.otherPercussion().smufl});
+        }
+        return core::PercussionChoice::otherPercussion(std::move(other));
+    }
+    case Kind::glass:
+    default: {
+        core::Glass glass{};
+        glass.setValue(myConverter.convert(choice.glass().value));
+        if (choice.glass().smufl.has_value())
+        {
+            glass.setSmufl(core::SmuflPictogramGlyphName::parse(*choice.glass().smufl));
+        }
+        return core::PercussionChoice::glass(std::move(glass));
+    }
+    }
+}
+
+void DirectionWriter::emitPercussion(const api::PercussionData &item, core::Direction &direction)
+{
+    core::Percussion percussion{};
+    percussion.setChoice(createPercussionChoice(item.choice));
+    if (item.enclosure != api::PercussionEnclosure::unspecified)
+    {
+        percussion.setEnclosure(myConverter.convert(item.enclosure));
+    }
+    setAttributesFromPositionData(item.positionData, percussion);
+    setAttributesFromFontData(item.fontData, percussion);
+    if (item.color.has_value())
+    {
+        setAttributesFromColorData(*item.color, percussion);
+    }
+    if (item.id.has_value())
+    {
+        percussion.setID(core::Token{*item.id});
+    }
+    core::DirectionType dt{};
+    dt.setChoice(core::DirectionTypeChoice::percussion(core::OneOrMore<core::Percussion>{std::move(percussion)}));
+    addDirectionType(std::move(dt), direction);
+}
+
 void DirectionWriter::emitFixedOrder(core::Direction &direction)
 {
     for (const auto &mark : myDirectionData.marks)
@@ -1069,6 +1214,11 @@ void DirectionWriter::emitFixedOrder(core::Direction &direction)
     for (const auto &item : myDirectionData.scordaturas)
     {
         emitScordatura(item, direction);
+    }
+
+    for (const auto &item : myDirectionData.percussions)
+    {
+        emitPercussion(item, direction);
     }
 }
 
@@ -1272,6 +1422,13 @@ void DirectionWriter::emitOrderedComponents(core::Direction &direction)
             if (i >= 0 && static_cast<size_t>(i) < myDirectionData.scordaturas.size())
             {
                 emitScordatura(myDirectionData.scordaturas.at(i), direction);
+            }
+            break;
+
+        case api::DirectionComponentKind::percussion:
+            if (i >= 0 && static_cast<size_t>(i) < myDirectionData.percussions.size())
+            {
+                emitPercussion(myDirectionData.percussions.at(i), direction);
             }
             break;
 

--- a/src/private/mx/impl/DirectionWriter.h
+++ b/src/private/mx/impl/DirectionWriter.h
@@ -8,6 +8,7 @@
 #include "mx/api/DirectionData.h"
 #include "mx/core/generated/EmptyPrintStyleAlignID.h"
 #include "mx/core/generated/MusicDataChoice.h"
+#include "mx/core/generated/PercussionChoice.h"
 #include "mx/impl/Converter.h"
 #include "mx/impl/Cursor.h"
 #include "mx/impl/SpannerNumberResolver.h"
@@ -67,6 +68,8 @@ class DirectionWriter
     void emitAccordionRegistration(const api::AccordionRegistrationData &item, core::Direction &direction);
     void emitHarpPedals(const api::HarpPedalsData &item, core::Direction &direction);
     void emitScordatura(const api::ScordaturaData &item, core::Direction &direction);
+    core::PercussionChoice createPercussionChoice(const api::PercussionDataChoice &choice);
+    void emitPercussion(const api::PercussionData &item, core::Direction &direction);
     void emitFixedOrder(core::Direction &direction);
     void emitOrderedComponents(core::Direction &direction);
 

--- a/src/private/mxtest/api/DirectionMarksRoundTripTest.cpp
+++ b/src/private/mxtest/api/DirectionMarksRoundTripTest.cpp
@@ -286,6 +286,151 @@ TEST(ScordaturaNoStringNumbers, DirectionMarksRoundTrip)
 
 T_END;
 
+TEST(PercussionGlass, DirectionMarksRoundTrip)
+{
+    DirectionData direction;
+    PercussionData percussion;
+    GlassPercussion glass;
+    glass.value = GlassInstrument::windChimes;
+    percussion.choice = PercussionDataChoice{glass};
+    percussion.enclosure = PercussionEnclosure::rectangle;
+    direction.percussions.push_back(percussion);
+    const auto directions = roundTripDirectionData(direction);
+    REQUIRE(directions.size() == 1);
+    REQUIRE(directions.front().percussions.size() == 1);
+    const auto &out = directions.front().percussions.front();
+    REQUIRE(out.choice.isGlass());
+    CHECK(out.choice.glass().value == GlassInstrument::windChimes);
+    CHECK(out.enclosure == PercussionEnclosure::rectangle);
+}
+
+T_END;
+
+TEST(PercussionBeaterTip, DirectionMarksRoundTrip)
+{
+    DirectionData direction;
+    PercussionData percussion;
+    BeaterPercussion beater;
+    beater.value = BeaterValue::wireBrush;
+    beater.tip = TipDirection::northeast;
+    percussion.choice = PercussionDataChoice{beater};
+    direction.percussions.push_back(percussion);
+    const auto directions = roundTripDirectionData(direction);
+    REQUIRE(directions.size() == 1);
+    REQUIRE(directions.front().percussions.size() == 1);
+    const auto &out = directions.front().percussions.front();
+    REQUIRE(out.choice.isBeater());
+    CHECK(out.choice.beater().value == BeaterValue::wireBrush);
+    CHECK(out.choice.beater().tip == TipDirection::northeast);
+}
+
+T_END;
+
+TEST(PercussionStick, DirectionMarksRoundTrip)
+{
+    DirectionData direction;
+    PercussionData percussion;
+    StickPercussion stick;
+    stick.stickType = StickType::timpani;
+    stick.stickMaterial = StickMaterial::hard;
+    stick.tip = TipDirection::down;
+    stick.parentheses = Bool::yes;
+    percussion.choice = PercussionDataChoice{stick};
+    direction.percussions.push_back(percussion);
+    const auto directions = roundTripDirectionData(direction);
+    REQUIRE(directions.size() == 1);
+    REQUIRE(directions.front().percussions.size() == 1);
+    const auto &out = directions.front().percussions.front();
+    REQUIRE(out.choice.isStick());
+    CHECK(out.choice.stick().stickType == StickType::timpani);
+    CHECK(out.choice.stick().stickMaterial == StickMaterial::hard);
+    CHECK(out.choice.stick().tip == TipDirection::down);
+    CHECK(out.choice.stick().parentheses == Bool::yes);
+}
+
+T_END;
+
+TEST(PercussionTimpaniSmufl, DirectionMarksRoundTrip)
+{
+    DirectionData direction;
+    PercussionData percussion;
+    TimpaniPercussion timpani;
+    timpani.smufl = "pictGong";
+    percussion.choice = PercussionDataChoice{timpani};
+    direction.percussions.push_back(percussion);
+    const auto directions = roundTripDirectionData(direction);
+    REQUIRE(directions.size() == 1);
+    REQUIRE(directions.front().percussions.size() == 1);
+    const auto &out = directions.front().percussions.front();
+    REQUIRE(out.choice.isTimpani());
+    REQUIRE(out.choice.timpani().smufl.has_value());
+    CHECK_EQUAL("pictGong", *out.choice.timpani().smufl);
+}
+
+T_END;
+
+TEST(PercussionStickLocationAndOther, DirectionMarksRoundTrip)
+{
+    DirectionData direction;
+    PercussionData stickLocationPercussion;
+    stickLocationPercussion.choice = PercussionDataChoice{StickLocation::cymbalEdge};
+    direction.percussions.push_back(stickLocationPercussion);
+    PercussionData otherPercussionData;
+    OtherPercussion other;
+    other.text = "ocean drum";
+    otherPercussionData.choice = PercussionDataChoice{other};
+    direction.percussions.push_back(otherPercussionData);
+    const auto directions = roundTripDirectionData(direction);
+    REQUIRE(directions.size() == 1);
+    REQUIRE(directions.front().percussions.size() == 2);
+    REQUIRE(directions.front().percussions.at(0).choice.isStickLocation());
+    CHECK(directions.front().percussions.at(0).choice.stickLocation() == StickLocation::cymbalEdge);
+    REQUIRE(directions.front().percussions.at(1).choice.isOtherPercussion());
+    CHECK_EQUAL("ocean drum", directions.front().percussions.at(1).choice.otherPercussion().text);
+}
+
+T_END;
+
+TEST(PercussionMembraneMetalWoodPitchedEffect, DirectionMarksRoundTrip)
+{
+    DirectionData direction;
+    PercussionData membraneData;
+    MembranePercussion membrane;
+    membrane.value = MembraneInstrument::congaDrum;
+    membraneData.choice = PercussionDataChoice{membrane};
+    direction.percussions.push_back(membraneData);
+    PercussionData metalData;
+    MetalPercussion metal;
+    metal.value = MetalInstrument::tamTamWithBeater;
+    metalData.choice = PercussionDataChoice{metal};
+    direction.percussions.push_back(metalData);
+    PercussionData woodData;
+    WoodPercussion wood;
+    wood.value = WoodInstrument::templeBlock;
+    woodData.choice = PercussionDataChoice{wood};
+    direction.percussions.push_back(woodData);
+    PercussionData pitchedData;
+    PitchedPercussion pitched;
+    pitched.value = PitchedInstrument::steelDrums;
+    pitchedData.choice = PercussionDataChoice{pitched};
+    direction.percussions.push_back(pitchedData);
+    PercussionData effectData;
+    EffectPercussion effect;
+    effect.value = EffectInstrument::windMachine;
+    effectData.choice = PercussionDataChoice{effect};
+    direction.percussions.push_back(effectData);
+    const auto directions = roundTripDirectionData(direction);
+    REQUIRE(directions.size() == 1);
+    REQUIRE(directions.front().percussions.size() == 5);
+    CHECK(directions.front().percussions.at(0).choice.membrane().value == MembraneInstrument::congaDrum);
+    CHECK(directions.front().percussions.at(1).choice.metal().value == MetalInstrument::tamTamWithBeater);
+    CHECK(directions.front().percussions.at(2).choice.wood().value == WoodInstrument::templeBlock);
+    CHECK(directions.front().percussions.at(3).choice.pitched().value == PitchedInstrument::steelDrums);
+    CHECK(directions.front().percussions.at(4).choice.effect().value == EffectInstrument::windMachine);
+}
+
+T_END;
+
 TEST(DampFormatting, DirectionMarksRoundTrip)
 {
     DirectionData direction;

--- a/src/private/mxtest/api/roundtrip-baseline.txt
+++ b/src/private/mxtest/api/roundtrip-baseline.txt
@@ -461,3 +461,31 @@ synthetic/principal-voice.3.1.xml
 synthetic/harp-pedals.3.0.xml
 synthetic/harp-pedals.3.1.xml
 synthetic/scordatura.3.1.xml
+
+# Unblocked by modeling the percussion direction family (#324): the full set
+# of pictogram alternatives (glass, metal, wood, pitched, membrane, effect,
+# timpani, beater, stick, stick-location, other-percussion).
+synthetic/beater.3.0.xml
+synthetic/effect.3.0.xml
+synthetic/effect.4.0.xml
+synthetic/glass.3.0.xml
+synthetic/glass.3.1.xml
+synthetic/membrane.3.0.xml
+synthetic/membrane.4.0.xml
+synthetic/metal.3.0.xml
+synthetic/metal.4.0.xml
+synthetic/other-percussion.3.0.xml
+synthetic/other-percussion.3.1.xml
+synthetic/percussion.3.0.xml
+synthetic/percussion.3.1.xml
+synthetic/pitched.3.0.xml
+synthetic/pitched.3.1.xml
+synthetic/stick-location.3.0.xml
+synthetic/stick-material.3.0.xml
+synthetic/stick-type.3.0.xml
+synthetic/stick.3.0.xml
+synthetic/stick.3.1.xml
+synthetic/timpani.3.0.xml
+synthetic/timpani.4.0.xml
+synthetic/wood.3.0.xml
+synthetic/wood.4.0.xml


### PR DESCRIPTION
## Human Summary

More direction types that were unmodeled.

## Summary

Fourth slice of #324 (stacked on #360): the percussion pictogram family, the last unmodeled direction-type choice.

- `PercussionData` carries formatting, an optional enclosure, and a `PercussionDataChoice` — a TimeChoice/MarkDataChoice-style variant class over the eleven pictogram alternatives (glass, metal, wood, pitched, membrane, effect, timpani, beater, stick, stick-location, other-percussion), each a small struct pairing its instrument enum with the optional SMuFL glyph override (plus tip direction / material / parentheses / dashed-circle for beater and stick).
- Eleven parallel api enums (~150 enumerators) mirror the core value enums via new Converter EnumMaps, so no value can be silently dropped; `PercussionEnclosure` carries the full 15-value MusicXML 4.0 enclosure-shape list (inverted-bracket, pentagon..decagon included).
- Reader/writer wired through `DirectionReader`/`DirectionWriter` with `orderedComponents` fidelity. Like the existing words handling, several `<percussion>` children of one direction-type read into separate `PercussionData` items and are written back one per direction-type; no corpus file groups them, so nothing currently loses fidelity.

With this, every direction-type choice is modeled. Remaining #324 items are the metronome extras (metric modulation) and the pedal-type gaps (sostenuto/change/continue/discontinue/resume).

## Testing

- [x] New `DirectionMarksRoundTrip` tests covering all eleven alternatives, enclosure, tip direction, stick attributes, and the timpani SMuFL override (108 assertions in 20 test cases across the file)
- [x] Full api/impl suite passes (5091 assertions in 447 test cases)
- [x] Discovery: 272 PASS, zero regressions; baseline 248 -> 272 (the full synthetic percussion family); regression mode 272/272

## References

- Progresses #324
- Stacked on #360; part of #208
