### PR TITLE
fix: write arranger and publisher, add page-text enclosure

### DIFF
--- a/src/include/mx/api/ApiCommon.h
+++ b/src/include/mx/api/ApiCommon.h
@@ -87,10 +87,10 @@ enum class SystemRelation
 };
 
 // The shape drawn around a piece of text or a symbol -- MusicXML's enclosure attribute, carried by
-// RehearsalData, WordsData, SymbolData and PercussionData. unspecified means the attribute is
-// absent, which draws no enclosure; none states explicitly that there is none. A bracket is a
-// rectangle with the bottom line missing, as is common in jazz notation, and an invertedBracket is
-// one with the top line missing.
+// RehearsalData, WordsData, SymbolData, PercussionData and PageTextData. unspecified means the
+// attribute is absent, which draws no enclosure; none states explicitly that there is none. A
+// bracket is a rectangle with the bottom line missing, as is common in jazz notation, and an
+// invertedBracket is one with the top line missing.
 enum class Enclosure
 {
     unspecified,

--- a/src/include/mx/api/PageTextData.h
+++ b/src/include/mx/api/PageTextData.h
@@ -40,6 +40,10 @@ class PageTextData
     // carried in `positionData.horizontalAlignment`; MusicXML defines both
     // attributes on `<credit-words>`.
     HorizontalAlignment justify = HorizontalAlignment::unspecified;
+
+    // A shape drawn around the text. Enclosure::unspecified draws no enclosure; Enclosure::none
+    // states explicitly that there is none.
+    Enclosure enclosure = Enclosure::unspecified;
 };
 
 MXAPI_EQUALS_BEGIN(PageTextData)
@@ -54,6 +58,7 @@ if (!areVectorsEqual(lhs.creditTypes, rhs.creditTypes))
     return false;
 }
 MXAPI_EQUALS_MEMBER(justify)
+MXAPI_EQUALS_MEMBER(enclosure)
 MXAPI_EQUALS_END;
 MXAPI_NOT_EQUALS_AND_VECTORS(PageTextData);
 } // namespace api

--- a/src/private/mx/impl/PageTextFunctions.cpp
+++ b/src/private/mx/impl/PageTextFunctions.cpp
@@ -91,6 +91,12 @@ void createCredits(const api::ScoreData &inScoreData, core::ScoreHeaderGroup &ou
                 words.setJustify(converter.convert(p.justify));
             }
 
+            if (p.enclosure != api::Enclosure::unspecified)
+            {
+                const Converter converter;
+                words.setEnclosure(converter.convert(p.enclosure));
+            }
+
             core::CreditChoiceGroupChoice groupChoice = core::CreditChoiceGroupChoice::creditWords(words);
             core::CreditChoiceGroup group;
             group.setChoice(groupChoice);
@@ -163,6 +169,12 @@ void createCredits(const core::ScoreHeaderGroup &inHeader, api::ScoreData &outSc
             {
                 const Converter converter;
                 pageText.justify = converter.convert(*words.justify());
+            }
+
+            if (words.enclosure().has_value())
+            {
+                const Converter converter;
+                pageText.enclosure = converter.convert(*words.enclosure());
             }
         }
 

--- a/src/private/mx/impl/ScoreReader.cpp
+++ b/src/private/mx/impl/ScoreReader.cpp
@@ -171,12 +171,14 @@ api::ScoreData ScoreReader::getScoreData() const
         myOutScoreData.movementNumber = *myHeaderGroup.movementNumber();
     }
 
-    bool isComposerFound = false;
-    bool isCopyrightFound = false;
-
     if (myHeaderGroup.identification().has_value())
     {
         const auto &ident = *myHeaderGroup.identification();
+
+        bool isComposerFound = false;
+        bool isArrangerFound = false;
+        bool isPublisherFound = false;
+        bool isCopyrightFound = false;
 
         for (const auto &i : ident.creator())
         {
@@ -199,17 +201,18 @@ api::ScoreData ScoreReader::getScoreData() const
                 myOutScoreData.lyricist = i.value();
             }
 
-            // TODO: arranger/publisher overwrite lyricist (ScoreData has no fields for them),
-            // and ScoreWriter re-emits the value as type="lyricist" -- lossy and mislabeled.
-            // Issue: add arranger/publisher fields to ScoreData.
-            if (typeStr == "arranger")
+            // ScoreData has one slot each for arranger and publisher, but MusicXML permits any
+            // number of <creator> elements of a given type. Keep the first of each.
+            if (typeStr == "arranger" && !isArrangerFound)
             {
-                myOutScoreData.lyricist = i.value();
+                myOutScoreData.arranger = i.value();
+                isArrangerFound = true;
             }
 
-            if (typeStr == "publisher")
+            if (typeStr == "publisher" && !isPublisherFound)
             {
-                myOutScoreData.lyricist = i.value();
+                myOutScoreData.publisher = i.value();
+                isPublisherFound = true;
             }
         }
 

--- a/src/private/mx/impl/ScoreWriter.cpp
+++ b/src/private/mx/impl/ScoreWriter.cpp
@@ -117,6 +117,24 @@ core::ScorePartwise ScoreWriter::getScorePartwise() const
         hasIdentification = true;
     }
 
+    if (!myScoreData.arranger.empty())
+    {
+        core::TypedText arranger{};
+        arranger.setType(std::string{"arranger"});
+        arranger.setValue(myScoreData.arranger);
+        identification.addCreator(arranger);
+        hasIdentification = true;
+    }
+
+    if (!myScoreData.publisher.empty())
+    {
+        core::TypedText publisher{};
+        publisher.setType(std::string{"publisher"});
+        publisher.setValue(myScoreData.publisher);
+        identification.addCreator(publisher);
+        hasIdentification = true;
+    }
+
     if (!myScoreData.copyright.empty())
     {
         core::TypedText copyright{};

--- a/src/private/mx/impl/SpannerNumberResolver.cpp
+++ b/src/private/mx/impl/SpannerNumberResolver.cpp
@@ -85,7 +85,7 @@ class SpannerNumberEventCollector
     // Mirrors DirectionWriter::emitDirectionTypes: one pass over the ordered direction-type
     // content, registering each spanner event with the address of its DirectionChoice -- the
     // same identity the writer presents when it asks for the emitted number. Pedals are
-    // skipped: <pedal> has no number attribute.
+    // skipped: mx::api does not model <pedal>'s number attribute.
     void addDirection(const api::DirectionData &inDirection)
     {
         for (const auto &choice : inDirection.directionTypes)

--- a/src/private/mx/impl/SpannerNumberResolver.h
+++ b/src/private/mx/impl/SpannerNumberResolver.h
@@ -40,8 +40,9 @@ namespace impl
 //
 // Identity ids are scoped per part and per spanner class: events in the same
 // part sharing a class and id are one logical spanner, even across staves.
-// Pedal starts/stops carry SpannerNumber but the <pedal> element has no
-// number attribute, so pedals are ignored here.
+// Pedal starts/stops carry SpannerNumber, but mx::api does not model the
+// <pedal> number attribute (added in MusicXML 3.1), so pedals are ignored
+// here and no number is ever emitted for one.
 //
 // If more than 16 spanners of one class are open at once in a part (which no
 // real score approaches), resolution fails loudly with an exception rather

--- a/src/private/mxtest/api/CreditRoundTripTest.cpp
+++ b/src/private/mxtest/api/CreditRoundTripTest.cpp
@@ -149,4 +149,59 @@ TEST(creditRoundTrip, justifyAbsentStaysAbsent)
     CHECK(HorizontalAlignment::unspecified == out.pageTextItems.at(0).justify);
 }
 
+TEST(creditRoundTrip, enclosureSurvives)
+{
+    auto in = makeMinimalScore();
+    PageTextData credit{};
+    credit.text = "Framed title";
+    credit.pageNumber = 1;
+    credit.enclosure = Enclosure::rectangle;
+    in.pageTextItems.push_back(credit);
+
+    const auto xml = mxtest::toXml(in);
+    CHECK(xml.find("enclosure=\"rectangle\"") != std::string::npos);
+
+    const auto out = mxtest::roundTrip(in);
+
+    REQUIRE(out.pageTextItems.size() == 1);
+    const auto &got = out.pageTextItems.at(0);
+    CHECK_EQUAL("Framed title", got.text);
+    CHECK(Enclosure::rectangle == got.enclosure);
+}
+
+TEST(creditRoundTrip, enclosureNoneIsExplicit)
+{
+    auto in = makeMinimalScore();
+    PageTextData credit{};
+    credit.text = "Deliberately unframed";
+    credit.pageNumber = 1;
+    credit.enclosure = Enclosure::none;
+    in.pageTextItems.push_back(credit);
+
+    const auto xml = mxtest::toXml(in);
+    CHECK(xml.find("enclosure=\"none\"") != std::string::npos);
+
+    const auto out = mxtest::roundTrip(in);
+
+    REQUIRE(out.pageTextItems.size() == 1);
+    CHECK(Enclosure::none == out.pageTextItems.at(0).enclosure);
+}
+
+TEST(creditRoundTrip, enclosureAbsentStaysAbsent)
+{
+    auto in = makeMinimalScore();
+    PageTextData credit{};
+    credit.text = "no enclosure here";
+    credit.pageNumber = 1;
+    in.pageTextItems.push_back(credit);
+
+    const auto xml = mxtest::toXml(in);
+    CHECK(xml.find("enclosure=") == std::string::npos);
+
+    const auto out = mxtest::roundTrip(in);
+
+    REQUIRE(out.pageTextItems.size() == 1);
+    CHECK(Enclosure::unspecified == out.pageTextItems.at(0).enclosure);
+}
+
 #endif

--- a/src/private/mxtest/api/DocumentManagerTest.cpp
+++ b/src/private/mxtest/api/DocumentManagerTest.cpp
@@ -261,12 +261,74 @@ ROUND_TRIP_TEST_SCALAR(std::string, movementTitle, movementTitle, "value", 0);
 ROUND_TRIP_TEST_SCALAR(std::string, movementNumber, movementNumber, "value", 0);
 ROUND_TRIP_TEST_SCALAR(std::string, composer, composer, "value", 0);
 ROUND_TRIP_TEST_SCALAR(std::string, lyricist, lyricist, "value", 0);
+ROUND_TRIP_TEST_SCALAR(std::string, arranger, arranger, "value", 0);
+ROUND_TRIP_TEST_SCALAR(std::string, publisher, publisher, "value", 0);
 ROUND_TRIP_TEST_SCALAR(std::string, copyright, copyright, "value", 0);
 ROUND_TRIP_TEST_SCALAR(std::string, encoding.encoder, encoder, "value", 0);
 ROUND_TRIP_TEST_SCALAR(std::string, encoding.encodingDescription, encodingDescription, "value", 0);
 ROUND_TRIP_TEST_SCALAR(int, encoding.encodingDate.year, year, 2016, 0);
 ROUND_TRIP_TEST_SCALAR(int, encoding.encodingDate.month, month, 9, 0);
 ROUND_TRIP_TEST_SCALAR(int, encoding.encodingDate.day, day, 12, 0);
+
+// The four <creator> types mx::api models are independent slots. The arranger used to be read
+// into ScoreData::lyricist and rewritten as type="lyricist", so a file carrying both lost the
+// lyricist; the publisher was dropped on the way out entirely.
+
+TEST(RoundTrip_AllCreatorTypes, DocumentManager)
+{
+    auto input = ScoreData{};
+    input.composer = "MetaComposer";
+    input.lyricist = "MetaLyricist";
+    input.arranger = "MetaArranger";
+    input.publisher = "MetaPublisher";
+
+    auto &docMngr = DocumentManager::getInstance();
+    const auto createResult = docMngr.createFromScore(input);
+    REQUIRE(createResult.ok());
+    const int writeId = createResult.value();
+    std::ostringstream oss;
+    const auto writeResult = docMngr.writeToStream(writeId, oss);
+    REQUIRE(writeResult.ok());
+    docMngr.destroyDocument(writeId);
+
+    const auto xml = oss.str();
+    CHECK(xml.find("<creator type=\"composer\">MetaComposer</creator>") != std::string::npos);
+    CHECK(xml.find("<creator type=\"lyricist\">MetaLyricist</creator>") != std::string::npos);
+    CHECK(xml.find("<creator type=\"arranger\">MetaArranger</creator>") != std::string::npos);
+    CHECK(xml.find("<creator type=\"publisher\">MetaPublisher</creator>") != std::string::npos);
+
+    const auto output = roundTripScore(input);
+    CHECK_EQUAL("MetaComposer", output.composer);
+    CHECK_EQUAL("MetaLyricist", output.lyricist);
+    CHECK_EQUAL("MetaArranger", output.arranger);
+    CHECK_EQUAL("MetaPublisher", output.publisher);
+}
+
+T_END
+
+// Reading the same shape from a real file: musuite/testMetaData.xml carries an arranger, a
+// composer and a lyricist, plus creator types mx::api does not model, which must not disturb
+// the ones it does.
+
+TEST(ReadAllCreatorTypes, DocumentManager)
+{
+    auto &docMngr = DocumentManager::getInstance();
+    const auto createResult = docMngr.createFromFile(std::string{mxtest::getResourcesDirectoryPath()} +
+                                                     std::string{"/musuite/testMetaData.xml"});
+    REQUIRE(createResult.ok());
+    const int documentId = createResult.value();
+    const auto dataResult = docMngr.getData(documentId);
+    REQUIRE(dataResult.ok());
+    const auto score = dataResult.value();
+    docMngr.destroyDocument(documentId);
+
+    CHECK_EQUAL("MetaComposer", score.composer);
+    CHECK_EQUAL("MetaLyricist", score.lyricist);
+    CHECK_EQUAL("MetaArranger", score.arranger);
+    CHECK_EQUAL("", score.publisher);
+}
+
+T_END
 
 // --- Page margin coalescing -------------------------------------------------
 // Equal odd/even margins collapse to a single <page-margins type="both">;


### PR DESCRIPTION
## Human Summary

This is a omnibus PR that cleans up some minor issues.
- clean up stale comments
- add enclosure to `PageTextData`
- correctly read/write lyricist, arranger, and publisher credits

## Summary

Three small gaps in `mx::api`, collected into one fix-up PR. Each is confined to `mx::impl` plus a single new field; none needs a new API model.

**Arranger and publisher were accepted but never written.** `ScoreData::arranger` and `ScoreData::publisher` have existed, with equality members, but nothing in `mx::impl` ever touched them -- a scan of every `MXAPI_EQUALS_MEMBER` name against `src/private/mx/impl/` showed these two as the only dead public fields. Worse than dead: `ScoreReader` read an incoming `<creator type="arranger">` into `ScoreData::lyricist`, so a file carrying both an arranger and a lyricist lost the lyricist, and `ScoreWriter` then re-emitted the arranger's text mislabelled as `type="lyricist"`. Both now read into their own field and are written beside composer and lyricist. Where a file has several creators of one type (`recsuite/Echigo_Jishi.xml` has two arrangers) the first wins, since the api has one slot.

Before, on `musuite/testMetaData.xml`: `lyricist == "MetaArranger"`, `arranger == ""`, and the round trip emitted `<creator type="lyricist">MetaArranger</creator>`. After: composer, lyricist and arranger each land in their own field and are rewritten with the right type.

**Page text carried no enclosure.** `<credit-words>` is type `formatted-text-id`, the same core class as `<words>` and `<rehearsal>`, so it carries the whole `text-formatting` attribute group. `core::FormattedTextID` already exposes `enclosure()`/`setEnclosure()`, and `Converter` already has both directions from #378, so only the api field was missing. `PageTextData` gains `Enclosure enclosure`, converted in both directions in `PageTextFunctions.cpp` beside the existing `justify` handling -- the same shape #273 used for justify.

**A stale comment about `<pedal>`.** `SpannerNumberResolver` asserted in two places that `<pedal>` has no `number` attribute. True through MusicXML 3.0; 3.1 added it and `core::Pedal` supports it. Pedals still stay out of number resolution, because `mx::api` does not model the attribute -- behaviour unchanged, only the stated reason corrected.

## Testing

- [x] Two new `DocumentManager` tests: all four creator types survive a round trip independently and serialize with the right `type`, and a read of `musuite/testMetaData.xml` keeps composer, lyricist and arranger apart. The second fails before the fix (`lyricist` comes back as `MetaArranger`).
- [x] Two new `ROUND_TRIP_TEST_SCALAR` entries for `arranger` and `publisher`
- [x] Three new `creditRoundTrip` tests: `enclosure="rectangle"` survives, an explicit `none` survives, and an unset enclosure writes no attribute and reads back `unspecified`
- [x] Full api suite passes (5922 assertions in 528 test cases)
- [x] `make api-roundtrip` passes (363 of 363 pinned)
- [x] `make api-roundtrip-discover` still shows 363 PASS -- no file changed status, so the baseline is untouched
- [x] `make core-roundtrip-test` passes (839 test cases)
- [x] `make core-unit` passes (212 assertions in 41 test cases)
- [x] `make fmt-check` clean on touched files

No corpus files added or removed, so no pinned-count bump and no audit regeneration.

## References

- Related to #273 (credit-words `justify`) and #187 (credit gaps) -- same family, and the enclosure work follows the pattern both established
- Builds on #378, which unified the `Enclosure` enum

