### PR TITLE
feat: extend direction text formatting in mx::api and unify the enclosure enum

### DIFF
--- a/src/include/mx/api/ApiCommon.h
+++ b/src/include/mx/api/ApiCommon.h
@@ -71,9 +71,11 @@ enum class MeasureNumbering
     system
 };
 
-// The <measure-numbering system="..."> attribute: whether this part's measure numbers are also,
-// or only, associated with the system (as opposed to just this part). unspecified means the
-// attribute is absent.
+// Whether an item is associated with the system rather than only with the part it appears in --
+// the system attribute of <measure-numbering> (MeasureData) and of <direction> and <harmony>
+// (DirectionData). only... means the item is drawn on the top or bottom part of the system instead
+// of this part; also... means it is drawn on both. unspecified means the attribute is absent.
+// onlyBottom and alsoBottom are measure-numbering only; MusicXML has no bottom-of-system direction.
 enum class SystemRelation
 {
     unspecified,
@@ -82,6 +84,31 @@ enum class SystemRelation
     onlyBottom,
     alsoTop,
     alsoBottom
+};
+
+// The shape drawn around a piece of text or a symbol -- MusicXML's enclosure attribute, carried by
+// RehearsalData, WordsData, SymbolData and PercussionData. unspecified means the attribute is
+// absent, which draws no enclosure; none states explicitly that there is none. A bracket is a
+// rectangle with the bottom line missing, as is common in jazz notation, and an invertedBracket is
+// one with the top line missing.
+enum class Enclosure
+{
+    unspecified,
+    rectangle,
+    square,
+    oval,
+    circle,
+    bracket,
+    invertedBracket,
+    triangle,
+    diamond,
+    pentagon,
+    hexagon,
+    heptagon,
+    octagon,
+    nonagon,
+    decagon,
+    none
 };
 } // namespace api
 } // namespace mx

--- a/src/include/mx/api/ChordData.h
+++ b/src/include/mx/api/ChordData.h
@@ -251,6 +251,13 @@ class ChordData
     ChordKind chordKind;
     std::string text;
     Bool useSymbols;
+    // How the chord's degree alterations (the 'extensions' below) are laid out next to the chord
+    // symbol. stackDegrees stacks them vertically instead of running them left to right;
+    // parenthesesDegrees wraps all of them in parentheses, e.g. C7(#9b13). These are the MusicXML
+    // stack-degrees and parentheses-degrees attributes; unspecified leaves the choice to the
+    // notation software rendering the score.
+    Bool stackDegrees;
+    Bool parenthesesDegrees;
     Step bass;
     int bassAlter;
     // The MusicXML <inversion> (0 = root position, 1 = first inversion, ...). Present only when
@@ -279,6 +286,8 @@ MXAPI_EQUALS_MEMBER(numeralMode)
 MXAPI_EQUALS_MEMBER(chordKind)
 MXAPI_EQUALS_MEMBER(text)
 MXAPI_EQUALS_MEMBER(useSymbols)
+MXAPI_EQUALS_MEMBER(stackDegrees)
+MXAPI_EQUALS_MEMBER(parenthesesDegrees)
 MXAPI_EQUALS_MEMBER(bass)
 MXAPI_EQUALS_MEMBER(bassAlter)
 MXAPI_EQUALS_MEMBER(inversion)

--- a/src/include/mx/api/ClefData.h
+++ b/src/include/mx/api/ClefData.h
@@ -21,6 +21,11 @@ enum class ClefSymbol
     jianpu
 };
 
+// Where a clef sits relative to its measure. A clef at the start of a measure normally prints
+// before the barline; beforeBarline and afterBarline choose between the two, which matters for cue
+// clefs and for the clef that resumes after a repeated section. midMeasure describes a clef change
+// partway through the measure, positioned by tickTimePosition. unspecified leaves the choice to the
+// notation program.
 enum class ClefLocation
 {
     unspecified,
@@ -53,6 +58,12 @@ class ClefData
     bool isOctaveChangeSpecified;
     int tickTimePosition;
     ClefLocation location;
+    // Marks a supplementary clef placed on the staff alongside the regular one - a cue clef, or a
+    // second clef in effect at the same time. MusicXML writes this as clef@additional="yes"; such a
+    // clef sits at a non-standard line position, is not restated at the start of each system, and
+    // notation software disregards its line. unspecified (the default) omits the attribute, which
+    // describes an ordinary clef.
+    Bool additional;
     // Visibility of the clef via the MusicXML print-object attribute.
     // unspecified -> omit the attribute, yes/no -> write print-object verbatim.
     Bool printObject;
@@ -86,6 +97,7 @@ MXAPI_EQUALS_MEMBER(octaveChange)
 MXAPI_EQUALS_MEMBER(isOctaveChangeSpecified)
 MXAPI_EQUALS_MEMBER(tickTimePosition)
 MXAPI_EQUALS_MEMBER(location)
+MXAPI_EQUALS_MEMBER(additional)
 MXAPI_EQUALS_MEMBER(printObject)
 MXAPI_EQUALS_END;
 MXAPI_NOT_EQUALS_AND_VECTORS(ClefData);

--- a/src/include/mx/api/DirectionData.h
+++ b/src/include/mx/api/DirectionData.h
@@ -28,6 +28,14 @@ struct DirectionData
     int tickTimePosition;
     Placement placement;
 
+    // The system attribute of <direction> and <harmony>: content that belongs to the whole system
+    // rather than to this part alone, such as a tempo mark drawn once above the top staff. onlyTop
+    // draws it only on the top part of the system, alsoTop on both this part and the top part, and
+    // none states explicitly that it belongs to this part alone. One value covers the direction
+    // types and the chords held here; both elements are written with it. SystemRelation::onlyBottom
+    // and ::alsoBottom exist only for measure numbering; either one here writes no attribute.
+    SystemRelation systemRelation;
+
     // The source's <offset>, in divisions, or absent when it had none. An <offset> nudges only
     // where the direction is *drawn*, shifting it away from the note it is anchored to; it does not
     // move that anchor. tickTimePosition holds the anchor -- the musical location the direction
@@ -73,9 +81,9 @@ struct DirectionData
     std::vector<FiguredBassData> figuredBasses;
 
     DirectionData()
-        : tickTimePosition{0}, placement{Placement::unspecified}, offset{}, voice{VALUE_UNSPECIFIED},
-          isStaffValueSpecified{true}, isSoundDataSpecified{false}, soundData{}, directionTypes{}, chords{},
-          figuredBasses{}
+        : tickTimePosition{0}, placement{Placement::unspecified}, systemRelation{SystemRelation::unspecified}, offset{},
+          voice{VALUE_UNSPECIFIED}, isStaffValueSpecified{true}, isSoundDataSpecified{false}, soundData{},
+          directionTypes{}, chords{}, figuredBasses{}
     {
     }
 };
@@ -89,6 +97,7 @@ inline bool isDirectionDataEmpty(const DirectionData &directionData)
 MXAPI_EQUALS_BEGIN(DirectionData)
 MXAPI_EQUALS_MEMBER(tickTimePosition)
 MXAPI_EQUALS_MEMBER(placement)
+MXAPI_EQUALS_MEMBER(systemRelation)
 MXAPI_EQUALS_MEMBER(offset)
 MXAPI_EQUALS_MEMBER(voice)
 MXAPI_EQUALS_MEMBER(isStaffValueSpecified)

--- a/src/include/mx/api/MeasureData.h
+++ b/src/include/mx/api/MeasureData.h
@@ -13,6 +13,7 @@
 #include "mx/api/TransposeData.h"
 
 #include <map>
+#include <optional>
 #include <string>
 
 namespace mx
@@ -51,6 +52,15 @@ class MeasureData
     // about measure numbering can be defined using the measure-numbering element.
     std::string number;
 
+    // The measure number as it should appear on the page, when that differs from the 'number'
+    // above. 'number' identifies the measure (and aligns it with the same measure in other parts),
+    // while this is purely what the engraver prints. Set it when the printed numbering does not
+    // follow the identifying numbering -- a second ending that restarts at 8, an editor's numbering
+    // like "12a", or a rehearsal-driven relabeling. Leave it absent and the printed number is the
+    // 'number' value. An empty string is not written; use implicit = Bool::yes to suppress the
+    // number entirely, which is also what makes engravers ignore this field.
+    std::optional<std::string> displayedNumber;
+
     // The measure-numbering-value type describes how measure numbers are displayed on this part:
     // no numbers, numbers every measure, or numbers every system.
     MeasureNumbering measureNumbering;
@@ -64,6 +74,10 @@ class MeasureData
 
     // The <measure-numbering system="..."> attribute; see SystemRelation.
     SystemRelation measureNumberingSystemRelation;
+
+    // Which staff of the part the measure number is vertically positioned against, zero-based from
+    // the top staff. Meaningful only when measureNumbering != unspecified. Absent means the top staff.
+    std::optional<int> measureNumberingStaffIndex;
 
     // a number greater than zero indicates that this measure is the beginning of a mult-measure
     // rest that will last for the indicated number of measures. following measures will be affected
@@ -112,10 +126,12 @@ MXAPI_EQUALS_MEMBER(staves)
 MXAPI_EQUALS_MEMBER(timeSignature)
 MXAPI_EQUALS_MEMBER(staffTimeSignatures)
 MXAPI_EQUALS_MEMBER(number)
+MXAPI_EQUALS_MEMBER(displayedNumber)
 MXAPI_EQUALS_MEMBER(measureNumbering)
 MXAPI_EQUALS_MEMBER(measureNumberingMultipleRestAlways)
 MXAPI_EQUALS_MEMBER(measureNumberingMultipleRestRange)
 MXAPI_EQUALS_MEMBER(measureNumberingSystemRelation)
+MXAPI_EQUALS_MEMBER(measureNumberingStaffIndex)
 MXAPI_EQUALS_MEMBER(multiMeasureRest)
 MXAPI_EQUALS_MEMBER(multiMeasureRestUseSymbols)
 MXAPI_EQUALS_MEMBER(implicit)

--- a/src/include/mx/api/NoteData.h
+++ b/src/include/mx/api/NoteData.h
@@ -13,6 +13,7 @@
 #include "mx/api/PrintData.h"
 
 #include <optional>
+#include <string>
 #include <vector>
 
 namespace mx
@@ -132,6 +133,22 @@ class NoteData
     bool isCue;
 
     Notehead notehead;
+
+    // The <notehead> element's filled attribute: whether the notehead shape is drawn solid or
+    // hollow. Leave it unspecified to get MusicXML's default, which follows the note's duration
+    // (hollow for a half note and longer, solid for shorter). Set yes or no to override that,
+    // for example a solid whole note in a rhythm-notation part.
+    Bool noteheadFilled;
+
+    // The <notehead> element's smufl attribute: the canonical SMuFL glyph name to draw for this
+    // notehead, for example "noteheadSlashHorizontalEnds". It names a glyph directly, so a
+    // notation program can draw a notehead that MusicXML has no value for -- pair it with
+    // Notehead::other -- or narrow one that MusicXML names only broadly, such as
+    // Notehead::cluster. Note-name noteheads (the SMuFL ranges U+E150-U+E1AF and U+EEE0-U+EEFF)
+    // are not written this way; MusicXML spells those out in <notehead-text>. An empty string
+    // names no glyph and is written the same as leaving this empty.
+    std::optional<std::string> noteheadSmufl;
+
     PitchData pitchData; // step, alter, octave, accidental, etc
     int userRequestedVoiceNumber;
 
@@ -196,6 +213,9 @@ MXAPI_EQUALS_MEMBER(tieLetRing)
 MXAPI_EQUALS_MEMBER(isGrace)
 MXAPI_EQUALS_MEMBER(isCue)
 MXAPI_EQUALS_MEMBER(graceSlash)
+MXAPI_EQUALS_MEMBER(notehead)
+MXAPI_EQUALS_MEMBER(noteheadFilled)
+MXAPI_EQUALS_MEMBER(noteheadSmufl)
 MXAPI_EQUALS_MEMBER(pitchData)
 MXAPI_EQUALS_MEMBER(userRequestedVoiceNumber)
 MXAPI_EQUALS_MEMBER(writeStaffNumber)

--- a/src/include/mx/api/PercussionData.h
+++ b/src/include/mx/api/PercussionData.h
@@ -464,27 +464,6 @@ class PercussionDataChoice
 
 MXAPI_NOT_EQUALS_AND_VECTORS(PercussionDataChoice);
 
-// How a percussion pictogram is enclosed, MusicXML's enclosure attribute on <percussion>.
-enum class PercussionEnclosure
-{
-    unspecified,
-    rectangle,
-    square,
-    oval,
-    circle,
-    bracket,
-    invertedBracket,
-    triangle,
-    diamond,
-    pentagon,
-    hexagon,
-    heptagon,
-    octagon,
-    nonagon,
-    decagon,
-    none
-};
-
 // A percussion pictogram, MusicXML's <percussion> element: a symbol for an unpitched instrument
 // or the implement striking it, used in percussion parts and legends. Several PercussionData in
 // one direction read as a group (for example a membrane pictogram followed by a beater).
@@ -495,13 +474,17 @@ class PercussionData
 {
   public:
     PercussionDataChoice choice;
-    PercussionEnclosure enclosure;
+
+    // A shape drawn around the pictogram. Enclosure::unspecified draws no enclosure;
+    // Enclosure::none states explicitly that there is none.
+    Enclosure enclosure;
+
     PositionData positionData;
     FontData fontData;
     std::optional<ColorData> color;
     std::optional<std::string> id;
 
-    PercussionData() : choice{}, enclosure{PercussionEnclosure::unspecified}, positionData{}, fontData{}, color{}, id{}
+    PercussionData() : choice{}, enclosure{Enclosure::unspecified}, positionData{}, fontData{}, color{}, id{}
     {
     }
 };

--- a/src/include/mx/api/RehearsalData.h
+++ b/src/include/mx/api/RehearsalData.h
@@ -6,25 +6,13 @@
 
 #include "mx/api/ApiCommon.h"
 #include "mx/api/ColorData.h"
+#include "mx/api/FontData.h"
 #include "mx/api/PositionData.h"
 
 namespace mx
 {
 namespace api
 {
-enum class RehearsalEnclosure
-{
-    unspecified,
-    rectangle,
-    square,
-    oval,
-    circle,
-    bracket,
-    triangle,
-    diamond,
-    none
-};
-
 class RehearsalData
 {
   public:
@@ -33,11 +21,20 @@ class RehearsalData
     bool isColorSpecified;
     ColorData colorData;
     FontData fontData;
-    RehearsalEnclosure enclosure;
+
+    // A shape drawn around the text. Enclosure::unspecified draws no enclosure; Enclosure::none
+    // states explicitly that there is none.
+    Enclosure enclosure;
+
+    // The `justify` attribute of `<rehearsal>`: how the mark's lines sit relative to each other
+    // when its text runs to more than one line. `unspecified` means the attribute is absent.
+    // Distinct from the `halign` attribute, which is carried in `positionData.horizontalAlignment`
+    // and says which edge of the text the position refers to; MusicXML defines both.
+    HorizontalAlignment justify;
 
     RehearsalData()
-        : text{}, positionData{}, isColorSpecified{false}, colorData{}, fontData{},
-          enclosure{RehearsalEnclosure::unspecified}
+        : text{}, positionData{}, isColorSpecified{false}, colorData{}, fontData{}, enclosure{Enclosure::unspecified},
+          justify{HorizontalAlignment::unspecified}
     {
     }
 };
@@ -49,6 +46,7 @@ MXAPI_EQUALS_MEMBER(isColorSpecified)
 MXAPI_EQUALS_MEMBER(colorData)
 MXAPI_EQUALS_MEMBER(fontData)
 MXAPI_EQUALS_MEMBER(enclosure)
+MXAPI_EQUALS_MEMBER(justify)
 MXAPI_EQUALS_END;
 MXAPI_NOT_EQUALS_AND_VECTORS(RehearsalData);
 } // namespace api

--- a/src/include/mx/api/SymbolData.h
+++ b/src/include/mx/api/SymbolData.h
@@ -8,7 +8,6 @@
 #include "mx/api/ColorData.h"
 #include "mx/api/FontData.h"
 #include "mx/api/PositionData.h"
-#include "mx/api/RehearsalData.h"
 
 #include <optional>
 #include <string>
@@ -32,11 +31,19 @@ class SymbolData
     FontData fontData;
     std::optional<ColorData> color;
 
-    // A shape drawn around the symbol. RehearsalEnclosure::unspecified draws no enclosure;
-    // RehearsalEnclosure::none states explicitly that there is none.
-    RehearsalEnclosure enclosure;
+    // A shape drawn around the symbol. Enclosure::unspecified draws no enclosure; Enclosure::none
+    // states explicitly that there is none.
+    Enclosure enclosure;
 
-    SymbolData() : smufl{}, positionData{}, fontData{}, color{}, enclosure{RehearsalEnclosure::unspecified}
+    // The `justify` attribute of `<symbol>`. `unspecified` means the attribute is absent. Distinct
+    // from the `halign` attribute, which is carried in `positionData.horizontalAlignment` and says
+    // which edge of the glyph the position refers to; MusicXML defines both on `<symbol>`, whose
+    // symbol-formatting attributes mirror the text-formatting ones on `<words>`.
+    HorizontalAlignment justify;
+
+    SymbolData()
+        : smufl{}, positionData{}, fontData{}, color{}, enclosure{Enclosure::unspecified},
+          justify{HorizontalAlignment::unspecified}
     {
     }
 };
@@ -47,6 +54,7 @@ MXAPI_EQUALS_MEMBER(positionData)
 MXAPI_EQUALS_MEMBER(fontData)
 MXAPI_EQUALS_MEMBER(color)
 MXAPI_EQUALS_MEMBER(enclosure)
+MXAPI_EQUALS_MEMBER(justify)
 MXAPI_EQUALS_END;
 MXAPI_NOT_EQUALS_AND_VECTORS(SymbolData);
 } // namespace api

--- a/src/include/mx/api/WordsData.h
+++ b/src/include/mx/api/WordsData.h
@@ -8,7 +8,6 @@
 #include "mx/api/ColorData.h"
 #include "mx/api/FontData.h"
 #include "mx/api/PositionData.h"
-#include "mx/api/RehearsalData.h"
 
 namespace mx
 {
@@ -26,13 +25,19 @@ class WordsData
     bool isColorSpecified;
     ColorData colorData;
 
-    // A shape drawn around the text. RehearsalEnclosure::unspecified draws no enclosure;
-    // RehearsalEnclosure::none states explicitly that there is none.
-    RehearsalEnclosure enclosure;
+    // A shape drawn around the text. Enclosure::unspecified draws no enclosure; Enclosure::none
+    // states explicitly that there is none.
+    Enclosure enclosure;
+
+    // The `justify` attribute of `<words>`: how the text lines up within itself when it spans
+    // more than one line. `unspecified` means the attribute is absent. Distinct from the `halign`
+    // attribute, which is carried in `positionData.horizontalAlignment` and aligns the whole text
+    // block against its anchor point; MusicXML defines both attributes on `<words>`.
+    HorizontalAlignment justify;
 
     WordsData()
-        : text{}, positionData{}, fontData{}, isColorSpecified{false}, colorData{},
-          enclosure{RehearsalEnclosure::unspecified}
+        : text{}, positionData{}, fontData{}, isColorSpecified{false}, colorData{}, enclosure{Enclosure::unspecified},
+          justify{HorizontalAlignment::unspecified}
     {
     }
 };
@@ -44,6 +49,7 @@ MXAPI_EQUALS_MEMBER(fontData)
 MXAPI_EQUALS_MEMBER(isColorSpecified)
 MXAPI_EQUALS_MEMBER(colorData)
 MXAPI_EQUALS_MEMBER(enclosure)
+MXAPI_EQUALS_MEMBER(justify)
 MXAPI_EQUALS_END;
 MXAPI_NOT_EQUALS_AND_VECTORS(WordsData);
 } // namespace api

--- a/src/private/mx/api/ChordData.cpp
+++ b/src/private/mx/api/ChordData.cpp
@@ -32,8 +32,8 @@ ChordData::ChordData()
     : harmonyChordSource{HarmonyChordSource::root}, root{Step::c}, rootAlter{0}, functionText{}, numeralRoot{0},
       numeralRootText{}, numeralAlter{0}, hasNumeralAlter{false}, hasNumeralKey{false}, numeralKeyFifths{0},
       numeralMode{NumeralMode::unspecified}, chordKind{ChordKind::unspecified}, text{}, useSymbols{Bool::unspecified},
-      bass{Step::unspecified}, bassAlter{0}, inversion{0}, hasInversion{false}, extensions{}, miscData{},
-      hasFrameData{false}, frameData{}, positionData{}
+      stackDegrees{Bool::unspecified}, parenthesesDegrees{Bool::unspecified}, bass{Step::unspecified}, bassAlter{0},
+      inversion{0}, hasInversion{false}, extensions{}, miscData{}, hasFrameData{false}, frameData{}, positionData{}
 {
 }
 

--- a/src/private/mx/api/ClefData.cpp
+++ b/src/private/mx/api/ClefData.cpp
@@ -12,7 +12,7 @@ namespace api
 ClefData::ClefData()
     : writeStaffNumber{Bool::unspecified}, symbol{DEFAULT_CLEF_SYMBOL}, line{DEFAULT_CLEF_LINE}, isLineSpecified{true},
       octaveChange{DEFAULT_CLEF_OCTAVE_CHANGE}, isOctaveChangeSpecified{true}, tickTimePosition{0},
-      location{ClefLocation::unspecified}, printObject{Bool::unspecified}
+      location{ClefLocation::unspecified}, additional{Bool::unspecified}, printObject{Bool::unspecified}
 {
 }
 

--- a/src/private/mx/api/NoteData.cpp
+++ b/src/private/mx/api/NoteData.cpp
@@ -11,9 +11,9 @@ namespace api
 NoteData::NoteData()
     : isRest{false}, isMeasureRest{false}, isUnpitched{false}, isDisplayStepOctaveSpecified{false}, isChord{false},
       isTieStart{false}, isTieStop{false}, tieLetRing{}, isGrace{false}, graceSlash{Bool::unspecified}, isCue{false},
-      notehead{Notehead::normal}, pitchData{}, userRequestedVoiceNumber{VALUE_UNSPECIFIED},
-      writeStaffNumber{Bool::unspecified}, stem{Stem::unspecified}, tickTimePosition{0}, durationData{}, beams{},
-      positionData{}, printData{}, noteAttachmentData{}, lyrics{}
+      notehead{Notehead::normal}, noteheadFilled{Bool::unspecified}, noteheadSmufl{}, pitchData{},
+      userRequestedVoiceNumber{VALUE_UNSPECIFIED}, writeStaffNumber{Bool::unspecified}, stem{Stem::unspecified},
+      tickTimePosition{0}, durationData{}, beams{}, positionData{}, printData{}, noteAttachmentData{}, lyrics{}
 {
 }
 } // namespace api

--- a/src/private/mx/impl/Converter.cpp
+++ b/src/private/mx/impl/Converter.cpp
@@ -300,6 +300,12 @@ const Converter::EnumMap<core::SystemRelationNumber, api::SystemRelation> Conver
     {core::SystemRelationNumber::alsoBottom(), api::SystemRelation::alsoBottom},
 };
 
+const Converter::EnumMap<core::SystemRelation, api::SystemRelation> Converter::directionSystemRelationMap = {
+    {core::SystemRelation::none(), api::SystemRelation::none},
+    {core::SystemRelation::onlyTop(), api::SystemRelation::onlyTop},
+    {core::SystemRelation::alsoTop(), api::SystemRelation::alsoTop},
+};
+
 const Converter::EnumMap<core::TechnicalChoice::Kind, api::MarkType> Converter::technicalMarkMap = {
     // { core::TechnicalChoice::Kind::technical,
     // api::MarkType::unspecified },
@@ -1581,22 +1587,22 @@ const Converter::EnumMap<core::TipDirection, api::TipDirection> Converter::tipDi
     {core::TipDirection::southwest(), api::TipDirection::southwest},
 };
 
-const Converter::EnumMap<core::EnclosureShape, api::PercussionEnclosure> Converter::percussionEnclosureMap = {
-    {core::EnclosureShape::rectangle(), api::PercussionEnclosure::rectangle},
-    {core::EnclosureShape::square(), api::PercussionEnclosure::square},
-    {core::EnclosureShape::oval(), api::PercussionEnclosure::oval},
-    {core::EnclosureShape::circle(), api::PercussionEnclosure::circle},
-    {core::EnclosureShape::bracket(), api::PercussionEnclosure::bracket},
-    {core::EnclosureShape::invertedBracket(), api::PercussionEnclosure::invertedBracket},
-    {core::EnclosureShape::triangle(), api::PercussionEnclosure::triangle},
-    {core::EnclosureShape::diamond(), api::PercussionEnclosure::diamond},
-    {core::EnclosureShape::pentagon(), api::PercussionEnclosure::pentagon},
-    {core::EnclosureShape::hexagon(), api::PercussionEnclosure::hexagon},
-    {core::EnclosureShape::heptagon(), api::PercussionEnclosure::heptagon},
-    {core::EnclosureShape::octagon(), api::PercussionEnclosure::octagon},
-    {core::EnclosureShape::nonagon(), api::PercussionEnclosure::nonagon},
-    {core::EnclosureShape::decagon(), api::PercussionEnclosure::decagon},
-    {core::EnclosureShape::none(), api::PercussionEnclosure::none},
+const Converter::EnumMap<core::EnclosureShape, api::Enclosure> Converter::enclosureMap = {
+    {core::EnclosureShape::rectangle(), api::Enclosure::rectangle},
+    {core::EnclosureShape::square(), api::Enclosure::square},
+    {core::EnclosureShape::oval(), api::Enclosure::oval},
+    {core::EnclosureShape::circle(), api::Enclosure::circle},
+    {core::EnclosureShape::bracket(), api::Enclosure::bracket},
+    {core::EnclosureShape::invertedBracket(), api::Enclosure::invertedBracket},
+    {core::EnclosureShape::triangle(), api::Enclosure::triangle},
+    {core::EnclosureShape::diamond(), api::Enclosure::diamond},
+    {core::EnclosureShape::pentagon(), api::Enclosure::pentagon},
+    {core::EnclosureShape::hexagon(), api::Enclosure::hexagon},
+    {core::EnclosureShape::heptagon(), api::Enclosure::heptagon},
+    {core::EnclosureShape::octagon(), api::Enclosure::octagon},
+    {core::EnclosureShape::nonagon(), api::Enclosure::nonagon},
+    {core::EnclosureShape::decagon(), api::Enclosure::decagon},
+    {core::EnclosureShape::none(), api::Enclosure::none},
 };
 
 api::Step Converter::convert(core::Step inStep) const
@@ -1803,6 +1809,24 @@ core::SystemRelationNumber Converter::convertSystemRelation(api::SystemRelation 
 api::SystemRelation Converter::convertSystemRelation(core::SystemRelationNumber value) const
 {
     return findApiItem(systemRelationMap, api::SystemRelation::unspecified, value);
+}
+
+std::optional<core::SystemRelation> Converter::convertDirectionSystemRelation(api::SystemRelation value) const
+{
+    const auto compare = [&value](const std::pair<core::SystemRelation, api::SystemRelation> &v) {
+        return v.second == value;
+    };
+    const auto it = std::find_if(directionSystemRelationMap.cbegin(), directionSystemRelationMap.cend(), compare);
+    if (it == directionSystemRelationMap.cend())
+    {
+        return std::nullopt;
+    }
+    return it->first;
+}
+
+api::SystemRelation Converter::convertDirectionSystemRelation(core::SystemRelation value) const
+{
+    return findApiItem(directionSystemRelationMap, api::SystemRelation::unspecified, value);
 }
 
 core::StemValue Converter::convert(api::Stem value) const
@@ -2095,14 +2119,14 @@ core::TipDirection Converter::convert(api::TipDirection value) const
     return findCoreItem(tipDirectionMap, core::TipDirection::up(), value);
 }
 
-api::PercussionEnclosure Converter::convert(core::EnclosureShape value) const
+api::Enclosure Converter::convert(core::EnclosureShape value) const
 {
-    return findApiItem(percussionEnclosureMap, api::PercussionEnclosure::unspecified, value);
+    return findApiItem(enclosureMap, api::Enclosure::unspecified, value);
 }
 
-core::EnclosureShape Converter::convert(api::PercussionEnclosure value) const
+core::EnclosureShape Converter::convert(api::Enclosure value) const
 {
-    return findCoreItem(percussionEnclosureMap, core::EnclosureShape::none(), value);
+    return findCoreItem(enclosureMap, core::EnclosureShape::none(), value);
 }
 
 double Converter::convertToAlter(int semitones, double cents)

--- a/src/private/mx/impl/Converter.h
+++ b/src/private/mx/impl/Converter.h
@@ -51,6 +51,7 @@
 #include "mx/core/generated/StickLocation.h"
 #include "mx/core/generated/StickMaterial.h"
 #include "mx/core/generated/StickType.h"
+#include "mx/core/generated/SystemRelation.h"
 #include "mx/core/generated/SystemRelationNumber.h"
 #include "mx/core/generated/TechnicalChoice.h"
 #include "mx/core/generated/TimeRelation.h"
@@ -65,6 +66,7 @@
 #include "mx/core/generated/YesNo.h"
 
 #include <algorithm>
+#include <optional>
 #include <utility>
 #include <vector>
 
@@ -142,6 +144,12 @@ class Converter
 
     core::SystemRelationNumber convertSystemRelation(api::SystemRelation value) const;
     api::SystemRelation convertSystemRelation(core::SystemRelationNumber value) const;
+
+    // <direction system="..."> uses a narrower vocabulary than <measure-numbering system="...">:
+    // only-top, also-top and none. api::SystemRelation::onlyBottom and ::alsoBottom have no
+    // direction equivalent and, like unspecified, yield nullopt so the caller writes no attribute.
+    std::optional<core::SystemRelation> convertDirectionSystemRelation(api::SystemRelation value) const;
+    api::SystemRelation convertDirectionSystemRelation(core::SystemRelation value) const;
 
     core::StemValue convert(api::Stem value) const;
     api::Stem convert(core::StemValue value) const;
@@ -227,8 +235,8 @@ class Converter
     core::StickLocation convert(api::StickLocation value) const;
     api::TipDirection convert(core::TipDirection value) const;
     core::TipDirection convert(api::TipDirection value) const;
-    api::PercussionEnclosure convert(core::EnclosureShape value) const;
-    core::EnclosureShape convert(api::PercussionEnclosure value) const;
+    api::Enclosure convert(core::EnclosureShape value) const;
+    core::EnclosureShape convert(api::Enclosure value) const;
 
     static double convertToAlter(int semitones, double cents);
     static std::pair<int, double> convertToSemitonesAndCents(double alter);
@@ -256,6 +264,7 @@ class Converter
     const static EnumMap<core::TechnicalChoice::Kind, api::MarkType> technicalMarkMap;
     const static EnumMap<core::MeasureNumberingValue, api::MeasureNumbering> measureNumberingMap;
     const static EnumMap<core::SystemRelationNumber, api::SystemRelation> systemRelationMap;
+    const static EnumMap<core::SystemRelation, api::SystemRelation> directionSystemRelationMap;
     const static EnumMap<core::StemValue, api::Stem> stemMap;
     const static EnumMap<core::LineType, api::LineType> lineType;
     const static EnumMap<core::WedgeType, api::WedgeType> wedgeMap;
@@ -286,7 +295,7 @@ class Converter
     const static EnumMap<core::StickMaterial, api::StickMaterial> stickMaterialMap;
     const static EnumMap<core::StickLocation, api::StickLocation> stickLocationMap;
     const static EnumMap<core::TipDirection, api::TipDirection> tipDirectionMap;
-    const static EnumMap<core::EnclosureShape, api::PercussionEnclosure> percussionEnclosureMap;
+    const static EnumMap<core::EnclosureShape, api::Enclosure> enclosureMap;
 
   private:
     template <typename CORE_TYPE, typename API_TYPE>

--- a/src/private/mx/impl/DirectionReader.cpp
+++ b/src/private/mx/impl/DirectionReader.cpp
@@ -112,6 +112,7 @@ api::DirectionData DirectionReader::getDirectionData()
     myOutDirectionData = initializeData();
     parseOffset();
     parsePlacement();
+    parseSystemRelation();
     parseValues();
     return returnData();
 }
@@ -175,6 +176,24 @@ void DirectionReader::parsePlacement()
     }
 }
 
+void DirectionReader::parseSystemRelation()
+{
+    if (myDirection)
+    {
+        if (myDirection->system().has_value())
+        {
+            myOutDirectionData.systemRelation = myConverter.convertDirectionSystemRelation(*myDirection->system());
+        }
+    }
+    else if (myHarmony)
+    {
+        if (myHarmony->system().has_value())
+        {
+            myOutDirectionData.systemRelation = myConverter.convertDirectionSystemRelation(*myHarmony->system());
+        }
+    }
+}
+
 void DirectionReader::parseValues()
 {
     if (myDirection)
@@ -219,33 +238,6 @@ mx::api::DirectionData DirectionReader::returnData()
     api::DirectionData temp{std::move(myOutDirectionData)};
     myOutDirectionData = api::DirectionData{};
     return temp;
-}
-
-// Maps a core enclosure-shape attribute to the api enum shared by rehearsals, words, and
-// symbols.
-api::RehearsalEnclosure directionReaderEnclosure(core::EnclosureShape::Tag tag)
-{
-    switch (tag)
-    {
-    case core::EnclosureShape::Tag::rectangle:
-        return api::RehearsalEnclosure::rectangle;
-    case core::EnclosureShape::Tag::square:
-        return api::RehearsalEnclosure::square;
-    case core::EnclosureShape::Tag::oval:
-        return api::RehearsalEnclosure::oval;
-    case core::EnclosureShape::Tag::circle:
-        return api::RehearsalEnclosure::circle;
-    case core::EnclosureShape::Tag::bracket:
-        return api::RehearsalEnclosure::bracket;
-    case core::EnclosureShape::Tag::triangle:
-        return api::RehearsalEnclosure::triangle;
-    case core::EnclosureShape::Tag::diamond:
-        return api::RehearsalEnclosure::diamond;
-    case core::EnclosureShape::Tag::none:
-        return api::RehearsalEnclosure::none;
-    default:
-        return api::RehearsalEnclosure::unspecified;
-    }
 }
 
 void DirectionReader::parseDirectionType(const core::DirectionType &directionType)
@@ -369,7 +361,11 @@ void DirectionReader::parseRehearsal(const core::DirectionType &directionType)
         }
         if (rehearsal.enclosure().has_value())
         {
-            outRehearsal.enclosure = directionReaderEnclosure(rehearsal.enclosure()->tag());
+            outRehearsal.enclosure = myConverter.convert(*rehearsal.enclosure());
+        }
+        if (rehearsal.justify().has_value())
+        {
+            outRehearsal.justify = myConverter.convert(*rehearsal.justify());
         }
         myOutDirectionData.directionTypes.emplace_back(api::DirectionChoice{std::move(outRehearsal)});
     }
@@ -426,7 +422,11 @@ void DirectionReader::parseWordsRun(const core::DirectionType &directionType)
             }
             if (symbolEl.enclosure().has_value())
             {
-                outSymbol.enclosure = directionReaderEnclosure(symbolEl.enclosure()->tag());
+                outSymbol.enclosure = myConverter.convert(*symbolEl.enclosure());
+            }
+            if (symbolEl.justify().has_value())
+            {
+                outSymbol.justify = myConverter.convert(*symbolEl.justify());
             }
             run.emplace_back(std::move(outSymbol));
             continue;
@@ -443,7 +443,11 @@ void DirectionReader::parseWordsRun(const core::DirectionType &directionType)
         outWords.fontData = getFontData(wordEl);
         if (wordEl.enclosure().has_value())
         {
-            outWords.enclosure = directionReaderEnclosure(wordEl.enclosure()->tag());
+            outWords.enclosure = myConverter.convert(*wordEl.enclosure());
+        }
+        if (wordEl.justify().has_value())
+        {
+            outWords.justify = myConverter.convert(*wordEl.justify());
         }
         run.emplace_back(std::move(outWords));
     }

--- a/src/private/mx/impl/DirectionReader.cpp
+++ b/src/private/mx/impl/DirectionReader.cpp
@@ -1285,6 +1285,18 @@ void DirectionReader::parseHarmony(const core::Harmony &inHarmony, const core::H
         }
     }
 
+    if (kind.stackDegrees().has_value())
+    {
+        const bool isYes = kind.stackDegrees()->tag() == mx::core::YesNo::Tag::yes;
+        chord.stackDegrees = isYes ? api::Bool::yes : api::Bool::no;
+    }
+
+    if (kind.parenthesesDegrees().has_value())
+    {
+        const bool isYes = kind.parenthesesDegrees()->tag() == mx::core::YesNo::Tag::yes;
+        chord.parenthesesDegrees = isYes ? api::Bool::yes : api::Bool::no;
+    }
+
     if (inGrp.bass().has_value())
     {
         const auto &bass = *inGrp.bass();

--- a/src/private/mx/impl/DirectionReader.h
+++ b/src/private/mx/impl/DirectionReader.h
@@ -40,6 +40,7 @@ class DirectionReader
     mx::api::DirectionData initializeData();
     void parseOffset();
     void parsePlacement();
+    void parseSystemRelation();
     void parseValues();
     mx::api::DirectionData returnData();
     void parseStaffIndex();

--- a/src/private/mx/impl/DirectionWriter.cpp
+++ b/src/private/mx/impl/DirectionWriter.cpp
@@ -1591,6 +1591,18 @@ std::vector<core::MusicDataChoice> DirectionWriter::createHarmonyElements(int in
             kind.setUseSymbols(chordIter->useSymbols == api::Bool::yes ? core::YesNo::yes() : core::YesNo::no());
         }
 
+        if (chordIter->stackDegrees != api::Bool::unspecified)
+        {
+            const bool isYes = chordIter->stackDegrees == api::Bool::yes;
+            kind.setStackDegrees(isYes ? core::YesNo::yes() : core::YesNo::no());
+        }
+
+        if (chordIter->parenthesesDegrees != api::Bool::unspecified)
+        {
+            const bool isYes = chordIter->parenthesesDegrees == api::Bool::yes;
+            kind.setParenthesesDegrees(isYes ? core::YesNo::yes() : core::YesNo::no());
+        }
+
         grp.setKind(kind);
 
         for (const auto &extension : chordIter->extensions)

--- a/src/private/mx/impl/DirectionWriter.cpp
+++ b/src/private/mx/impl/DirectionWriter.cpp
@@ -1683,6 +1683,13 @@ std::vector<core::MusicDataChoice> DirectionWriter::createHarmonyElements(int in
             degree.setDegreeType(degreeType);
             degree.setDegreeValue(degreeValue);
             degree.setDegreeAlter(degreeAlter);
+
+            if (extension.printObject != api::Bool::unspecified)
+            {
+                const bool isYes = extension.printObject == api::Bool::yes;
+                degree.setPrintObject(isYes ? core::YesNo::yes() : core::YesNo::no());
+            }
+
             grp.addDegree(degree);
         }
 

--- a/src/private/mx/impl/DirectionWriter.cpp
+++ b/src/private/mx/impl/DirectionWriter.cpp
@@ -162,6 +162,10 @@ std::vector<core::MusicDataChoice> DirectionWriter::getDirectionLikeThings()
         direction.setPlacement(myConverter.convert(myDirectionData.placement));
     }
 
+    // nullopt for unspecified, and for the bottom-of-system values that only measure numbering has.
+    // <harmony> carries the same attribute; createHarmonyElements writes it there too.
+    direction.setSystem(myConverter.convertDirectionSystemRelation(myDirectionData.systemRelation));
+
     if (myDirectionData.isStaffValueSpecified || myCursor.staffIndex != 0)
     {
         direction.setStaff(myCursor.staffIndex + 1);
@@ -710,34 +714,6 @@ void DirectionWriter::emitTempo(const api::TempoData &tempo, core::Direction &di
     addDirectionType(std::move(dt), direction);
 }
 
-// Maps the api enclosure enum shared by rehearsals, words, and symbols to the core
-// enclosure-shape attribute; nullopt (for unspecified) emits no attribute.
-static std::optional<core::EnclosureShape> directionWriterEnclosure(api::RehearsalEnclosure enclosure)
-{
-    switch (enclosure)
-    {
-    case api::RehearsalEnclosure::rectangle:
-        return core::EnclosureShape::rectangle();
-    case api::RehearsalEnclosure::square:
-        return core::EnclosureShape::square();
-    case api::RehearsalEnclosure::oval:
-        return core::EnclosureShape::oval();
-    case api::RehearsalEnclosure::circle:
-        return core::EnclosureShape::circle();
-    case api::RehearsalEnclosure::bracket:
-        return core::EnclosureShape::bracket();
-    case api::RehearsalEnclosure::triangle:
-        return core::EnclosureShape::triangle();
-    case api::RehearsalEnclosure::diamond:
-        return core::EnclosureShape::diamond();
-    case api::RehearsalEnclosure::none:
-        return core::EnclosureShape::none();
-    case api::RehearsalEnclosure::unspecified:
-    default:
-        return std::nullopt;
-    }
-}
-
 void DirectionWriter::emitWordsRun(const std::vector<api::WordsChoice> &inRun, core::Direction &direction)
 {
     // An empty run cannot be expressed (the schema requires at least one words or symbol) and is
@@ -765,7 +741,14 @@ void DirectionWriter::emitWordsRun(const std::vector<api::WordsChoice> &inRun, c
             {
                 setAttributesFromColorData(*symbolData.color, outSymbol);
             }
-            outSymbol.setEnclosure(directionWriterEnclosure(symbolData.enclosure));
+            if (symbolData.enclosure != api::Enclosure::unspecified)
+            {
+                outSymbol.setEnclosure(myConverter.convert(symbolData.enclosure));
+            }
+            if (symbolData.justify != api::HorizontalAlignment::unspecified)
+            {
+                outSymbol.setJustify(myConverter.convert(symbolData.justify));
+            }
             choiceItem = core::DirectionTypeChoiceChoice::symbol(std::move(outSymbol));
         }
         else
@@ -779,7 +762,14 @@ void DirectionWriter::emitWordsRun(const std::vector<api::WordsChoice> &inRun, c
             {
                 setAttributesFromColorData(wordsData.colorData, outWords);
             }
-            outWords.setEnclosure(directionWriterEnclosure(wordsData.enclosure));
+            if (wordsData.enclosure != api::Enclosure::unspecified)
+            {
+                outWords.setEnclosure(myConverter.convert(wordsData.enclosure));
+            }
+            if (wordsData.justify != api::HorizontalAlignment::unspecified)
+            {
+                outWords.setJustify(myConverter.convert(wordsData.justify));
+            }
             choiceItem = core::DirectionTypeChoiceChoice::words(std::move(outWords));
         }
 
@@ -853,7 +843,14 @@ void DirectionWriter::emitRehearsal(const api::RehearsalData &item, core::Direct
     {
         setAttributesFromColorData(item.colorData, rehearsal);
     }
-    rehearsal.setEnclosure(directionWriterEnclosure(item.enclosure));
+    if (item.enclosure != api::Enclosure::unspecified)
+    {
+        rehearsal.setEnclosure(myConverter.convert(item.enclosure));
+    }
+    if (item.justify != api::HorizontalAlignment::unspecified)
+    {
+        rehearsal.setJustify(myConverter.convert(item.justify));
+    }
     core::DirectionType dt{};
     dt.setChoice(core::DirectionTypeChoice::rehearsal(core::OneOrMore<core::FormattedTextID>{std::move(rehearsal)}));
     addDirectionType(std::move(dt), direction);
@@ -1280,7 +1277,7 @@ void DirectionWriter::emitPercussion(const api::PercussionData &item, core::Dire
 {
     core::Percussion percussion{};
     percussion.setChoice(createPercussionChoice(item.choice));
-    if (item.enclosure != api::PercussionEnclosure::unspecified)
+    if (item.enclosure != api::Enclosure::unspecified)
     {
         percussion.setEnclosure(myConverter.convert(item.enclosure));
     }
@@ -1451,6 +1448,8 @@ std::vector<core::MusicDataChoice> DirectionWriter::createHarmonyElements(int in
     {
         harmony.setStaff(myCursor.staffIndex + 1);
     }
+
+    harmony.setSystem(myConverter.convertDirectionSystemRelation(myDirectionData.systemRelation));
 
     const auto &chords = myDirectionData.chords;
 

--- a/src/private/mx/impl/MeasureReader.cpp
+++ b/src/private/mx/impl/MeasureReader.cpp
@@ -151,6 +151,11 @@ std::pair<api::MeasureData, std::optional<api::TransposeData>> MeasureReader::ge
         myOutMeasureData.number = "";
     }
 
+    if (myPartwiseMeasure.text().has_value())
+    {
+        myOutMeasureData.displayedNumber = myPartwiseMeasure.text()->value();
+    }
+
     if (myPartwiseMeasure.width().has_value())
     {
         myOutMeasureData.width = static_cast<double>(myPartwiseMeasure.width()->value().value());
@@ -882,6 +887,12 @@ void MeasureReader::parsePrint(const core::Print &inMxPrint) const
         {
             myOutMeasureData.measureNumberingSystemRelation =
                 myConverter.convertSystemRelation(*measureNumbering.system());
+        }
+
+        if (measureNumbering.staff().has_value())
+        {
+            // core staff numbers are one-based; the api index is zero-based.
+            myOutMeasureData.measureNumberingStaffIndex = measureNumbering.staff()->value() - 1;
         }
     }
 }

--- a/src/private/mx/impl/MeasureReader.cpp
+++ b/src/private/mx/impl/MeasureReader.cpp
@@ -1114,6 +1114,11 @@ void MeasureReader::importClef(const core::Clef &inClef) const
         clefData.isOctaveChangeSpecified = false;
     }
 
+    if (inClef.additional().has_value())
+    {
+        clefData.additional = converter.convert(*inClef.additional());
+    }
+
     if (inClef.printObject().has_value())
     {
         clefData.printObject = converter.convert(*inClef.printObject());

--- a/src/private/mx/impl/MeasureWriter.cpp
+++ b/src/private/mx/impl/MeasureWriter.cpp
@@ -16,6 +16,7 @@
 #include "mx/core/generated/LeftRightMarginsGroup.h"
 #include "mx/core/generated/MarginType.h"
 #include "mx/core/generated/MeasureNumbering.h"
+#include "mx/core/generated/MeasureText.h"
 #include "mx/core/generated/MusicDataChoice.h"
 #include "mx/core/generated/PageLayout.h"
 #include "mx/core/generated/PageLayoutGroup.h"
@@ -86,6 +87,12 @@ void MeasureWriter::writeMeasureGlobals()
     else
     {
         myOutMeasure.setNumber(std::to_string(myHistory.getCursor().measureIndex + 1));
+    }
+
+    // <measure text=""> is not legal MusicXML; an empty displayedNumber means "no override".
+    if (myMeasureData.displayedNumber.has_value() && !myMeasureData.displayedNumber->empty())
+    {
+        myOutMeasure.setText(core::MeasureText{*myMeasureData.displayedNumber});
     }
 
     if (myMeasureData.width >= 0.0)
@@ -451,6 +458,12 @@ void MeasureWriter::writeMeasureNumbering()
     if (myMeasureData.measureNumberingSystemRelation != api::SystemRelation::unspecified)
     {
         outMeasureNumbering.setSystem(myConverter.convertSystemRelation(myMeasureData.measureNumberingSystemRelation));
+    }
+
+    if (myMeasureData.measureNumberingStaffIndex.has_value())
+    {
+        // the api index is zero-based; core staff numbers are one-based.
+        outMeasureNumbering.setStaff(core::StaffNumber{*myMeasureData.measureNumberingStaffIndex + 1});
     }
 
     outPrint.setMeasureNumbering(std::move(outMeasureNumbering));

--- a/src/private/mx/impl/NoteFunctions.cpp
+++ b/src/private/mx/impl/NoteFunctions.cpp
@@ -93,6 +93,13 @@ api::NoteData NoteFunctions::parseNote() const
 
     myOutNoteData.notehead = converter.convert(reader.getNoteheadValue());
 
+    if (reader.getNoteheadFilled().has_value())
+    {
+        myOutNoteData.noteheadFilled = converter.convert(*reader.getNoteheadFilled());
+    }
+
+    myOutNoteData.noteheadSmufl = reader.getNoteheadSmufl();
+
     if (reader.getIsDurationTypeSpecified())
     {
         myOutNoteData.durationData.durationName = converter.convert(reader.getDurationType());

--- a/src/private/mx/impl/NoteReader.cpp
+++ b/src/private/mx/impl/NoteReader.cpp
@@ -145,20 +145,21 @@ NoteReader::NoteReader(const core::Note &mxNote)
       myIsNormal(false), myIsGrace(false), myIsCue(false), myIsRest(false), myIsChord(false), myIsMeasureRest(false),
       myIsUnpitched(false), myIsPitch(false), myIsDisplayStepOctaveSpecified(false), myDurationValue(0.0),
       myStep(core::Step::c()), myAlter(0), myCents(0.0), myOctave(4), myStaffNumber(0), myIsStaffSpecified(false),
-      myVoiceNumber(0), myNoteheadValue(core::NoteheadValue::normal()), myDurationType(core::NoteTypeValue::maxima()),
-      myIsDurationTypeSpecified(false), myNumDots(0), myBeams(), myTimeModificationActualNotes(-1),
-      myTimeModificationNormalNotes(-1), myTimeModificationNormalType(core::NoteTypeValue::maxima()),
-      myTimeModificationNormalTypeDots(0), myHasAccidental(false), myAccidental(core::AccidentalValue::natural()),
-      myIsAccidentalParenthetical(false), myIsAccidentalCautionary{false}, myIsAccidentalEditorial{false},
-      myIsAccidentalBracketed{false}, myIsStemSpecified{false}, myStem{}, myIsGraceSlashSpecified{false},
-      myGraceSlash{}, myIsTieStart{false}, myIsTieStop{false}, myHasLyric{false}
+      myVoiceNumber(0), myNoteheadValue(core::NoteheadValue::normal()), myNoteheadFilled{}, myNoteheadSmufl{},
+      myDurationType(core::NoteTypeValue::maxima()), myIsDurationTypeSpecified(false), myNumDots(0), myBeams(),
+      myTimeModificationActualNotes(-1), myTimeModificationNormalNotes(-1),
+      myTimeModificationNormalType(core::NoteTypeValue::maxima()), myTimeModificationNormalTypeDots(0),
+      myHasAccidental(false), myAccidental(core::AccidentalValue::natural()), myIsAccidentalParenthetical(false),
+      myIsAccidentalCautionary{false}, myIsAccidentalEditorial{false}, myIsAccidentalBracketed{false},
+      myIsStemSpecified{false}, myStem{}, myIsGraceSlashSpecified{false}, myGraceSlash{}, myIsTieStart{false},
+      myIsTieStop{false}, myHasLyric{false}
 {
     setNormalGraceCueItems();
     setRestPitchUnpitchedItems();
     setChord();
     setStaffNumber();
     setVoiceNumber();
-    setNoteheadValue();
+    setNoteheadItems();
     setDurationType();
     setNumDots();
     setBeams();
@@ -323,11 +324,20 @@ void NoteReader::setVoiceNumber()
     utility::stringToInt(myNote.editorialVoice().voice()->c_str(), myVoiceNumber);
 }
 
-void NoteReader::setNoteheadValue()
+void NoteReader::setNoteheadItems()
 {
-    if (myNote.notehead().has_value())
+    if (!myNote.notehead().has_value())
     {
-        myNoteheadValue = myNote.notehead()->value();
+        return;
+    }
+
+    const auto &notehead = *myNote.notehead();
+    myNoteheadValue = notehead.value();
+    myNoteheadFilled = notehead.filled();
+
+    if (notehead.smufl().has_value())
+    {
+        myNoteheadSmufl = notehead.smufl()->toString();
     }
 }
 

--- a/src/private/mx/impl/NoteReader.h
+++ b/src/private/mx/impl/NoteReader.h
@@ -7,7 +7,9 @@
 #include "mx/api/LyricData.h"
 #include "mx/core/generated/Note.h"
 
+#include <optional>
 #include <span>
+#include <string>
 #include <vector>
 
 namespace mx
@@ -130,6 +132,16 @@ class NoteReader
     inline core::NoteheadValue getNoteheadValue() const
     {
         return myNoteheadValue;
+    }
+
+    inline const std::optional<core::YesNo> &getNoteheadFilled() const
+    {
+        return myNoteheadFilled;
+    }
+
+    inline const std::optional<std::string> &getNoteheadSmufl() const
+    {
+        return myNoteheadSmufl;
     }
 
     inline core::NoteTypeValue getDurationType() const
@@ -259,6 +271,8 @@ class NoteReader
     bool myIsStaffSpecified;
     int myVoiceNumber;
     core::NoteheadValue myNoteheadValue;
+    std::optional<core::YesNo> myNoteheadFilled;
+    std::optional<std::string> myNoteheadSmufl;
     core::NoteTypeValue myDurationType;
     bool myIsDurationTypeSpecified;
     int myNumDots;
@@ -289,7 +303,7 @@ class NoteReader
     void setChord();
     void setStaffNumber();
     void setVoiceNumber();
-    void setNoteheadValue();
+    void setNoteheadItems();
     void setDurationType();
     void setNumDots();
     void setBeams();

--- a/src/private/mx/impl/NoteWriter.cpp
+++ b/src/private/mx/impl/NoteWriter.cpp
@@ -20,6 +20,7 @@
 #include "mx/core/generated/NormalNoteGroup.h"
 #include "mx/core/generated/Pitch.h"
 #include "mx/core/generated/Rest.h"
+#include "mx/core/generated/SmuflGlyphName.h"
 #include "mx/core/generated/Syllabic.h"
 #include "mx/core/generated/TextElementData.h"
 #include "mx/core/generated/Tied.h"
@@ -477,12 +478,31 @@ void NoteWriter::setDurationNameAndDots() const
 
 void NoteWriter::setNotehead() const
 {
-    if (myNoteData.notehead != mx::api::Notehead::normal)
+    const bool isFilledSpecified = myNoteData.noteheadFilled != api::Bool::unspecified;
+    // An empty glyph name names no glyph, so it is treated the same as no smufl at all.
+    const bool isSmuflSpecified = myNoteData.noteheadSmufl.has_value() && !myNoteData.noteheadSmufl->empty();
+
+    // <notehead> stays out of the file for a plain notehead, but filled or smufl still needs
+    // the element even when the value itself is 'normal'.
+    if (myNoteData.notehead == api::Notehead::normal && !isFilledSpecified && !isSmuflSpecified)
     {
-        core::Notehead notehead;
-        notehead.setValue(myConverter.convert(myNoteData.notehead));
-        myOutNote.setNotehead(std::move(notehead));
+        return;
     }
+
+    core::Notehead notehead;
+    notehead.setValue(myConverter.convert(myNoteData.notehead));
+
+    if (isFilledSpecified)
+    {
+        notehead.setFilled(myConverter.convert(myNoteData.noteheadFilled));
+    }
+
+    if (isSmuflSpecified)
+    {
+        notehead.setSmufl(core::SmuflGlyphName{*myNoteData.noteheadSmufl});
+    }
+
+    myOutNote.setNotehead(std::move(notehead));
 }
 
 void NoteWriter::setStemDirection() const

--- a/src/private/mx/impl/PropertiesWriter.cpp
+++ b/src/private/mx/impl/PropertiesWriter.cpp
@@ -354,6 +354,22 @@ void PropertiesWriter::writeClef(int staffIndex, const api::ClefData &inClefData
         cg.setClefOctaveChange(inClefData.octaveChange);
     }
 
+    if (inClefData.additional != api::Bool::unspecified)
+    {
+        mxClef.setAdditional(converter.convert(inClefData.additional));
+    }
+
+    // after-barline states which side of the barline a start-of-measure clef prints on. MusicXML
+    // ignores it on mid-measure clefs, so those emit nothing.
+    if (inClefData.location == api::ClefLocation::afterBarline)
+    {
+        mxClef.setAfterBarline(core::YesNo::yes());
+    }
+    else if (inClefData.location == api::ClefLocation::beforeBarline)
+    {
+        mxClef.setAfterBarline(core::YesNo::no());
+    }
+
     if (inClefData.printObject != api::Bool::unspecified)
     {
         mxClef.setPrintObject(converter.convert(inClefData.printObject));

--- a/src/private/mxtest/api/ClefDataTest.cpp
+++ b/src/private/mxtest/api/ClefDataTest.cpp
@@ -31,6 +31,25 @@ ScoreData makeScoreWithClef(Bool printObject)
     staff.voices[0].notes.emplace_back();
     return score;
 }
+
+ScoreData makeScoreWithAdditionalClef(Bool additional)
+{
+    ScoreData score = makeScoreWithClef(Bool::unspecified);
+    score.parts.front().measures.front().staves.front().clefs.front().additional = additional;
+    return score;
+}
+
+ScoreData makeScoreWithClefLocation(ClefLocation location)
+{
+    ScoreData score = makeScoreWithClef(Bool::unspecified);
+    score.parts.front().measures.front().staves.front().clefs.front().location = location;
+    return score;
+}
+
+const ClefData &firstClef(const ScoreData &score)
+{
+    return score.parts.front().measures.front().staves.front().clefs.front();
+}
 } // namespace mxtest::api::clef_data_test
 
 TEST(clefPrintObjectNoRoundTrip, ClefData)
@@ -74,6 +93,158 @@ TEST(clefPrintObjectUnspecifiedIsOmitted, ClefData)
     CHECK_EQUAL(1, out.parts.front().measures.front().staves.size());
     CHECK_EQUAL(1, out.parts.front().measures.front().staves.front().clefs.size());
     CHECK(Bool::unspecified == out.parts.front().measures.front().staves.front().clefs.front().printObject);
+}
+
+T_END;
+
+TEST(clefAdditionalYesRoundTrip, ClefData)
+{
+    const auto xml = mxtest::toXml(mxtest::api::clef_data_test::makeScoreWithAdditionalClef(Bool::yes));
+    CHECK(xml.find("additional=\"yes\"") != std::string::npos);
+
+    const auto out = mxtest::fromXml(xml);
+    CHECK_EQUAL(1, out.parts.size());
+    CHECK_EQUAL(1, out.parts.front().measures.size());
+    CHECK_EQUAL(1, out.parts.front().measures.front().staves.size());
+    CHECK_EQUAL(1, out.parts.front().measures.front().staves.front().clefs.size());
+    CHECK(Bool::yes == out.parts.front().measures.front().staves.front().clefs.front().additional);
+}
+
+T_END;
+
+TEST(clefAdditionalNoRoundTrip, ClefData)
+{
+    const auto xml = mxtest::toXml(mxtest::api::clef_data_test::makeScoreWithAdditionalClef(Bool::no));
+    CHECK(xml.find("additional=\"no\"") != std::string::npos);
+
+    const auto out = mxtest::fromXml(xml);
+    CHECK_EQUAL(1, out.parts.size());
+    CHECK_EQUAL(1, out.parts.front().measures.size());
+    CHECK_EQUAL(1, out.parts.front().measures.front().staves.size());
+    CHECK_EQUAL(1, out.parts.front().measures.front().staves.front().clefs.size());
+    CHECK(Bool::no == out.parts.front().measures.front().staves.front().clefs.front().additional);
+}
+
+T_END;
+
+TEST(clefAdditionalUnspecifiedIsOmitted, ClefData)
+{
+    const auto xml = mxtest::toXml(mxtest::api::clef_data_test::makeScoreWithAdditionalClef(Bool::unspecified));
+    CHECK(xml.find("additional=") == std::string::npos);
+
+    const auto out = mxtest::fromXml(xml);
+    CHECK_EQUAL(1, out.parts.size());
+    CHECK_EQUAL(1, out.parts.front().measures.size());
+    CHECK_EQUAL(1, out.parts.front().measures.front().staves.size());
+    CHECK_EQUAL(1, out.parts.front().measures.front().staves.front().clefs.size());
+    CHECK(Bool::unspecified == out.parts.front().measures.front().staves.front().clefs.front().additional);
+}
+
+T_END;
+
+TEST(clefAfterBarlineYesRoundTrip, ClefData)
+{
+    using namespace mxtest::api::clef_data_test;
+    const auto xml = mxtest::toXml(makeScoreWithClefLocation(ClefLocation::afterBarline));
+    CHECK(xml.find("after-barline=\"yes\"") != std::string::npos);
+
+    const auto out = mxtest::fromXml(xml);
+    CHECK_EQUAL(1, out.parts.front().measures.front().staves.front().clefs.size());
+    CHECK(ClefLocation::afterBarline == firstClef(out).location);
+}
+
+T_END;
+
+TEST(clefAfterBarlineNoRoundTrip, ClefData)
+{
+    using namespace mxtest::api::clef_data_test;
+    const auto xml = mxtest::toXml(makeScoreWithClefLocation(ClefLocation::beforeBarline));
+    CHECK(xml.find("after-barline=\"no\"") != std::string::npos);
+
+    const auto out = mxtest::fromXml(xml);
+    CHECK_EQUAL(1, out.parts.front().measures.front().staves.front().clefs.size());
+    CHECK(ClefLocation::beforeBarline == firstClef(out).location);
+}
+
+T_END;
+
+TEST(clefAfterBarlineUnspecifiedIsOmitted, ClefData)
+{
+    using namespace mxtest::api::clef_data_test;
+    const auto xml = mxtest::toXml(makeScoreWithClefLocation(ClefLocation::unspecified));
+    CHECK(xml.find("after-barline=") == std::string::npos);
+
+    const auto out = mxtest::fromXml(xml);
+    CHECK_EQUAL(1, out.parts.front().measures.front().staves.front().clefs.size());
+    CHECK(ClefLocation::unspecified == firstClef(out).location);
+}
+
+T_END;
+
+TEST(clefAllFieldsSurviveWrite, ClefData)
+{
+    using namespace mxtest::api::clef_data_test;
+    ScoreData score = makeScoreWithClef(Bool::unspecified);
+    auto &clef = score.parts.front().measures.front().staves.front().clefs.front();
+    clef.writeStaffNumber = Bool::yes;
+    clef.symbol = ClefSymbol::f;
+    clef.line = 4;
+    clef.isLineSpecified = true;
+    clef.octaveChange = -1;
+    clef.isOctaveChangeSpecified = true;
+    clef.tickTimePosition = 0;
+    clef.location = ClefLocation::afterBarline;
+    clef.additional = Bool::yes;
+    clef.printObject = Bool::no;
+    const ClefData expected = clef;
+
+    const auto out = mxtest::fromXml(mxtest::toXml(score));
+    const auto &actual = firstClef(out);
+    CHECK(expected.writeStaffNumber == actual.writeStaffNumber);
+    CHECK(expected.symbol == actual.symbol);
+    CHECK_EQUAL(expected.line, actual.line);
+    CHECK_EQUAL(expected.isLineSpecified, actual.isLineSpecified);
+    CHECK_EQUAL(expected.octaveChange, actual.octaveChange);
+    CHECK_EQUAL(expected.isOctaveChangeSpecified, actual.isOctaveChangeSpecified);
+    CHECK_EQUAL(expected.tickTimePosition, actual.tickTimePosition);
+    CHECK(expected.location == actual.location);
+    CHECK(expected.additional == actual.additional);
+    CHECK(expected.printObject == actual.printObject);
+    CHECK(expected == actual);
+}
+
+T_END;
+
+TEST(clefUnspecifiedElementsSurviveWrite, ClefData)
+{
+    using namespace mxtest::api::clef_data_test;
+    ScoreData score = makeScoreWithClef(Bool::unspecified);
+    auto &clef = score.parts.front().measures.front().staves.front().clefs.front();
+    clef.symbol = ClefSymbol::c;
+    clef.isLineSpecified = false;
+    clef.line = 3;
+    clef.isOctaveChangeSpecified = false;
+    clef.octaveChange = 0;
+    clef.writeStaffNumber = Bool::no;
+    const ClefData expected = clef;
+
+    const auto xml = mxtest::toXml(score);
+    CHECK(xml.find("<line>") == std::string::npos);
+    CHECK(xml.find("<clef-octave-change>") == std::string::npos);
+    CHECK(xml.find("<clef>") != std::string::npos);
+
+    const auto out = mxtest::fromXml(xml);
+    const auto &actual = firstClef(out);
+    CHECK(expected.symbol == actual.symbol);
+    CHECK_EQUAL(expected.line, actual.line);
+    CHECK_EQUAL(expected.isLineSpecified, actual.isLineSpecified);
+    CHECK_EQUAL(expected.octaveChange, actual.octaveChange);
+    CHECK_EQUAL(expected.isOctaveChangeSpecified, actual.isOctaveChangeSpecified);
+
+    // writeStaffNumber records only a divergence from the automatic rule. On a single-staff part
+    // the automatic rule already omits the number, so no agrees with it and reads back as
+    // unspecified. The emitted XML is the same either way.
+    CHECK(Bool::unspecified == actual.writeStaffNumber);
 }
 
 T_END;

--- a/src/private/mxtest/api/DirectionDataTest.cpp
+++ b/src/private/mxtest/api/DirectionDataTest.cpp
@@ -263,7 +263,7 @@ TEST(RehearsalSyntheticFileRead, DirectionData)
     REQUIRE(directions.front().directionTypes.front().isRehearsal());
     const auto rehearsal = directions.front().directionTypes.front().rehearsal();
     CHECK_EQUAL("x", rehearsal.text);
-    CHECK(RehearsalEnclosure::rectangle == rehearsal.enclosure);
+    CHECK(Enclosure::rectangle == rehearsal.enclosure);
 }
 
 T_END;
@@ -291,7 +291,7 @@ TEST(RehearsalRoundTripXml, DirectionData)
 
     RehearsalData rehearsal;
     rehearsal.text = "B";
-    rehearsal.enclosure = RehearsalEnclosure::rectangle;
+    rehearsal.enclosure = Enclosure::rectangle;
     rehearsal.fontData.fontFamily = {"Times New Roman"};
     rehearsal.fontData.style = FontStyle::normal;
     rehearsal.fontData.weight = FontWeight::bold;
@@ -315,13 +315,13 @@ TEST(RehearsalRoundTripXml, DirectionData)
     REQUIRE(rdirections.front().directionTypes.front().isRehearsal());
     const auto outRehearsal = rdirections.front().directionTypes.front().rehearsal();
     CHECK_EQUAL("B", outRehearsal.text);
-    CHECK(RehearsalEnclosure::rectangle == outRehearsal.enclosure);
+    CHECK(Enclosure::rectangle == outRehearsal.enclosure);
     CHECK(FontWeight::bold == outRehearsal.fontData.weight);
 }
 
 T_END;
 
-// Verify that a rehearsal with no enclosure set (RehearsalEnclosure::unspecified) does not emit
+// Verify that a rehearsal with no enclosure set (Enclosure::unspecified) does not emit
 // an enclosure attribute in the serialized XML, and that the field round-trips as unspecified.
 TEST(RehearsalUnspecifiedEnclosureNoPhantomAttribute, DirectionData)
 {
@@ -358,7 +358,88 @@ TEST(RehearsalUnspecifiedEnclosureNoPhantomAttribute, DirectionData)
     REQUIRE(rdirections.size() == 1);
     REQUIRE(rdirections.front().directionTypes.size() == 1);
     REQUIRE(rdirections.front().directionTypes.front().isRehearsal());
-    CHECK(RehearsalEnclosure::unspecified == rdirections.front().directionTypes.front().rehearsal().enclosure);
+    CHECK(Enclosure::unspecified == rdirections.front().directionTypes.front().rehearsal().enclosure);
+}
+
+T_END;
+
+// A rehearsal mark's justify attribute round-trips and stays independent of halign, which lives in
+// positionData. An unspecified justify emits no attribute.
+TEST(RehearsalJustify, DirectionData)
+{
+    ScoreData oscore;
+    oscore.ticksPerQuarter = 10;
+    oscore.parts.emplace_back();
+    auto &opart = oscore.parts.back();
+    opart.measures.emplace_back();
+    auto &omeasure = opart.measures.back();
+    omeasure.staves.emplace_back();
+    auto &ostaff = omeasure.staves.back();
+    auto &ovoice = ostaff.voices[0];
+
+    NoteData onote{};
+    onote.tickTimePosition = 0;
+    onote.durationData.durationTimeTicks = 10;
+    onote.durationData.durationName = DurationName::quarter;
+    ovoice.notes.push_back(onote);
+
+    RehearsalData rehearsal;
+    rehearsal.text = "D";
+    rehearsal.justify = HorizontalAlignment::center;
+    rehearsal.positionData.horizontalAlignment = HorizontalAlignment::right;
+
+    DirectionData directionData;
+    directionData.tickTimePosition = 0;
+    directionData.directionTypes.emplace_back(DirectionChoice{rehearsal});
+    ostaff.directions.push_back(directionData);
+
+    const auto rscore = mxtest::roundTrip(oscore);
+    const auto &rdirections = rscore.parts.front().measures.front().staves.front().directions;
+    REQUIRE(rdirections.size() == 1);
+    REQUIRE(rdirections.front().directionTypes.size() == 1);
+    REQUIRE(rdirections.front().directionTypes.front().isRehearsal());
+    const auto outRehearsal = rdirections.front().directionTypes.front().rehearsal();
+    CHECK(HorizontalAlignment::center == outRehearsal.justify);
+    CHECK(HorizontalAlignment::right == outRehearsal.positionData.horizontalAlignment);
+}
+
+T_END;
+
+TEST(RehearsalUnspecifiedJustifyNoPhantomAttribute, DirectionData)
+{
+    ScoreData oscore;
+    oscore.ticksPerQuarter = 10;
+    oscore.parts.emplace_back();
+    auto &opart = oscore.parts.back();
+    opart.measures.emplace_back();
+    auto &omeasure = opart.measures.back();
+    omeasure.staves.emplace_back();
+    auto &ostaff = omeasure.staves.back();
+    auto &ovoice = ostaff.voices[0];
+
+    NoteData onote{};
+    onote.tickTimePosition = 0;
+    onote.durationData.durationTimeTicks = 10;
+    onote.durationData.durationName = DurationName::quarter;
+    ovoice.notes.push_back(onote);
+
+    RehearsalData rehearsal;
+    rehearsal.text = "E";
+
+    DirectionData directionData;
+    directionData.tickTimePosition = 0;
+    directionData.directionTypes.emplace_back(DirectionChoice{rehearsal});
+    ostaff.directions.push_back(directionData);
+
+    const auto xml = mxtest::toXml(oscore);
+    CHECK(xml.find("justify") == std::string::npos);
+
+    const auto rscore = mxtest::roundTrip(oscore);
+    const auto &rdirections = rscore.parts.front().measures.front().staves.front().directions;
+    REQUIRE(rdirections.size() == 1);
+    REQUIRE(rdirections.front().directionTypes.size() == 1);
+    REQUIRE(rdirections.front().directionTypes.front().isRehearsal());
+    CHECK(HorizontalAlignment::unspecified == rdirections.front().directionTypes.front().rehearsal().justify);
 }
 
 T_END;

--- a/src/private/mxtest/api/DirectionMarksRoundTripTest.cpp
+++ b/src/private/mxtest/api/DirectionMarksRoundTripTest.cpp
@@ -343,7 +343,7 @@ TEST(PercussionGlass, DirectionMarksRoundTrip)
     GlassPercussion glass;
     glass.value = GlassInstrument::windChimes;
     percussion.choice = PercussionDataChoice{glass};
-    percussion.enclosure = PercussionEnclosure::rectangle;
+    percussion.enclosure = Enclosure::rectangle;
     direction.directionTypes.emplace_back(DirectionChoice{percussion});
     const auto directions = roundTripDirectionData(direction);
     REQUIRE(directions.size() == 1);
@@ -352,7 +352,7 @@ TEST(PercussionGlass, DirectionMarksRoundTrip)
     const auto out = directions.front().directionTypes.front().percussion();
     REQUIRE(out.choice.isGlass());
     CHECK(out.choice.glass().value == GlassInstrument::windChimes);
-    CHECK(out.enclosure == PercussionEnclosure::rectangle);
+    CHECK(out.enclosure == Enclosure::rectangle);
 }
 
 T_END;
@@ -588,7 +588,7 @@ TEST(WordsEnclosure, DirectionMarksRoundTrip)
     DirectionData direction;
     WordsData words;
     words.text = "boxed";
-    words.enclosure = RehearsalEnclosure::rectangle;
+    words.enclosure = Enclosure::rectangle;
     direction.directionTypes.emplace_back(DirectionChoice{std::vector<WordsChoice>{WordsChoice{words}}});
     const auto directions = roundTripDirectionData(direction);
     REQUIRE(directions.size() == 1);
@@ -597,7 +597,161 @@ TEST(WordsEnclosure, DirectionMarksRoundTrip)
     const auto outRun = directions.front().directionTypes.front().wordsRun();
     REQUIRE(outRun.size() == 1);
     REQUIRE(outRun.front().isWords());
-    CHECK(outRun.front().words().enclosure == RehearsalEnclosure::rectangle);
+    CHECK(outRun.front().words().enclosure == Enclosure::rectangle);
+}
+
+T_END;
+
+// Every shape in the enclosure vocabulary reaches the wire and comes back. Keep this list complete:
+// a value the conversion switches do not map is silently dropped, which is what it guards against.
+TEST(WordsEnclosureAllShapes, DirectionMarksRoundTrip)
+{
+    const std::vector<Enclosure> shapes{
+        Enclosure::rectangle,       Enclosure::square,   Enclosure::oval,    Enclosure::circle,   Enclosure::bracket,
+        Enclosure::invertedBracket, Enclosure::triangle, Enclosure::diamond, Enclosure::pentagon, Enclosure::hexagon,
+        Enclosure::heptagon,        Enclosure::octagon,  Enclosure::nonagon, Enclosure::decagon,  Enclosure::none};
+    for (const auto shape : shapes)
+    {
+        DirectionData direction;
+        WordsData words;
+        words.text = "boxed";
+        words.enclosure = shape;
+        direction.directionTypes.emplace_back(DirectionChoice{std::vector<WordsChoice>{WordsChoice{words}}});
+        const auto directions = roundTripDirectionData(direction);
+        REQUIRE(directions.size() == 1);
+        REQUIRE(directions.front().directionTypes.size() == 1);
+        REQUIRE(directions.front().directionTypes.front().isWordsRun());
+        const auto outRun = directions.front().directionTypes.front().wordsRun();
+        REQUIRE(outRun.size() == 1);
+        REQUIRE(outRun.front().isWords());
+        CHECK(outRun.front().words().enclosure == shape);
+    }
+}
+
+T_END;
+
+// The justify attribute of <words> round-trips, and is independent of halign.
+TEST(WordsJustify, DirectionMarksRoundTrip)
+{
+    DirectionData direction;
+    WordsData words;
+    words.text = "a tempo";
+    words.justify = HorizontalAlignment::center;
+    words.positionData.horizontalAlignment = HorizontalAlignment::right;
+    direction.directionTypes.emplace_back(DirectionChoice{std::vector<WordsChoice>{WordsChoice{words}}});
+    const auto directions = roundTripDirectionData(direction);
+    REQUIRE(directions.size() == 1);
+    REQUIRE(directions.front().directionTypes.size() == 1);
+    REQUIRE(directions.front().directionTypes.front().isWordsRun());
+    const auto outRun = directions.front().directionTypes.front().wordsRun();
+    REQUIRE(outRun.size() == 1);
+    REQUIRE(outRun.front().isWords());
+    CHECK(outRun.front().words().justify == HorizontalAlignment::center);
+    CHECK(outRun.front().words().positionData.horizontalAlignment == HorizontalAlignment::right);
+}
+
+T_END;
+
+// <symbol> carries justify and enclosure just as <words> does; both survive within a run.
+TEST(SymbolJustify, DirectionMarksRoundTrip)
+{
+    DirectionData direction;
+    SymbolData symbol;
+    symbol.smufl = "arrowBlackUp";
+    symbol.justify = HorizontalAlignment::right;
+    symbol.enclosure = Enclosure::hexagon;
+    symbol.positionData.horizontalAlignment = HorizontalAlignment::left;
+    direction.directionTypes.emplace_back(DirectionChoice{std::vector<WordsChoice>{WordsChoice{symbol}}});
+    const auto directions = roundTripDirectionData(direction);
+    REQUIRE(directions.size() == 1);
+    REQUIRE(directions.front().directionTypes.size() == 1);
+    REQUIRE(directions.front().directionTypes.front().isWordsRun());
+    const auto outRun = directions.front().directionTypes.front().wordsRun();
+    REQUIRE(outRun.size() == 1);
+    REQUIRE(outRun.front().isSymbol());
+    const auto outSymbol = outRun.front().symbol();
+    CHECK_EQUAL("arrowBlackUp", outSymbol.smufl);
+    CHECK(outSymbol.justify == HorizontalAlignment::right);
+    CHECK(outSymbol.enclosure == Enclosure::hexagon);
+    CHECK(outSymbol.positionData.horizontalAlignment == HorizontalAlignment::left);
+}
+
+T_END;
+
+// An unspecified justify emits no attribute and reads back as unspecified, for words and symbols.
+TEST(SymbolJustifyUnspecified, DirectionMarksRoundTrip)
+{
+    DirectionData direction;
+    SymbolData symbol;
+    symbol.smufl = "arrowBlackUp";
+    direction.directionTypes.emplace_back(DirectionChoice{std::vector<WordsChoice>{WordsChoice{symbol}}});
+    const auto directions = roundTripDirectionData(direction);
+    REQUIRE(directions.size() == 1);
+    REQUIRE(directions.front().directionTypes.size() == 1);
+    REQUIRE(directions.front().directionTypes.front().isWordsRun());
+    const auto outRun = directions.front().directionTypes.front().wordsRun();
+    REQUIRE(outRun.size() == 1);
+    REQUIRE(outRun.front().isSymbol());
+    CHECK(outRun.front().symbol().justify == HorizontalAlignment::unspecified);
+}
+
+T_END;
+
+// An unspecified justify emits no attribute and reads back as unspecified.
+TEST(WordsJustifyUnspecified, DirectionMarksRoundTrip)
+{
+    DirectionData direction;
+    WordsData words;
+    words.text = "a tempo";
+    direction.directionTypes.emplace_back(DirectionChoice{std::vector<WordsChoice>{WordsChoice{words}}});
+    const auto directions = roundTripDirectionData(direction);
+    REQUIRE(directions.size() == 1);
+    REQUIRE(directions.front().directionTypes.size() == 1);
+    REQUIRE(directions.front().directionTypes.front().isWordsRun());
+    const auto outRun = directions.front().directionTypes.front().wordsRun();
+    REQUIRE(outRun.size() == 1);
+    REQUIRE(outRun.front().isWords());
+    CHECK(outRun.front().words().justify == HorizontalAlignment::unspecified);
+}
+
+T_END;
+
+// The <direction system="..."> attribute round-trips for each value the direction vocabulary has.
+TEST(DirectionSystemRelation, DirectionMarksRoundTrip)
+{
+    const std::vector<SystemRelation> values{SystemRelation::onlyTop, SystemRelation::alsoTop, SystemRelation::none};
+    for (const auto value : values)
+    {
+        DirectionData direction;
+        direction.systemRelation = value;
+        WordsData words;
+        words.text = "Allegro";
+        direction.directionTypes.emplace_back(DirectionChoice{std::vector<WordsChoice>{WordsChoice{words}}});
+        const auto directions = roundTripDirectionData(direction);
+        REQUIRE(directions.size() == 1);
+        CHECK(directions.front().systemRelation == value);
+    }
+}
+
+T_END;
+
+// A direction left at the default writes no system attribute; the measure-numbering-only bottom
+// values have no direction equivalent and are dropped rather than written as something else.
+TEST(DirectionSystemRelationUnwritable, DirectionMarksRoundTrip)
+{
+    const std::vector<SystemRelation> values{SystemRelation::unspecified, SystemRelation::onlyBottom,
+                                             SystemRelation::alsoBottom};
+    for (const auto value : values)
+    {
+        DirectionData direction;
+        direction.systemRelation = value;
+        WordsData words;
+        words.text = "Allegro";
+        direction.directionTypes.emplace_back(DirectionChoice{std::vector<WordsChoice>{WordsChoice{words}}});
+        const auto directions = roundTripDirectionData(direction);
+        REQUIRE(directions.size() == 1);
+        CHECK(directions.front().systemRelation == SystemRelation::unspecified);
+    }
 }
 
 T_END;

--- a/src/private/mxtest/api/HarmonyExtrasApiTest.cpp
+++ b/src/private/mxtest/api/HarmonyExtrasApiTest.cpp
@@ -8,6 +8,8 @@
 #include "cpul/cpulTestHarness.h"
 #include "mx/api/ScoreData.h"
 #include "mxtest/api/RoundTrip.h"
+#include "mxtest/api/TestHelpers.h"
+#include "mxtest/file/MxFileRepository.h"
 
 using namespace std;
 using namespace mx::api;
@@ -47,6 +49,56 @@ const ChordData &firstChord(const ScoreData &score)
     return score.parts.front().measures.front().staves.front().directions.front().chords.front();
 }
 } // namespace
+
+TEST(harmonyDegreeLayoutRoundTrip, HarmonyExtrasApi)
+{
+    auto score = makeScoreWithChord();
+    auto &chord = chordOf(score);
+    chord.root = Step::c;
+    chord.chordKind = ChordKind::dominantNinth;
+    chord.stackDegrees = Bool::yes;
+    chord.parenthesesDegrees = Bool::no;
+
+    const auto xml = mxtest::toXml(score);
+    CHECK(xml.find("stack-degrees=\"yes\"") != std::string::npos);
+    CHECK(xml.find("parentheses-degrees=\"no\"") != std::string::npos);
+
+    const auto out = mxtest::roundTrip(score);
+    const auto &outChord = firstChord(out);
+    CHECK(Bool::yes == outChord.stackDegrees);
+    CHECK(Bool::no == outChord.parenthesesDegrees);
+}
+
+T_END;
+
+TEST(harmonyDegreeLayoutUnspecifiedIsNotWritten, HarmonyExtrasApi)
+{
+    auto score = makeScoreWithChord();
+    auto &chord = chordOf(score);
+    chord.root = Step::c;
+    chord.chordKind = ChordKind::major;
+
+    const auto xml = mxtest::toXml(score);
+    CHECK(xml.find("stack-degrees") == std::string::npos);
+    CHECK(xml.find("parentheses-degrees") == std::string::npos);
+
+    const auto out = mxtest::roundTrip(score);
+    const auto &outChord = firstChord(out);
+    CHECK(Bool::unspecified == outChord.stackDegrees);
+    CHECK(Bool::unspecified == outChord.parenthesesDegrees);
+}
+
+T_END;
+
+TEST(harmonyDegreeLayoutFromFile, HarmonyExtrasApi)
+{
+    const auto score = mxtest::MxFileRepository::loadFile("kind.3.0.xml");
+    const auto &outChord = firstChord(score);
+    CHECK(Bool::yes == outChord.stackDegrees);
+    CHECK(Bool::yes == outChord.parenthesesDegrees);
+}
+
+T_END;
 
 TEST(harmonyInversionRoundTrip, HarmonyExtrasApi)
 {

--- a/src/private/mxtest/api/HarmonyExtrasApiTest.cpp
+++ b/src/private/mxtest/api/HarmonyExtrasApiTest.cpp
@@ -100,6 +100,93 @@ TEST(harmonyDegreeLayoutFromFile, HarmonyExtrasApi)
 
 T_END;
 
+// A degree the <kind> text already spells out is marked print-object="no" so it is not printed
+// twice. Finale exports exactly this: <kind text="7sus4">suspended-fourth</kind> plus a hidden
+// seventh.
+TEST(harmonyDegreePrintObjectRoundTrip, HarmonyExtrasApi)
+{
+    auto score = makeScoreWithChord();
+    auto &chord = chordOf(score);
+    chord.root = Step::c;
+    chord.chordKind = ChordKind::suspendedFourth;
+    chord.text = "7sus4";
+    Extension seventh;
+    seventh.extensionType = ExtensionType::add;
+    seventh.extensionNumber = ExtensionNumber::seventh;
+    seventh.extensionAlter = ExtensionAlter::none;
+    seventh.printObject = Bool::no;
+    chord.extensions.push_back(seventh);
+
+    const auto xml = mxtest::toXml(score);
+    CHECK(xml.find("<degree print-object=\"no\">") != std::string::npos);
+
+    const auto out = mxtest::roundTrip(score);
+    const auto &outChord = firstChord(out);
+    REQUIRE(outChord.extensions.size() == 1);
+    CHECK(Bool::no == outChord.extensions.front().printObject);
+    CHECK(ExtensionNumber::seventh == outChord.extensions.front().extensionNumber);
+}
+
+T_END;
+
+TEST(harmonyDegreePrintObjectUnspecifiedIsNotWritten, HarmonyExtrasApi)
+{
+    auto score = makeScoreWithChord();
+    auto &chord = chordOf(score);
+    chord.root = Step::c;
+    chord.chordKind = ChordKind::major;
+    Extension ninth;
+    ninth.extensionType = ExtensionType::add;
+    ninth.extensionNumber = ExtensionNumber::ninth;
+    ninth.extensionAlter = ExtensionAlter::sharp;
+    chord.extensions.push_back(ninth);
+
+    const auto xml = mxtest::toXml(score);
+    CHECK(xml.find("print-object") == std::string::npos);
+
+    const auto out = mxtest::roundTrip(score);
+    const auto &outChord = firstChord(out);
+    REQUIRE(outChord.extensions.size() == 1);
+    CHECK(Bool::unspecified == outChord.extensions.front().printObject);
+}
+
+T_END;
+
+// The read path against a real Finale export: three chord symbols in this file hide a degree the
+// kind text already spells out.
+TEST(harmonyDegreePrintObjectFromFinaleExport, HarmonyExtrasApi)
+{
+    const auto score = mxtest::MxFileRepository::loadFile("BrookeWestSample.xml");
+    int hiddenDegreeCount = 0;
+
+    for (const auto &part : score.parts)
+    {
+        for (const auto &measure : part.measures)
+        {
+            for (const auto &staff : measure.staves)
+            {
+                for (const auto &direction : staff.directions)
+                {
+                    for (const auto &chord : direction.chords)
+                    {
+                        for (const auto &extension : chord.extensions)
+                        {
+                            if (extension.printObject == Bool::no)
+                            {
+                                ++hiddenDegreeCount;
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    CHECK_EQUAL(3, hiddenDegreeCount);
+}
+
+T_END;
+
 TEST(harmonyInversionRoundTrip, HarmonyExtrasApi)
 {
     auto score = makeScoreWithChord();

--- a/src/private/mxtest/api/HarmonyExtrasApiTest.cpp
+++ b/src/private/mxtest/api/HarmonyExtrasApiTest.cpp
@@ -111,4 +111,38 @@ TEST(harmonyNumeralRoundTrip, HarmonyExtrasApi)
 
 T_END;
 
+// <harmony> carries the same system attribute as <direction>; a harmony-only direction writes it
+// and reads it back.
+TEST(harmonySystemRelationRoundTrip, HarmonyExtrasApi)
+{
+    auto score = makeScoreWithChord();
+    auto &chord = chordOf(score);
+    chord.root = Step::c;
+    chord.chordKind = ChordKind::major;
+    auto &direction = score.parts.front().measures.front().staves.front().directions.front();
+    direction.systemRelation = SystemRelation::alsoTop;
+
+    const auto out = mxtest::roundTrip(score);
+    const auto &outDirection = out.parts.front().measures.front().staves.front().directions.front();
+    CHECK(SystemRelation::alsoTop == outDirection.systemRelation);
+    CHECK(Step::c == firstChord(out).root);
+}
+
+T_END;
+
+// A harmony-only direction left at the default writes no system attribute.
+TEST(harmonySystemRelationUnspecified, HarmonyExtrasApi)
+{
+    auto score = makeScoreWithChord();
+    auto &chord = chordOf(score);
+    chord.root = Step::c;
+    chord.chordKind = ChordKind::major;
+
+    const auto out = mxtest::roundTrip(score);
+    const auto &outDirection = out.parts.front().measures.front().staves.front().directions.front();
+    CHECK(SystemRelation::unspecified == outDirection.systemRelation);
+}
+
+T_END;
+
 #endif

--- a/src/private/mxtest/api/MeasureDataTest.cpp
+++ b/src/private/mxtest/api/MeasureDataTest.cpp
@@ -332,6 +332,112 @@ TEST(measureNumberingUnspecifiedOmitsElement, MeasureData)
 
 T_END;
 
+TEST(measureNumberingStaffRoundTrip, MeasureData)
+{
+    ScoreData score;
+    score.parts.emplace_back();
+    auto &part = score.parts.back();
+    part.measures.emplace_back();
+    auto &measure = part.measures.back();
+    measure.measureNumbering = MeasureNumbering::system;
+    measure.measureNumberingStaffIndex = 1;
+    measure.staves.emplace_back();
+    measure.staves.back().voices[0].notes.emplace_back();
+    measure.staves.emplace_back();
+    measure.staves.back().voices[0].notes.emplace_back();
+
+    const auto xml = mxtest::toXml(score);
+    CHECK(xml.find("staff=\"2\"") != std::string::npos);
+
+    const auto outScore = mxtest::fromXml(xml);
+    const auto &outMeasure = outScore.parts.front().measures.front();
+    REQUIRE(outMeasure.measureNumberingStaffIndex.has_value());
+    CHECK_EQUAL(1, *outMeasure.measureNumberingStaffIndex);
+}
+
+T_END;
+
+TEST(measureNumberingStaffAbsentOmitsAttribute, MeasureData)
+{
+    ScoreData score;
+    score.parts.emplace_back();
+    auto &part = score.parts.back();
+    part.measures.emplace_back();
+    auto &measure = part.measures.back();
+    measure.measureNumbering = MeasureNumbering::system;
+    measure.staves.emplace_back();
+    measure.staves.back().voices[0].notes.emplace_back();
+
+    const auto xml = mxtest::toXml(score);
+    CHECK(xml.find("<measure-numbering staff=") == std::string::npos);
+
+    const auto outScore = mxtest::fromXml(xml);
+    CHECK(!outScore.parts.front().measures.front().measureNumberingStaffIndex.has_value());
+}
+
+T_END;
+
+TEST(displayedNumberRoundTrip, MeasureData)
+{
+    ScoreData score;
+    score.parts.emplace_back();
+    auto &part = score.parts.back();
+    part.measures.emplace_back();
+    auto &measure = part.measures.back();
+    measure.number = "7";
+    measure.displayedNumber = "12a";
+    measure.staves.emplace_back();
+    measure.staves.back().voices[0].notes.emplace_back();
+
+    const auto xml = mxtest::toXml(score);
+    CHECK(xml.find("number=\"7\"") != std::string::npos);
+    CHECK(xml.find("text=\"12a\"") != std::string::npos);
+
+    const auto outScore = mxtest::fromXml(xml);
+    const auto &outMeasure = outScore.parts.front().measures.front();
+    CHECK_EQUAL("7", outMeasure.number);
+    REQUIRE(outMeasure.displayedNumber.has_value());
+    CHECK_EQUAL("12a", *outMeasure.displayedNumber);
+}
+
+T_END;
+
+TEST(displayedNumberAbsentOmitsAttribute, MeasureData)
+{
+    ScoreData score;
+    score.parts.emplace_back();
+    auto &part = score.parts.back();
+    part.measures.emplace_back();
+    auto &measure = part.measures.back();
+    measure.staves.emplace_back();
+    measure.staves.back().voices[0].notes.emplace_back();
+
+    const auto xml = mxtest::toXml(score);
+    CHECK(xml.find("text=") == std::string::npos);
+
+    const auto outScore = mxtest::fromXml(xml);
+    CHECK(!outScore.parts.front().measures.front().displayedNumber.has_value());
+}
+
+T_END;
+
+TEST(emptyDisplayedNumberOmitsAttribute, MeasureData)
+{
+    ScoreData score;
+    score.parts.emplace_back();
+    auto &part = score.parts.back();
+    part.measures.emplace_back();
+    auto &measure = part.measures.back();
+    measure.displayedNumber = "";
+    measure.staves.emplace_back();
+    measure.staves.back().voices[0].notes.emplace_back();
+
+    const auto xml = mxtest::toXml(score);
+    CHECK(xml.find("text=") == std::string::npos);
+}
+
+T_END;
+
 TEST(multiMeasureRestRoundTrip, MeasureData)
 {
     ScoreData score;

--- a/src/private/mxtest/api/NoteDataTest.cpp
+++ b/src/private/mxtest/api/NoteDataTest.cpp
@@ -1582,7 +1582,8 @@ TEST(noteheadAttributesDefaultToAbsent, NoteData)
     const std::string xml = mxtest::toXml(score);
     CHECK(xml.find("<notehead") == std::string::npos);
 
-    const auto &outNote = firstNoteheadNote(mxtest::fromXml(xml));
+    const auto outScore = mxtest::fromXml(xml);
+    const auto &outNote = firstNoteheadNote(outScore);
     CHECK(Bool::unspecified == outNote.noteheadFilled);
     CHECK(!outNote.noteheadSmufl.has_value());
 }

--- a/src/private/mxtest/api/NoteDataTest.cpp
+++ b/src/private/mxtest/api/NoteDataTest.cpp
@@ -1471,6 +1471,149 @@ TEST(noteheadOtherRoundtrip, NoteData)
     CHECK(outNote.notehead == Notehead::other);
 }
 
+T_END;
+
+// A one-note score whose single quarter note is ready for notehead fields to be set on it.
+ScoreData makeNoteheadScore()
+{
+    ScoreData score;
+    score.ticksPerQuarter = 96;
+    score.parts.emplace_back();
+    auto &part = score.parts.back();
+    part.measures.emplace_back();
+    auto &measure = part.measures.back();
+    measure.staves.emplace_back();
+    auto &staff = measure.staves.back();
+    auto &voice = staff.voices[0];
+
+    NoteData note;
+    note.durationData.durationName = DurationName::quarter;
+    note.durationData.durationTimeTicks = 96;
+    voice.notes.push_back(note);
+
+    return score;
+}
+
+const NoteData &firstNoteheadNote(const ScoreData &score)
+{
+    return score.parts.front().measures.front().staves.front().voices.begin()->second.notes.front();
+}
+
+// filled="no" on an otherwise normal notehead: the <notehead> element has to be written even
+// though the notehead value itself is the default.
+TEST(noteheadFilledRoundtrip, NoteData)
+{
+    auto score = makeNoteheadScore();
+    score.parts.back().measures.back().staves.back().voices.at(0).notes.back().noteheadFilled = Bool::no;
+
+    const std::string xml = mxtest::toXml(score);
+    CHECK(xml.find(R"(<notehead filled="no">normal</notehead>)") != std::string::npos);
+
+    const auto outScore = mxtest::fromXml(xml);
+    CHECK(Bool::no == firstNoteheadNote(outScore).noteheadFilled);
+    CHECK(Notehead::normal == firstNoteheadNote(outScore).notehead);
+}
+
+T_END;
+
+// filled="yes" alongside a non-default notehead value.
+TEST(noteheadFilledYesWithShapeRoundtrip, NoteData)
+{
+    auto score = makeNoteheadScore();
+    auto &note = score.parts.back().measures.back().staves.back().voices.at(0).notes.back();
+    note.notehead = Notehead::diamond;
+    note.noteheadFilled = Bool::yes;
+
+    const std::string xml = mxtest::toXml(score);
+    CHECK(xml.find(R"(<notehead filled="yes">diamond</notehead>)") != std::string::npos);
+
+    const auto outScore = mxtest::fromXml(xml);
+    CHECK(Bool::yes == firstNoteheadNote(outScore).noteheadFilled);
+    CHECK(Notehead::diamond == firstNoteheadNote(outScore).notehead);
+}
+
+T_END;
+
+// The smufl attribute names a glyph that MusicXML has no notehead value for; it pairs with the
+// 'other' notehead value.
+TEST(noteheadSmuflRoundtrip, NoteData)
+{
+    auto score = makeNoteheadScore();
+    auto &note = score.parts.back().measures.back().staves.back().voices.at(0).notes.back();
+    note.notehead = Notehead::other;
+    note.noteheadSmufl = "noteheadSlashHorizontalEnds";
+
+    const std::string xml = mxtest::toXml(score);
+    CHECK(xml.find(R"(smufl="noteheadSlashHorizontalEnds")") != std::string::npos);
+
+    const auto outScore = mxtest::fromXml(xml);
+    const auto &outNote = firstNoteheadNote(outScore);
+    CHECK(Notehead::other == outNote.notehead);
+    REQUIRE(outNote.noteheadSmufl.has_value());
+    CHECK_EQUAL("noteheadSlashHorizontalEnds", *outNote.noteheadSmufl);
+}
+
+T_END;
+
+// Both attributes at once, refining a notehead value that MusicXML names only broadly.
+TEST(noteheadFilledAndSmuflRoundtrip, NoteData)
+{
+    auto score = makeNoteheadScore();
+    auto &note = score.parts.back().measures.back().staves.back().voices.at(0).notes.back();
+    note.notehead = Notehead::cluster;
+    note.noteheadFilled = Bool::yes;
+    note.noteheadSmufl = "noteheadClusterSquareBlack";
+
+    const auto outScore = mxtest::fromXml(mxtest::toXml(score));
+    const auto &outNote = firstNoteheadNote(outScore);
+    CHECK(Notehead::cluster == outNote.notehead);
+    CHECK(Bool::yes == outNote.noteheadFilled);
+    REQUIRE(outNote.noteheadSmufl.has_value());
+    CHECK_EQUAL("noteheadClusterSquareBlack", *outNote.noteheadSmufl);
+}
+
+T_END;
+
+// A note that sets neither field writes no <notehead> element at all.
+TEST(noteheadAttributesDefaultToAbsent, NoteData)
+{
+    const auto score = makeNoteheadScore();
+
+    const std::string xml = mxtest::toXml(score);
+    CHECK(xml.find("<notehead") == std::string::npos);
+
+    const auto &outNote = firstNoteheadNote(mxtest::fromXml(xml));
+    CHECK(Bool::unspecified == outNote.noteheadFilled);
+    CHECK(!outNote.noteheadSmufl.has_value());
+}
+
+T_END;
+
+// Parse the synthetic notehead file and confirm mx::api surfaces both attributes. This pins the
+// core -> api read path independently of what the writer emits.
+TEST(noteheadSyntheticFileRead, NoteData)
+{
+    const std::string path = mxtest::getResourcesDirectoryPath() + "synthetic/notehead.3.1.xml";
+    auto &docMgr = DocumentManager::getInstance();
+    const auto docIdResult = docMgr.createFromFile(path);
+    REQUIRE(docIdResult.ok());
+    const int docId = docIdResult.value();
+    const auto scoreResult = docMgr.getData(docId);
+    docMgr.destroyDocument(docId);
+    REQUIRE(scoreResult.ok());
+    const auto &score = scoreResult.value();
+    REQUIRE(score.parts.size() == 1);
+    REQUIRE(score.parts.front().measures.size() == 1);
+
+    const auto &outNote = firstNoteheadNote(score);
+    CHECK(Notehead::slash == outNote.notehead);
+    CHECK(Bool::yes == outNote.noteheadFilled);
+    REQUIRE(outNote.noteheadSmufl.has_value());
+    CHECK_EQUAL("noteheadBlack", *outNote.noteheadSmufl);
+}
+
+T_END;
+
 TEST(printObjectNo, NoteData)
 {
     ScoreData score;

--- a/src/private/mxtest/file/MxFileRepositoy.cpp
+++ b/src/private/mxtest/file/MxFileRepositoy.cpp
@@ -478,5 +478,6 @@ void MxFileRepository::initializeNameSubdirectoryMap()
     myNameSubdirectoryMap.emplace("segno.3.1.xml", "synthetic");
     myNameSubdirectoryMap.emplace("coda.3.0.xml", "synthetic");
     myNameSubdirectoryMap.emplace("coda.3.1.xml", "synthetic");
+    myNameSubdirectoryMap.emplace("kind.3.0.xml", "synthetic");
 }
 } // namespace mxtest

--- a/src/private/mxtest/impl/DirectionWriterTest.cpp
+++ b/src/private/mxtest/impl/DirectionWriterTest.cpp
@@ -212,7 +212,7 @@ TEST(rehearsalRoundTrip, DirectionWriter)
     rehearsal.colorData.blue = 0;
     rehearsal.colorData.isAlphaSpecified = true;
     rehearsal.colorData.alpha = 255;
-    rehearsal.enclosure = api::RehearsalEnclosure::square;
+    rehearsal.enclosure = api::Enclosure::square;
 
     api::DirectionData directionData;
     directionData.directionTypes.emplace_back(api::DirectionChoice{rehearsal});


### PR DESCRIPTION
## Human Summary

Extends direction text formatting with `justify` and `systemRelation` added where available in the musicxml spec. Also unified the `Enclosure` enum which resulted in a breaking change, but it seems like the best approach moving forward. (See below for more details.)

## Summary

Four MusicXML attributes that mx::api could not express are now modeled, and the two duplicate enclosure enums are merged into one.

justify on words, symbol and rehearsal. All three elements carry both justify and halign, which MusicXML treats as different things: halign says which edge of the text the position refers to, justify says how the lines sit relative to each other when the text runs to more than one line. halign was already reaching the api through positionData.horizontalAlignment; justify was dropped. PageTextData and TempoData already had a justify field, so the new ones follow that precedent. Elements carrying justify without halign (lyric, part-name, group-name) are deliberately left alone -- the spec says justify doubles as alignment there, which is how the lyric reader already treats it.

systemRelation on DirectionData, mapping the system attribute of both direction and harmony. The api::SystemRelation enum already existed for measure numbering. The direction vocabulary is narrower (only-top, also-top, none), so the api-to-core conversion returns an optional and writes no attribute for the two measure-numbering-only values instead of coercing them into something wrong.

The enclosure vocabulary is now complete. RehearsalEnclosure was missing invertedBracket and pentagon through decagon, while PercussionEnclosure already had all fifteen. Since both described the same MusicXML enclosure-shape type with identical values, they are replaced by a single Enclosure in ApiCommon.h. That also collapses three parallel conversion paths -- two hand-written switches in DirectionReader and DirectionWriter plus the Converter table -- into the Converter table alone, which is where the drift came from in the first place.

**Breaking change**: `RehearsalEnclosure` and `PercussionEnclosure` are removed rather than aliased. The vocabularies are unchanged, so the downstream fix is a mechanical rename to `Enclosure`. Otherwise there is no structural API change; the additions are new fields on existing types with defaults that preserve current behavior.

## Testing

- [x] 11 new tests across DirectionMarksRoundTripTest, DirectionDataTest and HarmonyExtrasApiTest, covering each attribute set and left unspecified, the unwritable system values, and every shape in the enclosure vocabulary
- [x] make api-test: 5367 assertions in 474 test cases
- [x] make api-roundtrip: 295 passed, 0 failed of 295 pinned
- [x] make core-roundtrip-test: 837 test cases
- [x] Unity build (CMAKE_UNITY_BUILD_BATCH_SIZE=0), since two file-local functions were removed

No corpus fixture was pinned to roundtrip-baseline.txt: the files exercising these attributes (synthetic/direction.4.0.xml, synthetic/words.3.x.xml) still fail the api round trip on unrelated gaps, directive on direction and dir on words.
