### PR TITLE
feat: model direction offset as an anchor plus a fidelity knob

### DIFF
--- a/src/include/mx/api/DirectionData.h
+++ b/src/include/mx/api/DirectionData.h
@@ -29,6 +29,8 @@
 #include "mx/api/WedgeData.h"
 #include "mx/api/WordsData.h"
 
+#include <optional>
+
 namespace mx
 {
 namespace api
@@ -97,15 +99,17 @@ struct DirectionData
     int tickTimePosition;
     Placement placement;
 
-    // mx::api will place the DirectionData element in the correct place by using an offset element.
+    // The source's <offset>, in divisions, or absent when it had none. An <offset> nudges only
+    // where the direction is *drawn*, shifting it away from the note it is anchored to; it does not
+    // move that anchor. tickTimePosition holds the anchor -- the musical location the direction
+    // belongs to -- so the drawn position is tickTimePosition + offset. This is a round-trip
+    // fidelity knob: leave it absent when authoring and set tickTimePosition to where the direction
+    // belongs; the reader fills it in only to preserve an <offset> already present in the source.
     // MusicXML Documentation: An offset is represented in terms of divisions, and indicates where
     // the direction will appear relative to the current musical location. This affects the visual
-    // appearance of the direction. If the sound attribute is "yes", then the offset affects
-    // playback too. If the sound attribute is "no", then any sound associated with the direction
-    // takes effect at the current location. The sound attribute is "no" by default for
-    // compatibility with earlier versions of the MusicXML format. If an element within a
-    // direction includes a default-x attribute, the offset value will be ignored when determining
-    // the appearance of that element.
+    // appearance of the direction. If an element within a direction includes a default-x
+    // attribute, the offset value will be ignored when determining the appearance of that element.
+    std::optional<int> offset;
 
     // a voice value of VALUE_UNSPECIFIED means unspecified
     int voice;
@@ -191,6 +195,7 @@ inline bool isDirectionDataEmpty(const DirectionData &directionData)
 MXAPI_EQUALS_BEGIN(DirectionData)
 MXAPI_EQUALS_MEMBER(tickTimePosition)
 MXAPI_EQUALS_MEMBER(placement)
+MXAPI_EQUALS_MEMBER(offset)
 MXAPI_EQUALS_MEMBER(voice)
 MXAPI_EQUALS_MEMBER(isStaffValueSpecified)
 MXAPI_EQUALS_MEMBER(isSoundDataSpecified)

--- a/src/include/mx/api/OttavaData.h
+++ b/src/include/mx/api/OttavaData.h
@@ -28,7 +28,14 @@ class OttavaStart
     SpannerStart spannerStart;
     OttavaType ottavaType;
 
-    OttavaStart() : spannerStart{}, ottavaType{OttavaType::unspecified}
+    // Octave-shift size fidelity knob. The size value (8 or 15) follows from ottavaType, so a
+    // 15ma/15mb line always writes size="15" while an 8va/8vb line omits the redundant, spec-
+    // default size="8". When true, the writer also emits that redundant size="8"; the reader sets
+    // it when the source spelled the attribute out. Leave false (the default) when authoring. It
+    // has no effect on a 15ma/15mb line, whose load-bearing size is always written.
+    bool writeDefaultSize;
+
+    OttavaStart() : spannerStart{}, ottavaType{OttavaType::unspecified}, writeDefaultSize{false}
     {
     }
 };
@@ -52,6 +59,7 @@ class OttavaStop
 MXAPI_EQUALS_BEGIN(OttavaStart)
 MXAPI_EQUALS_MEMBER(spannerStart)
 MXAPI_EQUALS_MEMBER(ottavaType)
+MXAPI_EQUALS_MEMBER(writeDefaultSize)
 MXAPI_EQUALS_END;
 MXAPI_NOT_EQUALS_AND_VECTORS(OttavaStart);
 

--- a/src/private/mx/impl/DirectionReader.cpp
+++ b/src/private/mx/impl/DirectionReader.cpp
@@ -110,7 +110,7 @@ DirectionReader::DirectionReader(const core::Harmony &inHarmony, Cursor inCursor
 api::DirectionData DirectionReader::getDirectionData()
 {
     myOutDirectionData = initializeData();
-    updateTimeForOffset();
+    parseOffset();
     parsePlacement();
     parseValues();
 
@@ -136,15 +136,18 @@ mx::api::DirectionData DirectionReader::initializeData()
     return result;
 }
 
-void DirectionReader::updateTimeForOffset()
+void DirectionReader::parseOffset()
 {
+    // tickTimePosition is left at the anchor (the current musical location); the <offset> is a
+    // drawn-position nudge recorded verbatim, not folded into the tick. The writer re-emits it and
+    // MeasureWriter still places the direction by its anchor, so an offset that happens to land on
+    // a note tick stays distinguishable from a plain direction there.
     if (myDirection)
     {
         if (myDirection->offset().has_value())
         {
             const auto rawVal = myDirection->offset()->value().value().value();
-            const auto offset = static_cast<int>(std::ceil(rawVal - 0.5));
-            myOutDirectionData.tickTimePosition += offset;
+            myOutDirectionData.offset = static_cast<int>(std::ceil(rawVal - 0.5));
         }
     }
     else if (myHarmony)
@@ -152,8 +155,7 @@ void DirectionReader::updateTimeForOffset()
         if (myHarmony->offset().has_value())
         {
             const auto rawVal = myHarmony->offset()->value().value().value();
-            const auto offset = static_cast<int>(std::ceil(rawVal - 0.5));
-            myOutDirectionData.tickTimePosition += offset;
+            myOutDirectionData.offset = static_cast<int>(std::ceil(rawVal - 0.5));
         }
     }
 }

--- a/src/private/mx/impl/DirectionReader.cpp
+++ b/src/private/mx/impl/DirectionReader.cpp
@@ -840,6 +840,8 @@ void DirectionReader::parseOctaveShift(const core::DirectionType &directionType)
     api::OttavaStart start;
     start.spannerStart = impl::getSpannerStart(octaveShift);
     start.ottavaType = ottavaType;
+    const bool isEightLine = ottavaType == api::OttavaType::o8va || ottavaType == api::OttavaType::o8vb;
+    start.writeDefaultSize = isEightLine && octaveShift.size().has_value();
     start.spannerStart.tickTimePosition = myCursor.tickTimePosition;
     myOutDirectionData.ottavaStarts.emplace_back(std::move(start));
     appendOrderedComponent(api::DirectionComponentKind::ottavaStart,

--- a/src/private/mx/impl/DirectionReader.h
+++ b/src/private/mx/impl/DirectionReader.h
@@ -38,7 +38,7 @@ class DirectionReader
 
   private:
     mx::api::DirectionData initializeData();
-    void updateTimeForOffset();
+    void parseOffset();
     void parsePlacement();
     void parseValues();
     void fixTimes();

--- a/src/private/mx/impl/DirectionWriter.cpp
+++ b/src/private/mx/impl/DirectionWriter.cpp
@@ -399,30 +399,40 @@ void DirectionWriter::emitOttavaStart(const api::OttavaStart &ottavaStart, core:
         os.setNumber(core::NumberLevel{*number});
     }
 
+    int sizeValue = 8;
+
     switch (ottavaStart.ottavaType)
     {
     case api::OttavaType::o15ma: {
         os.setType(core::UpDownStopContinue::down());
-        os.setSize(15);
+        sizeValue = 15;
         break;
     }
     case api::OttavaType::o15mb: {
         os.setType(core::UpDownStopContinue::up());
-        os.setSize(15);
+        sizeValue = 15;
         break;
     }
     case api::OttavaType::o8va: {
         os.setType(core::UpDownStopContinue::down());
-        os.setSize(8);
+        sizeValue = 8;
         break;
     }
     case api::OttavaType::o8vb: {
         os.setType(core::UpDownStopContinue::up());
-        os.setSize(8);
+        sizeValue = 8;
         break;
     }
     default:
         break;
+    }
+
+    // size follows from ottavaType; a 15ma/15mb line's size encodes the two-octave shift, so it is
+    // always written, while the redundant default size="8" is emitted only when writeDefaultSize is
+    // set (the source spelled it out).
+    if (sizeValue != 8 || ottavaStart.writeDefaultSize)
+    {
+        os.setSize(sizeValue);
     }
 
     core::DirectionType dt{};

--- a/src/private/mx/impl/DirectionWriter.cpp
+++ b/src/private/mx/impl/DirectionWriter.cpp
@@ -169,8 +169,24 @@ std::vector<core::MusicDataChoice> DirectionWriter::getDirectionLikeThings()
 
     int offset = 0;
 
-    if (myDirectionData.tickTimePosition != myCursor.tickTimePosition)
+    if (myDirectionData.offset.has_value())
     {
+        // The source carried an explicit <offset>: a drawn-position nudge measured from the
+        // direction's anchor (tickTimePosition). Re-emit it verbatim, with no sound attribute -- an
+        // <offset> moves only where the direction is drawn, so playback stays at the anchor.
+        offset = *myDirectionData.offset;
+        if (offset != 0)
+        {
+            core::Offset coreOffset{};
+            coreOffset.setValue(core::Divisions{core::Decimal{static_cast<double>(offset)}});
+            direction.setOffset(coreOffset);
+        }
+    }
+    else if (myDirectionData.tickTimePosition != myCursor.tickTimePosition)
+    {
+        // No modeled offset, but the direction is anchored off the cursor tick: synthesize an
+        // <offset> so the serialized location matches tickTimePosition, and carry playback with it
+        // (sound="yes") since here the offset stands in for the note-stream position itself.
         offset = myDirectionData.tickTimePosition - myCursor.tickTimePosition;
         core::Offset coreOffset{};
         coreOffset.setValue(core::Divisions{core::Decimal{static_cast<double>(offset)}});

--- a/src/private/mxtest/api/DirectionDataTest.cpp
+++ b/src/private/mxtest/api/DirectionDataTest.cpp
@@ -84,13 +84,20 @@ TEST(OutOfOrderDoesntThrow, DirectionData)
     const auto &rstaff = rmeasure.staves.back();
     const auto &rdirections = rstaff.directions;
 
+    // tickTimePosition is the anchor and offset is the drawn-position shift, so the direction's
+    // effective (drawn) location is their sum. A mark authored between note ticks anchors to the
+    // preceding note and carries the remainder as an offset.
+    const auto effectiveTick = [](const DirectionData &d) {
+        return d.tickTimePosition + (d.offset.has_value() ? *d.offset : 0);
+    };
+
     CHECK_EQUAL(3, rdirections.size());
     auto rdirection = rdirections.cbegin();
-    CHECK_EQUAL(8, rdirection->tickTimePosition);
+    CHECK_EQUAL(8, effectiveTick(*rdirection));
     ++rdirection;
-    CHECK_EQUAL(9, rdirection->tickTimePosition);
+    CHECK_EQUAL(9, effectiveTick(*rdirection));
     ++rdirection;
-    CHECK_EQUAL(10, rdirection->tickTimePosition);
+    CHECK_EQUAL(10, effectiveTick(*rdirection));
 }
 
 T_END;
@@ -184,13 +191,19 @@ TEST(OutOfOrderTorture, DirectionData)
             expectedShift = (-1 * tick0);
         }
 
+        // tickTimePosition is the anchor and offset is the drawn-position shift; their sum is the
+        // effective (drawn) location, which is what was authored on each mark.
+        const auto effectiveTick = [](const DirectionData &d) {
+            return d.tickTimePosition + (d.offset.has_value() ? *d.offset : 0);
+        };
+
         CHECK_EQUAL(3, rdirections.size());
         auto rdirection = rdirections.cbegin();
-        CHECK_EQUAL(tempTickSorter.at(0), rdirection->tickTimePosition);
+        CHECK_EQUAL(tempTickSorter.at(0), effectiveTick(*rdirection));
         ++rdirection;
-        CHECK_EQUAL(tempTickSorter.at(1), rdirection->tickTimePosition);
+        CHECK_EQUAL(tempTickSorter.at(1), effectiveTick(*rdirection));
         ++rdirection;
-        CHECK_EQUAL(tempTickSorter.at(2), rdirection->tickTimePosition);
+        CHECK_EQUAL(tempTickSorter.at(2), effectiveTick(*rdirection));
     }
 }
 


### PR DESCRIPTION
## Human Summary

This one is sort of complicated. But if I understand it correctly, the `<offset>` element places a direction somewhere other than where it happens to actually be in the stateful parse position. I believe it is unnecessary, perhaps, in MusicXML. Or perhaps it allows you to place a direction in the measure close to a note that the application attaches the direction to, then say where it actually appears by nudging its time position. It is weird. But this optional offset allows us to represent certain corpus files correctly and, as such, probably is actually needed for correctness in some cases.

## Summary

Reworks how a direction's `<offset>` is modeled so that the anchor a direction belongs to and the drawn-position nudge are two separate, first-class quantities. The goal is that an author positions a direction by the note it belongs to and never has to reach for the arcane `<offset>` element.

**Before.** The reader folded `<offset>` into `tickTimePosition` and discarded the raw value. `tickTimePosition` therefore meant the *drawn* location, and on write the offset was re-synthesized as `tickTimePosition - cursor`. An offset that landed exactly on a note tick collapsed to zero, so the `<offset>` silently vanished and the direction re-anchored to the wrong note. The model also could not tell a visual-only offset apart from one meant to move playback.

**After.**
- `tickTimePosition` is the **anchor** -- the musical location (note/beat) the direction belongs to.
- `DirectionData::offset` (new, `std::optional<int>`) is the source's `<offset>`, a drawn-position shift in divisions, kept verbatim or left absent. The drawn position is `tickTimePosition + offset`.
- The reader stores the anchor and the offset without folding. The writer is field-first: a modeled offset is re-emitted with **no** `sound` attribute (an `<offset>` moves only where the direction is drawn, so playback stays at the anchor); a direction that merely sits off the cursor tick with no modeled offset still gets a synthesized `sound="yes"` offset, exactly as before.
- `MeasureWriter` is untouched -- it already places directions by `tickTimePosition`, which is now the anchor.

Authoring stays simple: set `tickTimePosition` to where the direction belongs and leave `offset` absent; the automatic path handles placement. `offset` is a round-trip fidelity knob you only touch to preserve a source's explicit `<offset>`.

## Breaking change

`tickTimePosition` changes meaning for **offset-bearing** directions: it is now the anchor, not the drawn location. Directions without an offset are unaffected (anchor == drawn location). A consumer that reads `tickTimePosition` for an offset direction and wants the drawn location must now add `offset`.

The `OutOfOrderDoesntThrow` / `OutOfOrderTorture` round-trip tests now assert the effective (drawn) location `tickTimePosition + offset`, which equals what they previously asserted against the folded tick.

## Testing

- [x] Full unit suite passes (5130 assertions in 451 test cases), including the reworked `OutOfOrder*` direction round-trip tests
- [x] api round-trip discovery: 287 PASS, 0 regressions; the `<offset>`-bearing corpus files (`ly31a_Directions`, `ly33d_Spanners_OctaveShifts`) round-trip their bare `<offset>` elements byte-for-byte. The pins land in the stacked round-trip PR (#366).

## References

- Progresses #324
- Second of a three-PR stack: octave-shift size (#365) &rarr; direction offset (this) &rarr; round-trip canonicalizers + pins (#366)
