### PR TITLE
feat: round-trip repeat direction, after-jump, and winged in mx::api

### DIFF
--- a/src/include/mx/api/BarlineData.h
+++ b/src/include/mx/api/BarlineData.h
@@ -37,6 +37,27 @@ enum class EndingType
     discontinue
 };
 
+// Whether a repeat mark faces forward (the start of a repeated section, drawn |:) or backward
+// (the end, drawn :|).
+enum class RepeatDirection
+{
+    unspecified,
+    forward,
+    backward
+};
+
+// The winged extensions that can be drawn above and below a repeat barline. `none` is a real
+// value (no wings, the MusicXML default); `unspecified` means the attribute is absent.
+enum class RepeatWinged
+{
+    unspecified,
+    none,
+    straight,
+    curved,
+    doubleStraight,
+    doubleCurved
+};
+
 class BarlineData
 {
   public:
@@ -48,11 +69,23 @@ class BarlineData
     // Number of times a backward repeat is played (the repeat's `times` attribute). 0 = not
     // specified, mirroring endingNumber above.
     int repeatTimes;
+    // Whether the repeat faces forward (start of a repeated section) or backward (end). Leave
+    // unspecified to let mx infer it from the barline's position -- a repeat on a left or
+    // downbeat barline is forward, otherwise backward -- or set it to control the direction.
+    RepeatDirection repeatDirection;
+    // The repeat's `after-jump` attribute: when yes, the repeat is only taken after a da capo or
+    // dal segno jump reaches it, not on the first pass. Leave unspecified to omit the attribute.
+    Bool repeatAfterJump;
+    // The winged extensions drawn above and below the repeat barline. RepeatWinged::none is an
+    // explicit `winged="none"`; leave unspecified to omit the attribute.
+    RepeatWinged repeatWinged;
     HorizontalAlignment location;
 
     BarlineData()
         : tickTimePosition{0}, barlineType{BarlineType::normal}, endingType{EndingType::none}, endingNumber{0},
-          repeat{false}, repeatTimes{0}, location{HorizontalAlignment::unspecified}
+          repeat{false}, repeatTimes{0}, repeatDirection{RepeatDirection::unspecified},
+          repeatAfterJump{Bool::unspecified}, repeatWinged{RepeatWinged::unspecified},
+          location{HorizontalAlignment::unspecified}
     {
     }
 };
@@ -64,6 +97,9 @@ MXAPI_EQUALS_MEMBER(endingType)
 MXAPI_EQUALS_MEMBER(endingNumber)
 MXAPI_EQUALS_MEMBER(repeat)
 MXAPI_EQUALS_MEMBER(repeatTimes)
+MXAPI_EQUALS_MEMBER(repeatDirection)
+MXAPI_EQUALS_MEMBER(repeatAfterJump)
+MXAPI_EQUALS_MEMBER(repeatWinged)
 MXAPI_EQUALS_MEMBER(location)
 MXAPI_EQUALS_END;
 MXAPI_NOT_EQUALS_AND_VECTORS(BarlineData);

--- a/src/private/mx/impl/Converter.cpp
+++ b/src/private/mx/impl/Converter.cpp
@@ -402,6 +402,19 @@ const Converter::EnumMap<core::StartStopDiscontinue, api::EndingType> Converter:
     {core::StartStopDiscontinue::stop(), api::EndingType::stop},
     {core::StartStopDiscontinue::discontinue(), api::EndingType::discontinue}};
 
+const Converter::EnumMap<core::BackwardForward, api::RepeatDirection> Converter::repeatDirectionMap = {
+    {core::BackwardForward::forward(), api::RepeatDirection::forward},
+    {core::BackwardForward::backward(), api::RepeatDirection::backward},
+};
+
+const Converter::EnumMap<core::Winged, api::RepeatWinged> Converter::wingedMap = {
+    {core::Winged::none(), api::RepeatWinged::none},
+    {core::Winged::straight(), api::RepeatWinged::straight},
+    {core::Winged::curved(), api::RepeatWinged::curved},
+    {core::Winged::doubleStraight(), api::RepeatWinged::doubleStraight},
+    {core::Winged::doubleCurved(), api::RepeatWinged::doubleCurved},
+};
+
 const Converter::EnumMap<core::FermataShape, api::MarkType> Converter::fermataMap = {
     {core::FermataShape::normal(), api::MarkType::fermataNormal},
     {core::FermataShape::angled(), api::MarkType::fermataAngled},
@@ -1830,6 +1843,26 @@ core::BarStyle Converter::convert(api::BarlineType value) const
 core::StartStopDiscontinue Converter::convert(api::EndingType value) const
 {
     return findCoreItem(endingMap, core::StartStopDiscontinue::start(), value);
+}
+
+core::BackwardForward Converter::convert(api::RepeatDirection value) const
+{
+    return findCoreItem(repeatDirectionMap, core::BackwardForward::backward(), value);
+}
+
+api::RepeatDirection Converter::convert(core::BackwardForward value) const
+{
+    return findApiItem(repeatDirectionMap, api::RepeatDirection::unspecified, value);
+}
+
+core::Winged Converter::convert(api::RepeatWinged value) const
+{
+    return findCoreItem(wingedMap, core::Winged::none(), value);
+}
+
+api::RepeatWinged Converter::convert(core::Winged value) const
+{
+    return findApiItem(wingedMap, api::RepeatWinged::unspecified, value);
 }
 
 api::BarlineType Converter::convert(core::BarStyle value) const

--- a/src/private/mx/impl/Converter.h
+++ b/src/private/mx/impl/Converter.h
@@ -16,6 +16,7 @@
 #include "mx/core/generated/AboveBelow.h"
 #include "mx/core/generated/AccidentalValue.h"
 #include "mx/core/generated/ArticulationsChoice.h"
+#include "mx/core/generated/BackwardForward.h"
 #include "mx/core/generated/BarStyle.h"
 #include "mx/core/generated/BeamValue.h"
 #include "mx/core/generated/BeaterValue.h"
@@ -59,6 +60,7 @@
 #include "mx/core/generated/Transpose.h"
 #include "mx/core/generated/Valign.h"
 #include "mx/core/generated/WedgeType.h"
+#include "mx/core/generated/Winged.h"
 #include "mx/core/generated/WoodValue.h"
 #include "mx/core/generated/YesNo.h"
 
@@ -154,6 +156,12 @@ class Converter
     api::BarlineType convert(core::BarStyle value) const;
 
     core::StartStopDiscontinue convert(api::EndingType value) const;
+
+    core::BackwardForward convert(api::RepeatDirection value) const;
+    api::RepeatDirection convert(core::BackwardForward value) const;
+
+    core::Winged convert(api::RepeatWinged value) const;
+    api::RepeatWinged convert(core::Winged value) const;
 
     core::RightLeftMiddle convertBarlinePlacement(api::HorizontalAlignment value) const;
     api::HorizontalAlignment convertBarlinePlacement(core::RightLeftMiddle value) const;
@@ -254,6 +262,8 @@ class Converter
     const static EnumMap<core::BarStyle, api::BarlineType> barlineMap;
     const static EnumMap<core::RightLeftMiddle, api::HorizontalAlignment> barlinePlacementMap;
     const static EnumMap<core::StartStopDiscontinue, api::EndingType> endingMap;
+    const static EnumMap<core::BackwardForward, api::RepeatDirection> repeatDirectionMap;
+    const static EnumMap<core::Winged, api::RepeatWinged> wingedMap;
     const static EnumMap<core::LineEnd, api::LineHook> lineStopMap;
     const static EnumMap<core::GroupSymbolValue, api::BracketType> bracketMap;
     const static EnumMap<core::GroupBarlineValue, api::GroupBarline> groupBarlineMap;

--- a/src/private/mx/impl/MeasureReader.cpp
+++ b/src/private/mx/impl/MeasureReader.cpp
@@ -38,6 +38,7 @@
 #include "mx/core/generated/PartwiseMeasure.h"
 #include "mx/core/generated/PositiveDivisions.h"
 #include "mx/core/generated/Print.h"
+#include "mx/core/generated/Repeat.h"
 #include "mx/core/generated/RightLeftMiddle.h"
 #include "mx/core/generated/Semitones.h"
 #include "mx/core/generated/Sound.h"
@@ -913,6 +914,9 @@ void MeasureReader::parseBarline(const core::Barline &inMxBarline) const
     auto endingNumber = 0;
     auto repeat = false;
     auto repeatTimes = 0;
+    auto repeatDirection = api::RepeatDirection::unspecified;
+    auto repeatAfterJump = api::Bool::unspecified;
+    auto repeatWinged = api::RepeatWinged::unspecified;
 
     if (inMxBarline.location().has_value())
     {
@@ -962,8 +966,20 @@ void MeasureReader::parseBarline(const core::Barline &inMxBarline) const
 
     if (inMxBarline.repeat().has_value())
     {
+        const auto &mxRepeat = *inMxBarline.repeat();
         repeat = true;
-        repeatTimes = inMxBarline.repeat()->times().value_or(0);
+        repeatTimes = mxRepeat.times().value_or(0);
+        repeatDirection = myConverter.convert(mxRepeat.direction());
+
+        if (mxRepeat.afterJump().has_value())
+        {
+            repeatAfterJump = myConverter.convert(*mxRepeat.afterJump());
+        }
+
+        if (mxRepeat.winged().has_value())
+        {
+            repeatWinged = myConverter.convert(*mxRepeat.winged());
+        }
     }
 
     barline.barlineType = style;
@@ -972,6 +988,9 @@ void MeasureReader::parseBarline(const core::Barline &inMxBarline) const
     barline.endingNumber = endingNumber;
     barline.repeat = repeat;
     barline.repeatTimes = repeatTimes;
+    barline.repeatDirection = repeatDirection;
+    barline.repeatAfterJump = repeatAfterJump;
+    barline.repeatWinged = repeatWinged;
     myOutMeasureData.barlines.emplace_back(std::move(barline));
 }
 

--- a/src/private/mx/impl/MeasureWriter.cpp
+++ b/src/private/mx/impl/MeasureWriter.cpp
@@ -30,6 +30,7 @@
 #include "mx/core/generated/SystemLayout.h"
 #include "mx/core/generated/SystemMargins.h"
 #include "mx/core/generated/Tenths.h"
+#include "mx/core/generated/Winged.h"
 #include "mx/core/generated/YesNo.h"
 #include "mx/impl/Converter.h"
 #include "mx/impl/DirectionWriter.h"
@@ -860,7 +861,12 @@ void MeasureWriter::writeBarlines(int tickTimePosition)
         {
             core::Repeat repeatElement{};
 
-            if (myBarlinesIter->location == api::HorizontalAlignment::left || myBarlinesIter->tickTimePosition == 0)
+            if (myBarlinesIter->repeatDirection != api::RepeatDirection::unspecified)
+            {
+                repeatElement.setDirection(myConverter.convert(myBarlinesIter->repeatDirection));
+            }
+            else if (myBarlinesIter->location == api::HorizontalAlignment::left ||
+                     myBarlinesIter->tickTimePosition == 0)
             {
                 repeatElement.setDirection(mx::core::BackwardForward::forward());
             }
@@ -872,6 +878,16 @@ void MeasureWriter::writeBarlines(int tickTimePosition)
             if (myBarlinesIter->repeatTimes > 0)
             {
                 repeatElement.setTimes(myBarlinesIter->repeatTimes);
+            }
+
+            if (myBarlinesIter->repeatAfterJump != api::Bool::unspecified)
+            {
+                repeatElement.setAfterJump(myConverter.convert(myBarlinesIter->repeatAfterJump));
+            }
+
+            if (myBarlinesIter->repeatWinged != api::RepeatWinged::unspecified)
+            {
+                repeatElement.setWinged(myConverter.convert(myBarlinesIter->repeatWinged));
             }
 
             barlineElement.setRepeat(repeatElement);

--- a/src/private/mxtest/api/RepeatApiTest.cpp
+++ b/src/private/mxtest/api/RepeatApiTest.cpp
@@ -1,0 +1,147 @@
+// MusicXML Class Library
+// Copyright (c) by Matthew James Briggs
+// Distributed under the MIT License
+
+#include "mxtest/control/CompileControl.h"
+#ifdef MX_COMPILE_API_TESTS
+
+#include "cpul/cpulTestHarness.h"
+#include "mx/api/DocumentManager.h"
+#include "mxtest/api/RoundTrip.h"
+#include "mxtest/api/TestHelpers.h"
+
+using namespace std;
+using namespace mx::api;
+using namespace mxtest;
+
+// Build a one-measure, one-note score whose single barline the caller can configure. Mirrors the
+// scaffolding in MeasureDataTest.cpp so each test can focus on the repeat fields.
+static ScoreData makeScoreWithBarlineForRepeat()
+{
+    ScoreData score;
+    score.parts.emplace_back();
+    auto &part = score.parts.back();
+    part.measures.emplace_back();
+    auto &measure = part.measures.back();
+    measure.staves.emplace_back();
+    auto &staff = measure.staves.back();
+    staff.voices[0].notes.emplace_back();
+    measure.barlines.emplace_back();
+    return score;
+}
+
+// A backward (end) repeat that carries every repeat attribute must survive the round trip.
+TEST(backwardRepeatAllAttributesRoundTrip, Repeat)
+{
+    auto score = makeScoreWithBarlineForRepeat();
+    auto &barline = score.parts.back().measures.back().barlines.back();
+    barline.barlineType = BarlineType::lightHeavy;
+    barline.location = HorizontalAlignment::right;
+    barline.repeat = true;
+    barline.repeatDirection = RepeatDirection::backward;
+    barline.repeatTimes = 3;
+    barline.repeatAfterJump = Bool::yes;
+    barline.repeatWinged = RepeatWinged::curved;
+
+    const auto out = roundTrip(score);
+
+    const auto &obarlines = out.parts.back().measures.back().barlines;
+    REQUIRE(obarlines.size() == 1);
+    const auto &ob = obarlines.front();
+    CHECK(ob.repeat);
+    CHECK(RepeatDirection::backward == ob.repeatDirection);
+    CHECK_EQUAL(3, ob.repeatTimes);
+    CHECK(Bool::yes == ob.repeatAfterJump);
+    CHECK(RepeatWinged::curved == ob.repeatWinged);
+}
+
+T_END;
+
+// A forward (start) repeat must remain forward through the round trip, distinct from a backward
+// repeat -- the direction is no longer merely inferred from the barline position.
+TEST(forwardRepeatDirectionRoundTrip, Repeat)
+{
+    auto score = makeScoreWithBarlineForRepeat();
+    auto &barline = score.parts.back().measures.back().barlines.back();
+    barline.barlineType = BarlineType::heavyLight;
+    barline.location = HorizontalAlignment::left;
+    barline.repeat = true;
+    barline.repeatDirection = RepeatDirection::forward;
+    barline.repeatWinged = RepeatWinged::doubleStraight;
+
+    const auto out = roundTrip(score);
+
+    const auto &ob = out.parts.back().measures.back().barlines.front();
+    CHECK(ob.repeat);
+    CHECK(RepeatDirection::forward == ob.repeatDirection);
+    CHECK(RepeatWinged::doubleStraight == ob.repeatWinged);
+}
+
+T_END;
+
+// The reader must surface direction, times, after-jump, and winged from the MusicXML. An explicit
+// winged="none" is RepeatWinged::none, distinct from an absent attribute (unspecified).
+TEST(repeatAttributesReadFromXml, Repeat)
+{
+    const std::string xml = R"(<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<score-partwise version="4.0">
+  <part-list>
+    <score-part id="id1">
+      <part-name>x</part-name>
+    </score-part>
+  </part-list>
+  <part id="id1">
+    <measure number="1">
+      <barline location="right">
+        <repeat direction="backward" times="1" after-jump="yes" winged="none" />
+      </barline>
+    </measure>
+  </part>
+</score-partwise>)";
+
+    const auto score = fromXml(xml);
+    REQUIRE(score.parts.size() == 1);
+    const auto &barlines = score.parts.back().measures.back().barlines;
+    REQUIRE(barlines.size() == 1);
+    const auto &ob = barlines.front();
+    CHECK(ob.repeat);
+    CHECK(RepeatDirection::backward == ob.repeatDirection);
+    CHECK_EQUAL(1, ob.repeatTimes);
+    CHECK(Bool::yes == ob.repeatAfterJump);
+    CHECK(RepeatWinged::none == ob.repeatWinged);
+}
+
+T_END;
+
+// When after-jump and winged are absent from the source, they must read back as unspecified, not
+// as a defaulted concrete value.
+TEST(repeatOmittedAttributesAreUnspecified, Repeat)
+{
+    const std::string xml = R"(<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<score-partwise version="4.0">
+  <part-list>
+    <score-part id="id1">
+      <part-name>x</part-name>
+    </score-part>
+  </part-list>
+  <part id="id1">
+    <measure number="1">
+      <barline location="right">
+        <repeat direction="backward" />
+      </barline>
+    </measure>
+  </part>
+</score-partwise>)";
+
+    const auto score = fromXml(xml);
+    const auto &ob = score.parts.back().measures.back().barlines.front();
+    CHECK(ob.repeat);
+    CHECK(RepeatDirection::backward == ob.repeatDirection);
+    CHECK_EQUAL(0, ob.repeatTimes);
+    CHECK(Bool::unspecified == ob.repeatAfterJump);
+    CHECK(RepeatWinged::unspecified == ob.repeatWinged);
+}
+
+T_END;
+
+#endif


### PR DESCRIPTION
## Human Summary

Hmm, well I guess this completes support for repeats.

## Summary

`BarlineData` exposed a repeat only as a `repeat` bool plus `repeatTimes`. The reader
discarded the repeat's direction (forward vs backward), its `after-jump`, and its `winged`
attribute, and the writer could not emit them. Direction was reconstructed on write purely by
inferring it from the barline's position, which mislabels a repeat whenever the layout is not
the conventional one (for example a backward repeat in an otherwise empty measure).

This models the rest of the `<repeat>` element on `BarlineData`:

- `RepeatDirection repeatDirection` (forward or backward). Leave it unspecified and the writer
  still infers direction from the barline position, so hand-authored scores behave exactly as
  before; set it to control the direction explicitly. The reader always records the true
  direction.
- `Bool repeatAfterJump` for the `after-jump` attribute.
- `RepeatWinged repeatWinged` for the `winged` wing extensions. An explicit `winged="none"` is
  `RepeatWinged::none`, kept distinct from an absent attribute (`unspecified`).

The three fields are wired through `MeasureReader`, `MeasureWriter`, and `Converter` (two new
enum bridge tables; `after-jump` reuses the existing `YesNo` <-> `Bool` map). `after-jump` and
`winged` are emitted only when explicitly set, so barlines that never had them are byte-for-byte
unchanged.

The change is additive and non-breaking: `repeat` and `repeatTimes` keep their meaning, and the
new fields default to unspecified.

Context: this addresses the fidelity gap noted long ago in #130, where repeats were called
oversimplified in the api. It does not implement repeat expansion/unfolding (playing the score
straight through), which was that issue's original question and remains out of scope for the
data model.

## Testing

- [x] New `RepeatApiTest` cases: backward repeat with every attribute round-trips; forward
  direction stays forward; read-from-XML surfaces direction/times/after-jump/winged (including
  explicit `winged="none"`); omitted attributes read back as unspecified
- [x] Full unit suite passes (5151 assertions in 455 test cases)
- [x] api round-trip regression: 287 passed, 0 failed (of 287 pinned)
- [x] api round-trip discovery: no regressions. `synthetic/repeat.4.0.xml` is still blocked by
  an unrelated barline `location` normalization (its source `<barline>` carries no `location`,
  which the writer always emits), so it is not added to the baseline; the unit tests are the
  regression coverage

## References

- Progresses #130
- Follows #271, which added `repeatTimes`
