### PR TITLE
feat: round-trip metronome attributes and non-numeric per-minute

### DIFF
--- a/src/include/mx/api/TempoData.h
+++ b/src/include/mx/api/TempoData.h
@@ -4,34 +4,47 @@
 
 #pragma once
 #include "mx/api/ApiCommon.h"
+#include "mx/api/ColorData.h"
 #include "mx/api/DurationData.h"
+#include "mx/api/FontData.h"
 #include "mx/api/PositionData.h"
 #include "mx/api/PrintData.h"
+
+#include <optional>
+#include <string>
 
 namespace mx
 {
 namespace api
 {
+// Which kind of metronome mark a TempoData carries.
 enum class TempoType
 {
     unspecified,
     beatsPerMinute,
-    metricModulation,
-    tempoText
+    metricModulation
 };
 
+// A metronome mark of the form "note = number", e.g. a quarter note at 120. durationName and
+// dots give the beat-unit -- the note picture to the left of the equals sign. beatsPerMinute is
+// the value to the right of it. MusicXML allows free text there ("120", "ca. 76", a range like
+// "126-138"), so it is a string; an empty string is a valid "unset" value. A player that needs a
+// numeric playback tempo should read SoundData::tempo, which is always numeric and expressed in
+// quarter notes per minute.
 struct BeatsPerMinute
 {
     DurationName durationName;
     int dots;
-    int beatsPerMinute;
+    std::string beatsPerMinute;
 
-    BeatsPerMinute()
-        : durationName{DurationName::unspecified}, dots{VALUE_UNSPECIFIED}, beatsPerMinute{VALUE_UNSPECIFIED}
+    BeatsPerMinute() : durationName{DurationName::unspecified}, dots{VALUE_UNSPECIFIED}, beatsPerMinute{}
     {
     }
 };
 
+// A metronome mark of the form "note = note", e.g. a dotted quarter equal to a half note -- the
+// two-beat-unit spelling of a metric modulation. The left and right beat-units are each a note
+// picture (durationName + dots). playbackBeatsPerMinute is unused for this form.
 struct MetricModulation
 {
     DurationName leftDurationName;
@@ -47,12 +60,11 @@ struct MetricModulation
     }
 };
 
-struct TempoText
-{
-    std::string tempoText;
-    BeatsPerMinute playbackBeatsPerMinute;
-};
-
+// A metronome (tempo) mark carried by a <direction>. tempoType selects the form: a
+// note-equals-number mark (beatsPerMinute) or a note-equals-note metric modulation
+// (metricModulation). positionData, fontData, color, and id give the mark's placement and
+// appearance; justify aligns the mark's content within its box; printObject set to 'no' keeps the
+// mark in the file without drawing it; isParenthetical draws the mark in parentheses.
 class TempoData
 {
   public:
@@ -60,6 +72,11 @@ class TempoData
     Bool isParenthetical;
     PrintData printData;
     PositionData positionData;
+    FontData fontData;
+    std::optional<ColorData> color;
+    std::optional<std::string> id;
+    HorizontalAlignment justify;
+    Bool printObject;
     TempoType tempoType;
 
     // only used when tempoType is 'beatsPerMinute'
@@ -68,8 +85,12 @@ class TempoData
     // only used when tempoType is 'metricModulation'
     MetricModulation metricModulation;
 
-    // only used when tempoType is 'tempoText'
-    TempoText tempoText;
+    TempoData()
+        : tickTime{0}, isParenthetical{Bool::unspecified}, printData{}, positionData{}, fontData{}, color{}, id{},
+          justify{HorizontalAlignment::unspecified}, printObject{Bool::unspecified}, tempoType{TempoType::unspecified},
+          beatsPerMinute{}, metricModulation{}
+    {
+    }
 };
 
 MXAPI_EQUALS_BEGIN(BeatsPerMinute)
@@ -88,21 +109,19 @@ MXAPI_EQUALS_MEMBER(playbackBeatsPerMinute)
 MXAPI_EQUALS_END;
 MXAPI_NOT_EQUALS_AND_VECTORS(MetricModulation);
 
-MXAPI_EQUALS_BEGIN(TempoText)
-MXAPI_EQUALS_MEMBER(tempoText)
-MXAPI_EQUALS_MEMBER(playbackBeatsPerMinute)
-MXAPI_EQUALS_END;
-MXAPI_NOT_EQUALS_AND_VECTORS(TempoText);
-
 MXAPI_EQUALS_BEGIN(TempoData)
 MXAPI_EQUALS_MEMBER(tickTime)
 MXAPI_EQUALS_MEMBER(isParenthetical)
 MXAPI_EQUALS_MEMBER(printData)
 MXAPI_EQUALS_MEMBER(positionData)
+MXAPI_EQUALS_MEMBER(fontData)
+MXAPI_EQUALS_MEMBER(color)
+MXAPI_EQUALS_MEMBER(id)
+MXAPI_EQUALS_MEMBER(justify)
+MXAPI_EQUALS_MEMBER(printObject)
 MXAPI_EQUALS_MEMBER(tempoType)
 MXAPI_EQUALS_MEMBER(beatsPerMinute)
 MXAPI_EQUALS_MEMBER(metricModulation)
-MXAPI_EQUALS_MEMBER(tempoText)
 MXAPI_EQUALS_END;
 MXAPI_NOT_EQUALS_AND_VECTORS(TempoData);
 } // namespace api

--- a/src/private/mx/impl/DirectionWriter.cpp
+++ b/src/private/mx/impl/DirectionWriter.cpp
@@ -452,6 +452,24 @@ void DirectionWriter::emitDashesStop(const api::SpannerStop &item, core::Directi
 
 void DirectionWriter::emitTempo(const api::TempoData &tempo, core::Direction &direction)
 {
+    // Content-guard: a tempo with no beat-unit -- an unfilled/default TempoData, or the
+    // metronome-note form this api does not yet model -- has nothing to write. Skip it rather
+    // than emit an empty <metronome>. Nothing throws; the direction simply carries no tempo.
+    const bool hasBeatUnit = tempo.beatsPerMinute.durationName != api::DurationName::unspecified;
+    const bool hasModulation = tempo.metricModulation.leftDurationName != api::DurationName::unspecified;
+    if (tempo.tempoType == api::TempoType::beatsPerMinute && !hasBeatUnit)
+    {
+        return;
+    }
+    if (tempo.tempoType == api::TempoType::metricModulation && !hasModulation)
+    {
+        return;
+    }
+    if (tempo.tempoType != api::TempoType::beatsPerMinute && tempo.tempoType != api::TempoType::metricModulation)
+    {
+        return;
+    }
+
     const auto makeBeatUnitGroup = [&](api::DurationName durationName, int dots) {
         core::BeatUnitGroup beatUnitGroup{};
         beatUnitGroup.setBeatUnit(myConverter.convert(durationName));
@@ -466,16 +484,17 @@ void DirectionWriter::emitTempo(const api::TempoData &tempo, core::Direction &di
 
     if (tempo.tempoType == api::TempoType::beatsPerMinute)
     {
-        // beat-unit (+dots) followed by a numeric per-minute.
+        // beat-unit (+dots) followed by a per-minute string, kept verbatim from the source
+        // (per-minute is xs:string: "120", "ca. 76", a range, ...).
         core::PerMinute pm{};
-        pm.setValue(std::to_string(tempo.beatsPerMinute.beatsPerMinute));
+        pm.setValue(tempo.beatsPerMinute.beatsPerMinute);
 
         core::MetronomeChoiceGroup mcg{};
         mcg.setBeatUnit(makeBeatUnitGroup(tempo.beatsPerMinute.durationName, tempo.beatsPerMinute.dots));
         mcg.setChoice(core::MetronomeChoiceGroupChoice::perMinute(pm));
         metronome.setChoice(core::MetronomeChoice::group(mcg));
     }
-    else if (tempo.tempoType == api::TempoType::metricModulation)
+    else
     {
         // Metric modulation: two beat-units, e.g. <beat-unit>quarter</beat-unit>
         // = <beat-unit>half</beat-unit>. The second beat-unit is the 'group'
@@ -489,17 +508,27 @@ void DirectionWriter::emitTempo(const api::TempoData &tempo, core::Direction &di
         mcg.setChoice(core::MetronomeChoiceGroupChoice::group(rightBeatUnitHolder));
         metronome.setChoice(core::MetronomeChoice::group(mcg));
     }
-    else
-    {
-        // tempoText (a non-numeric <per-minute> whose beat-unit was not
-        // preserved by the api) and 'unspecified' (e.g. the metronome-note
-        // form, which the api does not model) have no faithful <metronome>
-        // representation. Skip rather than crash or fabricate wrong structure.
-        // Previously the writer threw here, producing no output (CREATEFAIL).
-        // See issue #218.
-        return;
-    }
 
+    // print-style-align (default-x/y, relative-x/y, font, color, halign, valign) + justify +
+    // print-object + parentheses + id.
+    setAttributesFromPositionData(tempo.positionData, metronome);
+    setAttributesFromFontData(tempo.fontData, metronome);
+    if (tempo.color.has_value())
+    {
+        setAttributesFromColorData(*tempo.color, metronome);
+    }
+    if (tempo.id.has_value())
+    {
+        metronome.setID(core::Token{*tempo.id});
+    }
+    if (tempo.justify != api::HorizontalAlignment::unspecified)
+    {
+        metronome.setJustify(myConverter.convert(tempo.justify));
+    }
+    if (tempo.printObject != api::Bool::unspecified)
+    {
+        metronome.setPrintObject(myConverter.convert(tempo.printObject));
+    }
     if (tempo.isParenthetical != api::Bool::unspecified)
     {
         metronome.setParentheses(myConverter.convert(tempo.isParenthetical));

--- a/src/private/mx/impl/MetronomeReader.cpp
+++ b/src/private/mx/impl/MetronomeReader.cpp
@@ -11,7 +11,9 @@
 #include "mx/core/generated/MetronomeChoiceGroupChoiceGroup.h"
 #include "mx/core/generated/PerMinute.h"
 #include "mx/impl/Converter.h"
-#include "mx/utility/StringToInt.h"
+#include "mx/impl/FontFunctions.h"
+#include "mx/impl/PositionFunctions.h"
+#include "mx/impl/PrintFunctions.h"
 
 namespace mx
 {
@@ -28,14 +30,32 @@ api::TempoData MetronomeReader::getTempoData() const
 {
     std::lock_guard<std::mutex> lock{myMutex};
     myOutTempoData = api::TempoData{};
-    // the old core's beatUnitPer is the new core's group; the old core's
-    // noteRelationNote (metronome-note based) is group2
+
+    Converter converter;
+
+    // print-style-align + print-object + justify + parentheses + id attributes.
+    myOutTempoData.positionData = getPositionData(myMetronome);
+    myOutTempoData.fontData = getFontData(myMetronome);
+    if (myMetronome.color().has_value())
+    {
+        myOutTempoData.color = getColor(myMetronome);
+    }
+    if (myMetronome.id().has_value())
+    {
+        myOutTempoData.id = myMetronome.id()->value();
+    }
+    if (myMetronome.justify().has_value())
+    {
+        myOutTempoData.justify = converter.convert(*myMetronome.justify());
+    }
+    myOutTempoData.printObject = getPrintObject(myMetronome);
     if (myMetronome.parentheses().has_value())
     {
-        Converter converter;
         myOutTempoData.isParenthetical = converter.convert(*myMetronome.parentheses());
     }
 
+    // the old core's beatUnitPer is the new core's group; the old core's
+    // noteRelationNote (metronome-note based) is group2
     using FirstChoice = core::MetronomeChoice::Kind;
     const auto firstChoice = myBeatUnitPerOrNoteRelationNoteChoice.kind();
 
@@ -95,18 +115,8 @@ void MetronomeReader::parseBeatsPerMinute() const
     Converter converter;
     myOutTempoData.beatsPerMinute.durationName = converter.convert(grp.beatUnit());
     myOutTempoData.beatsPerMinute.dots = static_cast<int>(grp.beatUnitDot().size());
-    const auto bpmStr = beatUnitPer.choice().asPerMinute().value();
-    int bpm = api::VALUE_UNSPECIFIED;
-    bool isNumeric = utility::stringToInt(bpmStr, bpm);
-    if (!isNumeric)
-    {
-        myOutTempoData.tempoType = api::TempoType::tempoText;
-        myOutTempoData.tempoText.tempoText = bpmStr;
-    }
-    else
-    {
-        myOutTempoData.beatsPerMinute.beatsPerMinute = bpm;
-    }
+    // per-minute is xs:string in MusicXML ("120", "ca. 76", a range, ...); keep it verbatim.
+    myOutTempoData.beatsPerMinute.beatsPerMinute = beatUnitPer.choice().asPerMinute().value();
 }
 
 void MetronomeReader::parseMetronomeModulation() const

--- a/src/private/mxtest/api/MetronomeApiTest.cpp
+++ b/src/private/mxtest/api/MetronomeApiTest.cpp
@@ -20,7 +20,7 @@ TEST(roundTripBpm, MetronomeApi)
 {
     const auto expectedDurationName = DurationName::dur16th;
     const int expectedDots = 1;
-    const int expectedBeatsPerMinute = 123;
+    const std::string expectedBeatsPerMinute = "123";
     const int expectedTickTimePosition = 77;
 
     ScoreData expectedScoreData;
@@ -52,7 +52,7 @@ TEST(roundTripBpm, MetronomeApi)
     actualTempo.tempoType = TempoType::beatsPerMinute;
     auto &actualBpm = actualTempo.beatsPerMinute;
 
-    CHECK_EQUAL(expectedBeatsPerMinute, actualBpm.beatsPerMinute);
+    CHECK(expectedBeatsPerMinute == actualBpm.beatsPerMinute);
     CHECK_EQUAL(expectedDots, actualBpm.dots);
     CHECK(expectedDurationName == actualBpm.durationName);
     CHECK_EQUAL(expectedTickTimePosition, actualDirection.tickTimePosition);
@@ -118,11 +118,10 @@ TEST(metronomeNoteFormReadDoesNotFail, MetronomeApi)
     CHECK(dataResult.ok());
 }
 
-// A non-numeric <per-minute> is legal -- per-minute is an xs:string. The reader
-// represents it as tempoText, and the writer used to throw on any non-bpm tempo,
-// failing createFromScore (CREATEFAIL). After the fix the tempo is skipped and
-// createFromScore succeeds.
-TEST(nonNumericPerMinuteWriteDoesNotFail, MetronomeApi)
+// A non-numeric <per-minute> is legal -- per-minute is an xs:string. It is kept verbatim on
+// BeatsPerMinute::beatsPerMinute, so a mark like "quarter = fast" round-trips faithfully instead
+// of being dropped (which is what the old tempoText fallback did).
+TEST(nonNumericPerMinuteRoundTrips, MetronomeApi)
 {
     const std::string xml = makeMetronomeDoc(R"(
             <beat-unit>quarter</beat-unit>
@@ -144,8 +143,26 @@ TEST(nonNumericPerMinuteWriteDoesNotFail, MetronomeApi)
     {
         return;
     }
+
+    const auto &score = dataResult.value();
+    CHECK_EQUAL(1, static_cast<int>(score.parts.size()));
+    if (score.parts.empty() || score.parts.back().measures.empty() || score.parts.back().measures.back().staves.empty())
+    {
+        return;
+    }
+    const auto &directions = score.parts.back().measures.back().staves.back().directions;
+    CHECK_EQUAL(1, static_cast<int>(directions.size()));
+    if (directions.empty() || directions.back().tempos.empty())
+    {
+        return;
+    }
+    const auto &tempo = directions.back().tempos.back();
+    CHECK(TempoType::beatsPerMinute == tempo.tempoType);
+    CHECK(DurationName::quarter == tempo.beatsPerMinute.durationName);
+    CHECK(std::string{"fast"} == tempo.beatsPerMinute.beatsPerMinute);
+
+    // The mark must also write back without error.
     const auto id2Result = mgr.createFromScore(dataResult.value());
-    // Before the fix createFromScore threw (CREATEFAIL); now it must succeed.
     CHECK(id2Result.ok());
     if (id2Result.ok())
     {
@@ -219,13 +236,58 @@ TEST(roundTripParentheses, MetronomeApi)
     tempo.tempoType = TempoType::beatsPerMinute;
     tempo.isParenthetical = Bool::yes;
     tempo.beatsPerMinute.durationName = DurationName::quarter;
-    tempo.beatsPerMinute.beatsPerMinute = 100;
+    tempo.beatsPerMinute.beatsPerMinute = "100";
 
     auto actualScoreData = roundTrip(score);
 
     const auto &actualTempo =
         actualScoreData.parts.back().measures.back().staves.back().directions.back().tempos.back();
     CHECK(actualTempo.isParenthetical == Bool::yes);
+}
+
+T_END
+
+TEST(roundTripMetronomeAttributes, MetronomeApi)
+{
+    // The <metronome> print-style-align, justify, print-object, color, and id attributes must
+    // survive a round trip via TempoData's positionData/fontData/justify/printObject/color/id.
+    ScoreData score;
+    score.ticksPerQuarter = 100;
+    score.parts.emplace_back();
+    score.parts.back().measures.emplace_back();
+    score.parts.back().measures.back().staves.emplace_back();
+    score.parts.back().measures.back().staves.back().directions.emplace_back();
+    auto &tempo = score.parts.back().measures.back().staves.back().directions.back().tempos.emplace_back();
+    tempo.tempoType = TempoType::beatsPerMinute;
+    tempo.beatsPerMinute.durationName = DurationName::quarter;
+    tempo.beatsPerMinute.beatsPerMinute = "120";
+    tempo.positionData.isDefaultYSpecified = true;
+    tempo.positionData.defaultY = 12.0;
+    tempo.positionData.horizontalAlignment = HorizontalAlignment::left;
+    tempo.fontData.style = FontStyle::italic;
+    tempo.justify = HorizontalAlignment::center;
+    tempo.printObject = Bool::no;
+    tempo.id = std::string{"tempo1"};
+
+    const auto out = roundTrip(score);
+
+    const auto &directions = out.parts.back().measures.back().staves.back().directions;
+    CHECK_EQUAL(1, static_cast<int>(directions.size()));
+    if (directions.empty() || directions.back().tempos.empty())
+    {
+        return;
+    }
+    const auto &outTempo = directions.back().tempos.back();
+    CHECK(outTempo.positionData.isDefaultYSpecified);
+    CHECK(HorizontalAlignment::left == outTempo.positionData.horizontalAlignment);
+    CHECK(FontStyle::italic == outTempo.fontData.style);
+    CHECK(HorizontalAlignment::center == outTempo.justify);
+    CHECK(Bool::no == outTempo.printObject);
+    CHECK(outTempo.id.has_value());
+    if (outTempo.id.has_value())
+    {
+        CHECK(std::string{"tempo1"} == *outTempo.id);
+    }
 }
 
 T_END

--- a/src/private/mxtest/api/roundtrip-baseline.txt
+++ b/src/private/mxtest/api/roundtrip-baseline.txt
@@ -489,3 +489,9 @@ synthetic/timpani.3.0.xml
 synthetic/timpani.4.0.xml
 synthetic/wood.3.0.xml
 synthetic/wood.4.0.xml
+
+# Metronome print-style-align attributes, justify, print-object, id, and
+# non-numeric per-minute text now round-trip (first metronome slice of #324).
+synthetic/metronome.3.0.xml
+synthetic/metronome.3.1.xml
+synthetic/metronome.4.0.xml


### PR DESCRIPTION
## Human Summary

I am reluctantly making the interface more and more complicated as we hill climb against the test corpus. This one makes metronome beats per minute a string (it was an int) and adds support for its attributes.

## Summary

The `<metronome>` element only round-tripped its `parentheses` attribute and a numeric per-minute; every other attribute was silently dropped, and a non-numeric per-minute discarded the beat-unit and was never written back.

This models the metronome's full attribute surface on `TempoData` — the `print-style-align` group (position, font, color, halign/valign) plus `justify`, `print-object`, and `id` — populated by `MetronomeReader` and emitted by `DirectionWriter`.

per-minute is `xs:string` in MusicXML ("120", "ca. 76", a range). `BeatsPerMinute::beatsPerMinute` changes from `int` to `std::string` and is kept verbatim, so "quarter = ca. 76" now round-trips. The unreachable `TempoType::tempoText` enumerator and the `TempoText` struct are removed. A numeric playback tempo is available separately on `SoundData::tempo` (quarter notes per minute).

Breaking: `BeatsPerMinute::beatsPerMinute` is now a string, and `TempoType::tempoText` / `TempoText` are gone. The metronome-note form and per-minute's own font are still not modeled (the note form is the next slice; per-minute's font is a documented drop).

## Testing

- [x] New `roundTripMetronomeAttributes` and `nonNumericPerMinuteRoundTrips` unit tests
- [x] Full unit suite passes (5104 assertions in 448 test cases)
- [x] Round-trip regression 275/275 pinned, no regressions
- [x] Round-trip baseline 272 -> 275 (synthetic metronome kitchen-sink fixtures); real-world files that reported an attribute mismatch at the metronome now progress past it

## References

- Progresses #324
