### PR TITLE
feat: round-trip octave-shift size

### DIFF
--- a/src/include/mx/api/OttavaData.h
+++ b/src/include/mx/api/OttavaData.h
@@ -28,7 +28,14 @@ class OttavaStart
     SpannerStart spannerStart;
     OttavaType ottavaType;
 
-    OttavaStart() : spannerStart{}, ottavaType{OttavaType::unspecified}
+    // Octave-shift size fidelity knob. The size value (8 or 15) follows from ottavaType, so a
+    // 15ma/15mb line always writes size="15" while an 8va/8vb line omits the redundant, spec-
+    // default size="8". When true, the writer also emits that redundant size="8"; the reader sets
+    // it when the source spelled the attribute out. Leave false (the default) when authoring. It
+    // has no effect on a 15ma/15mb line, whose load-bearing size is always written.
+    bool writeDefaultSize;
+
+    OttavaStart() : spannerStart{}, ottavaType{OttavaType::unspecified}, writeDefaultSize{false}
     {
     }
 };
@@ -52,6 +59,7 @@ class OttavaStop
 MXAPI_EQUALS_BEGIN(OttavaStart)
 MXAPI_EQUALS_MEMBER(spannerStart)
 MXAPI_EQUALS_MEMBER(ottavaType)
+MXAPI_EQUALS_MEMBER(writeDefaultSize)
 MXAPI_EQUALS_END;
 MXAPI_NOT_EQUALS_AND_VECTORS(OttavaStart);
 

--- a/src/include/mx/api/OttavaData.h
+++ b/src/include/mx/api/OttavaData.h
@@ -32,7 +32,7 @@ class OttavaStart
     // 15ma/15mb line always writes size="15" while an 8va/8vb line omits the redundant, spec-
     // default size="8". When true, the writer also emits that redundant size="8"; the reader sets
     // it when the source spelled the attribute out. Leave false (the default) when authoring. It
-    // has no effect on a 15ma/15mb line, whose load-bearing size is always written.
+    // has no effect on a 15ma/15mb line, whose size is always written.
     bool writeDefaultSize;
 
     OttavaStart() : spannerStart{}, ottavaType{OttavaType::unspecified}, writeDefaultSize{false}

--- a/src/private/mx/impl/DirectionReader.cpp
+++ b/src/private/mx/impl/DirectionReader.cpp
@@ -840,6 +840,8 @@ void DirectionReader::parseOctaveShift(const core::DirectionType &directionType)
     api::OttavaStart start;
     start.spannerStart = impl::getSpannerStart(octaveShift);
     start.ottavaType = ottavaType;
+    const bool isEightLine = ottavaType == api::OttavaType::o8va || ottavaType == api::OttavaType::o8vb;
+    start.writeDefaultSize = isEightLine && octaveShift.size().has_value();
     start.spannerStart.tickTimePosition = myCursor.tickTimePosition;
     myOutDirectionData.ottavaStarts.emplace_back(std::move(start));
     appendOrderedComponent(api::DirectionComponentKind::ottavaStart,

--- a/src/private/mx/impl/DirectionWriter.cpp
+++ b/src/private/mx/impl/DirectionWriter.cpp
@@ -399,30 +399,40 @@ void DirectionWriter::emitOttavaStart(const api::OttavaStart &ottavaStart, core:
         os.setNumber(core::NumberLevel{*number});
     }
 
+    int sizeValue = 8;
+
     switch (ottavaStart.ottavaType)
     {
     case api::OttavaType::o15ma: {
         os.setType(core::UpDownStopContinue::down());
-        os.setSize(15);
+        sizeValue = 15;
         break;
     }
     case api::OttavaType::o15mb: {
         os.setType(core::UpDownStopContinue::up());
-        os.setSize(15);
+        sizeValue = 15;
         break;
     }
     case api::OttavaType::o8va: {
         os.setType(core::UpDownStopContinue::down());
-        os.setSize(8);
+        sizeValue = 8;
         break;
     }
     case api::OttavaType::o8vb: {
         os.setType(core::UpDownStopContinue::up());
-        os.setSize(8);
+        sizeValue = 8;
         break;
     }
     default:
         break;
+    }
+
+    // size follows from ottavaType; a 15ma/15mb line's size encodes the two-octave shift, so it is
+    // always written, while the redundant default size="8" is emitted only when writeDefaultSize is
+    // set (the source spelled it out).
+    if (sizeValue != 8 || ottavaStart.writeDefaultSize)
+    {
+        os.setSize(sizeValue);
     }
 
     core::DirectionType dt{};


### PR DESCRIPTION
## Human Summary

Apparently, emitting "8" for a single octave shift is optional. Here we add a round-trip fidelity knob that can actually be ignored when using the API.

## Summary

octave-shift's `size` (8 or 15) is derived from `OttavaType`, so `emitOttavaStart` force-wrote `size="8"` -- the spec default -- on every 8va/8vb line. `OttavaStart::writeDefaultSize` (a plain-bool principle-7 fidelity knob, in the mold of `ClefData::writeStaffNumber`) records whether the source spelled out that redundant `size="8"`; the writer now omits it by default while always emitting the load-bearing, non-default `size="15"`. The reader sets the flag only for an 8va/8vb line that actually carried the attribute, so a file that did write `size="8"` still round-trips it.

The knob governs only the redundant default: a plain `bool` (not the ternary `Bool`) because the only real degree of freedom is whether to show `size="8"` on an 8-line. There is deliberately no way to suppress the load-bearing `size="15"` on a 15-line -- that state would be corrupting, so it is made unrepresentable.

Surfaced while hill-climbing `lysuite/ly31a_Directions.xml` to a full round-trip PASS.

## Testing

- [x] Full unit suite passes (5130 assertions in 451 test cases)
- [x] api round-trip discovery: no regressions; `lysuite/ly33d_Spanners_OctaveShifts.xml` moves toward PASS from the size fix. The pins land in the stacked round-trip PR (#366).

## References

- Progresses #324
- First of a three-PR stack: octave-shift size (this) &rarr; direction offset (#367) &rarr; round-trip canonicalizers + pins (#366)
