### PR TITLE
feat: multirest roundtrip and `useSymbols` in mx::api

### DIFF
--- a/src/include/mx/api/MeasureData.h
+++ b/src/include/mx/api/MeasureData.h
@@ -70,6 +70,10 @@ class MeasureData
     // by this.
     int multiMeasureRest;
 
+    // When yes, use 1-, 2-, and 4-measure rest symbols instead of a single multimeasure-rest shape.
+    // Meaningful only when multiMeasureRest is greater than zero.
+    Bool multiMeasureRestUseSymbols;
+
     // The implicit attribute is set to "yes" for measures where the measure number should never
     // appear, such as pickup measures and the last half of mid-measure repeats. The value is "no"
     // if not specified.
@@ -97,7 +101,8 @@ class MeasureData
         : staves{}, timeSignature{}, number{}, measureNumbering{MeasureNumbering::unspecified},
           measureNumberingMultipleRestAlways{Bool::unspecified}, measureNumberingMultipleRestRange{Bool::unspecified},
           measureNumberingSystemRelation{SystemRelation::unspecified}, multiMeasureRest{VALUE_UNSPECIFIED},
-          implicit{Bool::unspecified}, nonControlling{Bool::unspecified}, width{DOUBLE_UNSPECIFIED}
+          multiMeasureRestUseSymbols{Bool::unspecified}, implicit{Bool::unspecified}, nonControlling{Bool::unspecified},
+          width{DOUBLE_UNSPECIFIED}
     {
     }
 };
@@ -112,6 +117,7 @@ MXAPI_EQUALS_MEMBER(measureNumberingMultipleRestAlways)
 MXAPI_EQUALS_MEMBER(measureNumberingMultipleRestRange)
 MXAPI_EQUALS_MEMBER(measureNumberingSystemRelation)
 MXAPI_EQUALS_MEMBER(multiMeasureRest)
+MXAPI_EQUALS_MEMBER(multiMeasureRestUseSymbols)
 MXAPI_EQUALS_MEMBER(implicit)
 MXAPI_EQUALS_MEMBER(nonControlling)
 MXAPI_EQUALS_MEMBER(width)

--- a/src/private/mx/impl/MeasureReader.cpp
+++ b/src/private/mx/impl/MeasureReader.cpp
@@ -640,6 +640,12 @@ std::optional<api::TransposeData> MeasureReader::parseAttributes(const core::Att
         {
             const auto &mr = measureStyle.choice().asMultipleRest();
             myOutMeasureData.multiMeasureRest = mr.value();
+            myOutMeasureData.multiMeasureRestUseSymbols = api::Bool::unspecified;
+            if (mr.useSymbols().has_value())
+            {
+                myOutMeasureData.multiMeasureRestUseSymbols =
+                    mr.useSymbols()->tag() == core::YesNo::Tag::yes ? api::Bool::yes : api::Bool::no;
+            }
         }
     }
 

--- a/src/private/mx/impl/MeasureWriter.cpp
+++ b/src/private/mx/impl/MeasureWriter.cpp
@@ -139,7 +139,7 @@ void MeasureWriter::writeMeasureGlobals()
 
     if (myMeasureData.multiMeasureRest > 0)
     {
-        myPropertiesWriter->writeMultipleRest(myMeasureData.multiMeasureRest);
+        myPropertiesWriter->writeMultipleRest(myMeasureData.multiMeasureRest, myMeasureData.multiMeasureRestUseSymbols);
     }
 
     if (!myMeasureData.timeSignature.isImplicit)

--- a/src/private/mx/impl/MeasureWriter.cpp
+++ b/src/private/mx/impl/MeasureWriter.cpp
@@ -137,6 +137,11 @@ void MeasureWriter::writeMeasureGlobals()
         myPropertiesWriter->writePartSymbol(*myMeasureData.partSymbol);
     }
 
+    if (myMeasureData.multiMeasureRest > 0)
+    {
+        myPropertiesWriter->writeMultipleRest(myMeasureData.multiMeasureRest);
+    }
+
     if (!myMeasureData.timeSignature.isImplicit)
     {
         myPropertiesWriter->writeTime(myMeasureData.timeSignature, api::INDEX_UNSPECIFIED);

--- a/src/private/mx/impl/PropertiesWriter.cpp
+++ b/src/private/mx/impl/PropertiesWriter.cpp
@@ -15,7 +15,10 @@
 #include "mx/core/generated/Key.h"
 #include "mx/core/generated/KeyAccidental.h"
 #include "mx/core/generated/KeyChoice.h"
+#include "mx/core/generated/MeasureStyle.h"
+#include "mx/core/generated/MeasureStyleChoice.h"
 #include "mx/core/generated/Mode.h"
+#include "mx/core/generated/MultipleRest.h"
 #include "mx/core/generated/MusicDataChoice.h"
 #include "mx/core/generated/NonTraditionalKeyGroup.h"
 #include "mx/core/generated/PartSymbol.h"
@@ -69,6 +72,17 @@ bool PropertiesWriter::isPropertiesEmpty()
 void PropertiesWriter::writeDivisions(int value)
 {
     myAttributes.setDivisions(core::PositiveDivisions{core::Decimal{static_cast<double>(value)}});
+    myHasContent = true;
+}
+
+void PropertiesWriter::writeMultipleRest(int measureCount)
+{
+    core::MultipleRest multipleRest{};
+    multipleRest.setValue(measureCount);
+
+    core::MeasureStyle measureStyle{};
+    measureStyle.setChoice(core::MeasureStyleChoice::multipleRest(std::move(multipleRest)));
+    myAttributes.addMeasureStyle(std::move(measureStyle));
     myHasContent = true;
 }
 

--- a/src/private/mx/impl/PropertiesWriter.cpp
+++ b/src/private/mx/impl/PropertiesWriter.cpp
@@ -38,6 +38,7 @@
 #include "mx/core/generated/TimeSymbol.h"
 #include "mx/core/generated/TraditionalKeyGroup.h"
 #include "mx/core/generated/Transpose.h"
+#include "mx/core/generated/YesNo.h"
 #include "mx/impl/Converter.h"
 
 namespace mx
@@ -75,10 +76,14 @@ void PropertiesWriter::writeDivisions(int value)
     myHasContent = true;
 }
 
-void PropertiesWriter::writeMultipleRest(int measureCount)
+void PropertiesWriter::writeMultipleRest(int measureCount, api::Bool useSymbols)
 {
     core::MultipleRest multipleRest{};
     multipleRest.setValue(measureCount);
+    if (useSymbols != api::Bool::unspecified)
+    {
+        multipleRest.setUseSymbols(useSymbols == api::Bool::yes ? core::YesNo::yes() : core::YesNo::no());
+    }
 
     core::MeasureStyle measureStyle{};
     measureStyle.setChoice(core::MeasureStyleChoice::multipleRest(std::move(multipleRest)));

--- a/src/private/mx/impl/PropertiesWriter.h
+++ b/src/private/mx/impl/PropertiesWriter.h
@@ -59,7 +59,7 @@ class PropertiesWriter
     void writeClef(int staffIndex, const api::ClefData &inClefData);
     void writePartSymbol(const api::PartSymbolData &inPartSymbolData);
     void writeTranspose(int staffIndex, const api::TransposeData &inTransposeData);
-    void writeMultipleRest(int measureCount);
+    void writeMultipleRest(int measureCount, api::Bool useSymbols);
 
   private:
     void allocate();

--- a/src/private/mx/impl/PropertiesWriter.h
+++ b/src/private/mx/impl/PropertiesWriter.h
@@ -59,6 +59,7 @@ class PropertiesWriter
     void writeClef(int staffIndex, const api::ClefData &inClefData);
     void writePartSymbol(const api::PartSymbolData &inPartSymbolData);
     void writeTranspose(int staffIndex, const api::TransposeData &inTransposeData);
+    void writeMultipleRest(int measureCount);
 
   private:
     void allocate();

--- a/src/private/mxtest/api/MeasureDataTest.cpp
+++ b/src/private/mxtest/api/MeasureDataTest.cpp
@@ -340,15 +340,17 @@ TEST(multiMeasureRestRoundTrip, MeasureData)
     part.measures.emplace_back();
     auto &measure = part.measures.back();
     measure.multiMeasureRest = 4;
+    measure.multiMeasureRestUseSymbols = Bool::yes;
     measure.staves.emplace_back();
     measure.staves.back().voices[0].notes.emplace_back();
 
     const auto xml = mxtest::toXml(score);
     CHECK(xml.find("<measure-style>") != std::string::npos);
-    CHECK(xml.find("<multiple-rest>4</multiple-rest>") != std::string::npos);
+    CHECK(xml.find("<multiple-rest use-symbols=\"yes\">4</multiple-rest>") != std::string::npos);
 
     const auto outScore = mxtest::fromXml(xml);
     CHECK_EQUAL(4, outScore.parts.front().measures.front().multiMeasureRest);
+    CHECK(Bool::yes == outScore.parts.front().measures.front().multiMeasureRestUseSymbols);
 }
 
 T_END;
@@ -361,6 +363,7 @@ TEST(nonPositiveMultiMeasureRestOmitsElement, MeasureData)
     part.measures.emplace_back();
     auto &measure = part.measures.back();
     measure.multiMeasureRest = 0;
+    measure.multiMeasureRestUseSymbols = Bool::yes;
     measure.staves.emplace_back();
     measure.staves.back().voices[0].notes.emplace_back();
 

--- a/src/private/mxtest/api/MeasureDataTest.cpp
+++ b/src/private/mxtest/api/MeasureDataTest.cpp
@@ -332,4 +332,42 @@ TEST(measureNumberingUnspecifiedOmitsElement, MeasureData)
 
 T_END;
 
+TEST(multiMeasureRestRoundTrip, MeasureData)
+{
+    ScoreData score;
+    score.parts.emplace_back();
+    auto &part = score.parts.back();
+    part.measures.emplace_back();
+    auto &measure = part.measures.back();
+    measure.multiMeasureRest = 4;
+    measure.staves.emplace_back();
+    measure.staves.back().voices[0].notes.emplace_back();
+
+    const auto xml = mxtest::toXml(score);
+    CHECK(xml.find("<measure-style>") != std::string::npos);
+    CHECK(xml.find("<multiple-rest>4</multiple-rest>") != std::string::npos);
+
+    const auto outScore = mxtest::fromXml(xml);
+    CHECK_EQUAL(4, outScore.parts.front().measures.front().multiMeasureRest);
+}
+
+T_END;
+
+TEST(nonPositiveMultiMeasureRestOmitsElement, MeasureData)
+{
+    ScoreData score;
+    score.parts.emplace_back();
+    auto &part = score.parts.back();
+    part.measures.emplace_back();
+    auto &measure = part.measures.back();
+    measure.multiMeasureRest = 0;
+    measure.staves.emplace_back();
+    measure.staves.back().voices[0].notes.emplace_back();
+
+    const auto xml = mxtest::toXml(score);
+    CHECK(xml.find("<multiple-rest>") == std::string::npos);
+}
+
+T_END;
+
 #endif

--- a/src/private/mxtest/api/roundtrip-baseline.txt
+++ b/src/private/mxtest/api/roundtrip-baseline.txt
@@ -526,3 +526,14 @@ musuite/testDirections1.xml
 # words-then-dynamics directions with a words/symbol/words run ("gliss. " + arrowBlackUp
 # + " al niente").
 synthetic/words-symbol.4.0.xml
+
+# Unblocked by writing MeasureData::multiMeasureRest as
+# <attributes><measure-style><multiple-rest>. The reader already populated the
+# field, but the writer dropped it.
+lysuite/ly02a_Rests_Durations.xml
+lysuite/ly02c_Rests_MultiMeasureRests.xml
+lysuite/ly02d_Rests_Multimeasure_TimeSignatures.xml
+lysuite/ly03d_Rhythm_DottedDurations_Factors.xml
+musuite/testMultiMeasureRest1.xml
+musuite/testMultiMeasureRest2.xml
+musuite/testMultiMeasureRest3.xml


### PR DESCRIPTION
  ## Human Summary

This completes basic multimeasure-rest support in `mx::api`, including whether short rests use individual rest symbols or a single multimeasure-rest shape.

  ## Summary

`MeasureData::multiMeasureRest` already represented the number of measures in a multimeasure rest, and `MeasureReader` populated it from `<multiple-rest>`. The writer did not consume the field, so the element was dropped when writing a `ScoreData`.

This adds the missing write path:

- `PropertiesWriter` creates `<measure-style><multiple-rest>`.
- `MeasureWriter` emits it when `multiMeasureRest` is greater than zero.
- Nonpositive values are omitted because MusicXML requires a positive integer.

The change also adds `Bool multiMeasureRestUseSymbols` to `MeasureData` for the MusicXML `use-symbols` attribute:

- `yes` and `no` are read and written explicitly.
- `unspecified` omits the attribute.
- The field is ignored when the multimeasure-rest count is nonpositive.

The change is additive and non-breaking. Existing authored scores behave as before unless they set a positive `multiMeasureRest` value.

Seven corpus files now survive the API round trip and are pinned in the regression baseline:

- `lysuite/ly02a_Rests_Durations.xml`
- `lysuite/ly02c_Rests_MultiMeasureRests.xml`
- `lysuite/ly02d_Rests_Multimeasure_TimeSignatures.xml`
- `lysuite/ly03d_Rhythm_DottedDurations_Factors.xml`
- `musuite/testMultiMeasureRest1.xml`
- `musuite/testMultiMeasureRest2.xml`
- `musuite/testMultiMeasureRest3.xml`

## Testing

- [x] `multiMeasureRestRoundTrip_MeasureData` verifies the element, count, `use-symbols="yes"`, and read/write round trip
- [x] `nonPositiveMultiMeasureRestOmitsElement_MeasureData` verifies that invalid counts are omitted even when `useSymbols` is set
- [x] Full API suite passes: 5201 assertions in 460 test cases
- [x] API round-trip regression: 295 passed, 0 failed
- [x] API round-trip discovery: seven newly passing files and no regressions
- [x] Changed files formatted and `git diff --check` passes

