### PR TITLE
feat: extend octave-shift support in mx::api

### DIFF
--- a/src/include/mx/api/OttavaData.h
+++ b/src/include/mx/api/OttavaData.h
@@ -19,7 +19,9 @@ enum class OttavaType
     o8va,  // octave up (writes octave-shift type="down")
     o8vb,  // octave down (writes octave-shift type="up")
     o15ma, // 2 octaves up (writes octave-shift type="down")
-    o15mb  // 2 octaves down (writes octave-shift type="up")
+    o15mb, // 2 octaves down (writes octave-shift type="up")
+    o22ma, // 3 octaves up (writes octave-shift type="down")
+    o22mb  // 3 octaves down (writes octave-shift type="up")
 };
 
 class OttavaStart
@@ -28,11 +30,11 @@ class OttavaStart
     SpannerStart spannerStart;
     OttavaType ottavaType;
 
-    // Octave-shift size fidelity knob. The size value (8 or 15) follows from ottavaType, so a
-    // 15ma/15mb line always writes size="15" while an 8va/8vb line omits the redundant, spec-
-    // default size="8". When true, the writer also emits that redundant size="8"; the reader sets
-    // it when the source spelled the attribute out. Leave false (the default) when authoring. It
-    // has no effect on a 15ma/15mb line, whose size is always written.
+    // Octave-shift size fidelity knob. The size value (8, 15, or 22) follows from ottavaType, so
+    // 15ma/15mb and 22ma/22mb lines always write their size while an 8va/8vb line omits the
+    // redundant, spec-default size="8". When true, the writer also emits that redundant size="8";
+    // the reader sets it when the source spelled the attribute out. Leave false (the default) when
+    // authoring. It has no effect on a 15ma/15mb or 22ma/22mb line, whose size is always written.
     bool writeDefaultSize;
 
     OttavaStart() : spannerStart{}, ottavaType{OttavaType::unspecified}, writeDefaultSize{false}
@@ -45,7 +47,7 @@ class OttavaStop
   public:
     SpannerStop spannerStop;
 
-    // MusicXML's octave-shift allows a size attribute ("8" or "15") on the stop, not just the
+    // MusicXML's octave-shift allows a size attribute ("8", "15", or "22") on the stop, not just the
     // start. Most writers omit it there since it is implied by the corresponding start, but some
     // importers (e.g. MuseScore) expect it to be present. Absent by default; set it to have the
     // writer emit it explicitly.

--- a/src/private/mx/impl/DirectionReader.cpp
+++ b/src/private/mx/impl/DirectionReader.cpp
@@ -731,17 +731,25 @@ void DirectionReader::parseOctaveShift(const core::DirectionType &directionType)
     // Per the MusicXML spec, octave-shift's type attribute describes the direction the
     // *written* notes are shifted from the true (sounding) pitch: an 8va, which sounds an
     // octave above what is written, is encoded as type="down" (notes are written below true
-    // pitch). So type="down" maps to the "up" ottava variants (o8va/o15ma) and type="up" maps
-    // to the "down" variants (o8vb/o15mb).
+    // pitch). So type="down" maps to the "up" ottava variants (o8va/o15ma/o22ma) and type="up" maps
+    // to the "down" variants (o8vb/o15mb/o22mb).
     bool isUp = octaveShift.type().tag() == core::UpDownStopContinue::Tag::up;
 
-    if (!isUp && amount > 8)
+    if (!isUp && amount == 22)
+    {
+        ottavaType = api::OttavaType::o22ma;
+    }
+    else if (!isUp && amount > 8)
     {
         ottavaType = api::OttavaType::o15ma;
     }
     else if (!isUp)
     {
         ottavaType = api::OttavaType::o8va;
+    }
+    else if (isUp && amount == 22)
+    {
+        ottavaType = api::OttavaType::o22mb;
     }
     else if (isUp && amount > 8)
     {

--- a/src/private/mx/impl/DirectionWriter.cpp
+++ b/src/private/mx/impl/DirectionWriter.cpp
@@ -426,6 +426,16 @@ void DirectionWriter::emitOttavaStart(const api::OttavaStart &ottavaStart, const
         sizeValue = 15;
         break;
     }
+    case api::OttavaType::o22ma: {
+        os.setType(core::UpDownStopContinue::down());
+        sizeValue = 22;
+        break;
+    }
+    case api::OttavaType::o22mb: {
+        os.setType(core::UpDownStopContinue::up());
+        sizeValue = 22;
+        break;
+    }
     case api::OttavaType::o8va: {
         os.setType(core::UpDownStopContinue::down());
         sizeValue = 8;
@@ -440,9 +450,9 @@ void DirectionWriter::emitOttavaStart(const api::OttavaStart &ottavaStart, const
         break;
     }
 
-    // size follows from ottavaType; a 15ma/15mb line's size encodes the two-octave shift, so it is
-    // always written, while the redundant default size="8" is emitted only when writeDefaultSize is
-    // set (the source spelled it out).
+    // size follows from ottavaType; non-8va lines need an explicit size to encode their shift, while
+    // the redundant default size="8" is emitted only when writeDefaultSize is set (the source spelled
+    // it out).
     if (sizeValue != 8 || ottavaStart.writeDefaultSize)
     {
         os.setSize(sizeValue);

--- a/src/private/mx/impl/DirectionWriter.cpp
+++ b/src/private/mx/impl/DirectionWriter.cpp
@@ -402,6 +402,8 @@ void DirectionWriter::emitOttavaStart(const api::OttavaStart &ottavaStart, const
                                       core::Direction &direction)
 {
     core::OctaveShift os{};
+    impl::setAttributesFromPositionData(ottavaStart.spannerStart.positionData, os);
+    impl::setAttributesFromPrintData(ottavaStart.spannerStart.printData, os);
     impl::setAttributesFromLineData(ottavaStart.spannerStart.lineData, os);
 
     const auto number = myNumberResolver.emittedNumber(ottavaStart.spannerStart.number, inIdentity);

--- a/src/private/mxtest/api/DirectionDataTest.cpp
+++ b/src/private/mxtest/api/DirectionDataTest.cpp
@@ -7,6 +7,7 @@
 
 #include "cpul/cpulTestHarness.h"
 #include "mx/api/DocumentManager.h"
+#include "mx/api/OttavaData.h"
 #include "mx/api/RehearsalData.h"
 #include "mx/api/ScoreData.h"
 #include "mxtest/api/RoundTrip.h"
@@ -95,6 +96,43 @@ TEST(OutOfOrderDoesntThrow, DirectionData)
     CHECK_EQUAL(9, effectiveTick(*rdirection));
     ++rdirection;
     CHECK_EQUAL(10, effectiveTick(*rdirection));
+}
+
+T_END;
+
+TEST(Ottava22RoundTripXml, DirectionData)
+{
+    ScoreData score;
+    score.ticksPerQuarter = 10;
+    score.parts.emplace_back();
+    auto &measure = score.parts.back().measures.emplace_back();
+    auto &staff = measure.staves.emplace_back();
+    auto &note = staff.voices[0].notes.emplace_back();
+    note.durationData.durationTimeTicks = 10;
+    note.durationData.durationName = DurationName::quarter;
+
+    OttavaStart up;
+    up.ottavaType = OttavaType::o22ma;
+    OttavaStart down;
+    down.ottavaType = OttavaType::o22mb;
+
+    DirectionData direction;
+    direction.directionTypes.emplace_back(DirectionChoice{up});
+    direction.directionTypes.emplace_back(DirectionChoice{down});
+    staff.directions.emplace_back(direction);
+
+    const auto xml = mxtest::toXml(score);
+    CHECK(xml.find("<octave-shift type=\"down\" size=\"22\"") != std::string::npos);
+    CHECK(xml.find("<octave-shift type=\"up\" size=\"22\"") != std::string::npos);
+
+    const auto roundTripped = mxtest::roundTrip(score);
+    const auto &directionTypes =
+        roundTripped.parts.front().measures.front().staves.front().directions.front().directionTypes;
+    REQUIRE(directionTypes.size() == 2);
+    REQUIRE(directionTypes.front().isOttavaStart());
+    REQUIRE(directionTypes.back().isOttavaStart());
+    CHECK(OttavaType::o22ma == directionTypes.front().ottavaStart().ottavaType);
+    CHECK(OttavaType::o22mb == directionTypes.back().ottavaStart().ottavaType);
 }
 
 T_END;

--- a/src/private/mxtest/impl/DirectionReaderTest.cpp
+++ b/src/private/mxtest/impl/DirectionReaderTest.cpp
@@ -41,6 +41,37 @@ TEST(ottavaStart15ma, DirectionReader)
 
 T_END
 
+TEST(ottavaStart22maAnd22mb, DirectionReader)
+{
+    core::OctaveShift up{};
+    up.setType(core::UpDownStopContinue::down());
+    up.setSize(22);
+    core::DirectionType upType{};
+    upType.setChoice(core::DirectionTypeChoice::octaveShift(up));
+
+    core::OctaveShift down{};
+    down.setType(core::UpDownStopContinue::up());
+    down.setSize(22);
+    core::DirectionType downType{};
+    downType.setChoice(core::DirectionTypeChoice::octaveShift(down));
+
+    core::Direction direction{};
+    direction.setDirectionType(core::OneOrMore<core::DirectionType>{upType});
+    direction.addDirectionType(downType);
+
+    Cursor cursor{1, 100};
+    DirectionReader reader{direction, cursor};
+    const auto directionData = reader.getDirectionData();
+
+    REQUIRE(directionData.directionTypes.size() == 2);
+    REQUIRE(directionData.directionTypes.front().isOttavaStart());
+    REQUIRE(directionData.directionTypes.back().isOttavaStart());
+    CHECK(api::OttavaType::o22ma == directionData.directionTypes.front().ottavaStart().ottavaType);
+    CHECK(api::OttavaType::o22mb == directionData.directionTypes.back().ottavaStart().ottavaType);
+}
+
+T_END
+
 TEST(ottavaStart8vaAnd8vb, DirectionReader)
 {
     const int tickTimePosition = 199;

--- a/src/private/mxtest/impl/DirectionWriterTest.cpp
+++ b/src/private/mxtest/impl/DirectionWriterTest.cpp
@@ -76,6 +76,41 @@ TEST(ottavaStartStop, DirectionWriter)
 
 T_END
 
+TEST(ottava22maAnd22mb, DirectionWriter)
+{
+    api::DirectionData directionData;
+
+    api::OttavaStart up{};
+    up.ottavaType = api::OttavaType::o22ma;
+    directionData.directionTypes.emplace_back(api::DirectionChoice{up});
+
+    api::OttavaStart down{};
+    down.ottavaType = api::OttavaType::o22mb;
+    directionData.directionTypes.emplace_back(api::DirectionChoice{down});
+
+    Cursor cursor{1, 100};
+    SpannerNumberResolver numberResolver;
+    DirectionWriter writer{directionData, cursor, numberResolver};
+    const auto mdcSet = writer.getDirectionLikeThings();
+
+    REQUIRE(mdcSet.size() == 1);
+    REQUIRE(mdcSet.front().isDirection());
+    const auto &directionTypes = mdcSet.front().asDirection().directionType();
+    REQUIRE(directionTypes.size() == 2);
+
+    const auto &upCore = directionTypes.front().choice().asOctaveShift();
+    REQUIRE(upCore.size().has_value());
+    CHECK_EQUAL(22, *upCore.size());
+    CHECK(upCore.type().tag() == core::UpDownStopContinue::Tag::down);
+
+    const auto &downCore = directionTypes.back().choice().asOctaveShift();
+    REQUIRE(downCore.size().has_value());
+    CHECK_EQUAL(22, *downCore.size());
+    CHECK(downCore.type().tag() == core::UpDownStopContinue::Tag::up);
+}
+
+T_END
+
 // Build a segno and a coda carrying the full empty-print-object-style-align attribute set plus
 // smufl and id, write them with DirectionWriter, read them back with DirectionReader, and confirm
 // every field survives the api -> core -> api trip.

--- a/src/private/mxtest/impl/DirectionWriterTest.cpp
+++ b/src/private/mxtest/impl/DirectionWriterTest.cpp
@@ -36,6 +36,21 @@ TEST(ottavaStartStop, DirectionWriter)
     start.ottavaType = api::OttavaType::o15mb;
     start.spannerStart.positionData.isDefaultXSpecified = true;
     start.spannerStart.positionData.defaultX = 100.0;
+    start.spannerStart.positionData.isDefaultYSpecified = true;
+    start.spannerStart.positionData.defaultY = 20.0;
+    start.spannerStart.positionData.isRelativeXSpecified = true;
+    start.spannerStart.positionData.relativeX = 3.0;
+    start.spannerStart.positionData.isRelativeYSpecified = true;
+    start.spannerStart.positionData.relativeY = 4.0;
+    start.spannerStart.printData.fontData.fontFamily = {"Maestro"};
+    start.spannerStart.printData.fontData.style = api::FontStyle::italic;
+    start.spannerStart.printData.fontData.weight = api::FontWeight::bold;
+    start.spannerStart.printData.fontData.sizeType = api::FontSizeType::point;
+    start.spannerStart.printData.fontData.sizePoint = 18.0;
+    start.spannerStart.printData.isColorSpecified = true;
+    start.spannerStart.printData.color.red = 12;
+    start.spannerStart.printData.color.green = 34;
+    start.spannerStart.printData.color.blue = 56;
     directionData.directionTypes.emplace_back(api::DirectionChoice{start});
 
     SpannerNumberResolver numberResolver;
@@ -55,6 +70,8 @@ TEST(ottavaStartStop, DirectionWriter)
     CHECK(api::SpannerNumber(2) == roundTrippedStop.spannerStop.number);
     CHECK(roundTrippedStop.size.has_value());
     CHECK_EQUAL(15, *roundTrippedStop.size);
+    REQUIRE(roundTripped.directionTypes.back().isOttavaStart());
+    CHECK(start == roundTripped.directionTypes.back().ottavaStart());
 }
 
 T_END


### PR DESCRIPTION
## Human Summary

Fills in two gaps in ottava support: octave-shift start formatting was read but not written, and three-octave 22ma/22mb lines could not be represented in mx::api.

## Summary

Extends the existing ottava model and writer in two areas:

- `DirectionWriter::emitOttavaStart` now writes the start's `PositionData` and `PrintData`, including default/relative positioning, font, and color. The reader already populated
  these fields, making this a writer-only omission.
- `OttavaType` gains `o22ma` and `o22mb` for three-octave shifts.
- The reader maps MusicXML `size="22"` and `type="down"` / `type="up"` to `o22ma` / `o22mb`, following MusicXML's reversed written-pitch direction.
- The writer emits `size="22"` with the corresponding MusicXML direction.
- Existing 8va/8vb default-size behavior is unchanged, as is `OttavaStop::size`.

The public API change is additive.

## Testing

- [x] New API XML round-trip coverage for `o22ma` and `o22mb`
- [x] New focused reader tests for both 22-line directions
- [x] Writer tests cover size, direction, position, font, and color
- [x] Full unit suite passes: 5,224 assertions in 463 test cases
- [x] API round-trip regression passes: 295/295 pinned files
- [x] Full API round-trip discovery shows no regressions
- [x] Formatting and diff checks pass
