### PR TITLE
fix: correct miscelaneousFields typo in EncodingData

### DIFF
--- a/src/include/mx/api/DirectionData.h
+++ b/src/include/mx/api/DirectionData.h
@@ -52,7 +52,7 @@ struct DirectionData
     int voice;
 
     // Direction elements are placed inside the StaffData object in mx api.  This would mean that
-    // they are alyways assigned to a staff, however MusicXML makes the staff element optional.
+    // they are always assigned to a staff, however MusicXML makes the staff element optional.
     // in the case that we want a direction element to have no <staff> element then me must place
     // the direction on staffIndex = 0 and set isStaffValueSpecified. otherwise the we will
     // assume that the <staff> element is present with a value of staffIndex + 1. This bool is

--- a/src/include/mx/api/EncodingData.h
+++ b/src/include/mx/api/EncodingData.h
@@ -59,7 +59,7 @@ class EncodingData
     std::string encodingDescription;
     std::vector<std::string> software;
     std::vector<SupportedItem> supportedItems;
-    std::vector<MiscellaneousField> miscelaneousFields;
+    std::vector<MiscellaneousField> miscellaneousFields;
 
     // mx stamps its own provenance <software> node (the mx URL plus the build's git
     // SHA) into <encoding> on every api write. The intent is to aid in diagnosing and
@@ -102,7 +102,7 @@ MXAPI_EQUALS_MEMBER(encoder)
 MXAPI_EQUALS_MEMBER(encodingDescription)
 MXAPI_EQUALS_MEMBER(software)
 MXAPI_EQUALS_MEMBER(supportedItems)
-MXAPI_EQUALS_MEMBER(miscelaneousFields)
+MXAPI_EQUALS_MEMBER(miscellaneousFields)
 MXAPI_EQUALS_MEMBER(writeMxVersion)
 MXAPI_EQUALS_END;
 MXAPI_NOT_EQUALS_AND_VECTORS(EncodingData);

--- a/src/include/mx/api/MarkData.h
+++ b/src/include/mx/api/MarkData.h
@@ -174,7 +174,7 @@ enum class MarkType
     // instead it has an attribute 'type' that is either 'upright' or 'inverted'.
     // it appears that implementations interpret 'upright' to mean the 'normal' or
     // correct orientation and 'inverted' to mean that the fermata should be 'flipped'
-    // from its correct orientation.  in otherwords the implementation has to figure
+    // from its correct orientation.  in other words the implementation has to figure
     // out if the fermata is above or below the note on its own (using its own
     // algorithm combined with any default-y and relative-y values).  this mess is
     // going to be beyond the scope of the MusicXML Class Library at this time.  You

--- a/src/include/mx/api/PartData.h
+++ b/src/include/mx/api/PartData.h
@@ -206,7 +206,7 @@ class PartData
     /// The initial transposition for the part. If the music entered into the part is not in
     /// concert pitch, then this field is used to specify the transposition that is in-
     /// effect. Note, MusicXML encodes transposition in the measure data, not in the part
-    /// data. Here we offer a convient way to set the transposition in the first measure of
+    /// data. Here we offer a convenient way to set the transposition in the first measure of
     /// the part. Subsequent transposition changes are not currently supported by mx::api.
     std::optional<TransposeData> transposition;
 

--- a/src/include/mx/api/TransposeData.h
+++ b/src/include/mx/api/TransposeData.h
@@ -35,7 +35,7 @@ namespace api
 /// |---------------------|--------------------|----------|---------|
 /// | Glockenspiel        | Up two Octaves     | 24       | 14      |
 /// | Piccolo             | Up an Octave       | 12       | 7       |
-/// | Clarient in Bb      | Down a Major Second| -2       | -1      |
+/// | Clarinet in Bb      | Down a Major Second| -2       | -1      |
 /// | French Horn in F    | Down a Fifth       | -7       | -4      |
 /// | Alto Saxophone in Eb| Down a Major Sixth | -9       | -5      |
 /// | Bass Clarinet in Bb | Down a Major Ninth | -14      | -8      |

--- a/src/private/mx/impl/EncodingFunctions.cpp
+++ b/src/private/mx/impl/EncodingFunctions.cpp
@@ -91,7 +91,7 @@ void createEncoding(const api::EncodingData &inEncoding, core::ScoreHeaderGroup 
 
     bool hasMiscellaneous = identification.miscellaneous().has_value();
     core::Miscellaneous miscellaneous = identification.miscellaneous().value_or(core::Miscellaneous{});
-    for (const auto &m : inEncoding.miscelaneousFields)
+    for (const auto &m : inEncoding.miscellaneousFields)
     {
         hasIdentification = true;
         hasEncoding = true;

--- a/src/private/mx/impl/MeasureReader.cpp
+++ b/src/private/mx/impl/MeasureReader.cpp
@@ -1172,7 +1172,7 @@ void MeasureReader::consolidateVoicesForAllStaves() const
 {
     for (auto &staff : myOutMeasureData.staves)
     {
-        if (isUserRequestedVoiceNumberConsistentAccrossAllVoices(staff))
+        if (isUserRequestedVoiceNumberConsistentAcrossAllVoices(staff))
         {
             takeUserRequestedVoiceNumbers(staff);
         }
@@ -1231,7 +1231,7 @@ bool MeasureReader::isUserRequestedVoiceNumberConsistent(const api::VoiceData &v
     return true;
 }
 
-bool MeasureReader::isUserRequestedVoiceNumberConsistentAccrossAllVoices(const api::StaffData &staff) const
+bool MeasureReader::isUserRequestedVoiceNumberConsistentAcrossAllVoices(const api::StaffData &staff) const
 {
     std::set<int> userRequestedVoiceNumbers;
     for (const auto &voicePair : staff.voices)

--- a/src/private/mx/impl/MeasureReader.h
+++ b/src/private/mx/impl/MeasureReader.h
@@ -119,7 +119,7 @@ class MeasureReader
     void takeUserRequestedVoiceNumbers(api::StaffData &staff) const;
     void collapseVoicesAutomatically(api::StaffData &staff) const;
     bool isUserRequestedVoiceNumberConsistent(const api::VoiceData &voiceData) const;
-    bool isUserRequestedVoiceNumberConsistentAccrossAllVoices(const api::StaffData &staff) const;
+    bool isUserRequestedVoiceNumberConsistentAcrossAllVoices(const api::StaffData &staff) const;
     int getUserRequestedVoiceNumber(const api::VoiceData &voiceData) const;
     void advanceTickTimePosition(int amount, std::string reason) const;
 };

--- a/src/private/mx/impl/ScoreReader.cpp
+++ b/src/private/mx/impl/ScoreReader.cpp
@@ -247,7 +247,7 @@ api::ScoreData ScoreReader::getScoreData() const
             {
                 std::string key;
                 key = m.name();
-                encodingData.miscelaneousFields.emplace_back(m.name(), m.value());
+                encodingData.miscellaneousFields.emplace_back(m.name(), m.value());
             }
         }
 

--- a/src/private/mx/impl/TechnicalFunctions.cpp
+++ b/src/private/mx/impl/TechnicalFunctions.cpp
@@ -142,14 +142,14 @@ api::HarmonicMarkData harmonicMarkDataFromCore(const core::Harmonic &inHarmonic)
     return outData;
 }
 
-TechnicalFunctions::TechnicalFunctions(std::span<const core::TechnicalChoice> inTechincalChoiceSet, Cursor inCursor)
-    : myTechincalChoiceSet{inTechincalChoiceSet}, myCursor{inCursor}
+TechnicalFunctions::TechnicalFunctions(std::span<const core::TechnicalChoice> inTechnicalChoiceSet, Cursor inCursor)
+    : myTechnicalChoiceSet{inTechnicalChoiceSet}, myCursor{inCursor}
 {
 }
 
 void TechnicalFunctions::parseTechnicalMarks(std::vector<api::MarkData> &outMarks) const
 {
-    for (const auto &techChoice : myTechincalChoiceSet)
+    for (const auto &techChoice : myTechnicalChoiceSet)
     {
         const auto choiceKind = techChoice.kind();
         Converter converter;
@@ -162,7 +162,7 @@ void TechnicalFunctions::parseTechnicalMarks(std::vector<api::MarkData> &outMark
         api::MarkData markData;
         markData.markType = markType;
         markData.tickTimePosition = myCursor.tickTimePosition;
-        bool isSuccess = parseTechicalMark(techChoice, markData);
+        bool isSuccess = parseTechnicalMark(techChoice, markData);
 
         if (isSuccess)
         {
@@ -171,23 +171,23 @@ void TechnicalFunctions::parseTechnicalMarks(std::vector<api::MarkData> &outMark
     }
 }
 
-bool TechnicalFunctions::parseTechicalMark(const core::TechnicalChoice &techicalChoice,
-                                           api::MarkData &outMarkData) const
+bool TechnicalFunctions::parseTechnicalMark(const core::TechnicalChoice &technicalChoice,
+                                            api::MarkData &outMarkData) const
 {
-    switch (techicalChoice.kind())
+    switch (technicalChoice.kind())
     {
     case core::TechnicalChoice::Kind::upBow: {
-        parseMarkDataAttributes(techicalChoice.asUpBow(), outMarkData);
+        parseMarkDataAttributes(technicalChoice.asUpBow(), outMarkData);
         outMarkData.name = "up-bow";
         return true;
     }
     case core::TechnicalChoice::Kind::downBow: {
-        parseMarkDataAttributes(techicalChoice.asDownBow(), outMarkData);
+        parseMarkDataAttributes(technicalChoice.asDownBow(), outMarkData);
         outMarkData.name = "down-bow";
         return true;
     }
     case core::TechnicalChoice::Kind::harmonic: {
-        const auto &harmonic = techicalChoice.asHarmonic();
+        const auto &harmonic = technicalChoice.asHarmonic();
         parseMarkDataAttributes(harmonic, outMarkData);
         outMarkData.name = "harmonic";
         const auto harmonicData = harmonicMarkDataFromCore(harmonic);
@@ -199,17 +199,17 @@ bool TechnicalFunctions::parseTechicalMark(const core::TechnicalChoice &techical
         return true;
     }
     case core::TechnicalChoice::Kind::openString: {
-        parseMarkDataAttributes(techicalChoice.asOpenString(), outMarkData);
+        parseMarkDataAttributes(technicalChoice.asOpenString(), outMarkData);
         outMarkData.name = "open-string";
         return true;
     }
     case core::TechnicalChoice::Kind::thumbPosition: {
-        parseMarkDataAttributes(techicalChoice.asThumbPosition(), outMarkData);
+        parseMarkDataAttributes(technicalChoice.asThumbPosition(), outMarkData);
         outMarkData.name = "thumb-position";
         return true;
     }
     case core::TechnicalChoice::Kind::fingering: {
-        const auto &fingering = techicalChoice.asFingering();
+        const auto &fingering = technicalChoice.asFingering();
         parseMarkDataAttributes(fingering, outMarkData);
         outMarkData.name = fingering.value();
         Converter converter;
@@ -224,39 +224,39 @@ bool TechnicalFunctions::parseTechicalMark(const core::TechnicalChoice &techical
         return true;
     }
     case core::TechnicalChoice::Kind::pluck: {
-        const auto &pluck = techicalChoice.asPluck();
+        const auto &pluck = technicalChoice.asPluck();
         parseMarkDataAttributes(pluck, outMarkData);
         outMarkData.name = pluck.value();
         return true;
     }
     case core::TechnicalChoice::Kind::doubleTongue: {
-        parseMarkDataAttributes(techicalChoice.asDoubleTongue(), outMarkData);
+        parseMarkDataAttributes(technicalChoice.asDoubleTongue(), outMarkData);
         outMarkData.name = "double-tongue";
         return true;
     }
     case core::TechnicalChoice::Kind::tripleTongue: {
-        parseMarkDataAttributes(techicalChoice.asTripleTongue(), outMarkData);
+        parseMarkDataAttributes(technicalChoice.asTripleTongue(), outMarkData);
         outMarkData.name = "triple-tongue";
         return true;
     }
     case core::TechnicalChoice::Kind::stopped: {
-        parseMarkDataAttributes(techicalChoice.asStopped(), outMarkData);
+        parseMarkDataAttributes(technicalChoice.asStopped(), outMarkData);
         outMarkData.name = "stopped";
         return true;
     }
     case core::TechnicalChoice::Kind::snapPizzicato: {
-        parseMarkDataAttributes(techicalChoice.asSnapPizzicato(), outMarkData);
+        parseMarkDataAttributes(technicalChoice.asSnapPizzicato(), outMarkData);
         outMarkData.name = "snap-pizzicato";
         return true;
     }
     case core::TechnicalChoice::Kind::fret: {
-        const auto &fret = techicalChoice.asFret();
+        const auto &fret = technicalChoice.asFret();
         parseMarkDataAttributes(fret, outMarkData);
         outMarkData.name = std::to_string(fret.value());
         return true;
     }
     case core::TechnicalChoice::Kind::string: {
-        const auto &s = techicalChoice.asString();
+        const auto &s = technicalChoice.asString();
         parseMarkDataAttributes(s, outMarkData);
         outMarkData.name = std::to_string(s.value().value());
         return true;
@@ -270,75 +270,75 @@ bool TechnicalFunctions::parseTechicalMark(const core::TechnicalChoice &techical
     case core::TechnicalChoice::Kind::tap:
         return false;
     case core::TechnicalChoice::Kind::heel: {
-        parseMarkDataAttributes(techicalChoice.asHeel(), outMarkData);
+        parseMarkDataAttributes(technicalChoice.asHeel(), outMarkData);
         outMarkData.name = "heel";
         return true;
     }
     case core::TechnicalChoice::Kind::toe: {
-        parseMarkDataAttributes(techicalChoice.asToe(), outMarkData);
+        parseMarkDataAttributes(technicalChoice.asToe(), outMarkData);
         outMarkData.name = "toe";
         return true;
     }
     case core::TechnicalChoice::Kind::fingernails: {
-        parseMarkDataAttributes(techicalChoice.asFingernails(), outMarkData);
+        parseMarkDataAttributes(technicalChoice.asFingernails(), outMarkData);
         outMarkData.name = "fingernails";
         return true;
     }
     case core::TechnicalChoice::Kind::hole: {
-        const auto &hole = techicalChoice.asHole();
+        const auto &hole = technicalChoice.asHole();
         parseMarkDataAttributes(hole, outMarkData);
         outMarkData.name = technicalFunctionsHoleToSmuflName(hole);
         return true;
     }
     case core::TechnicalChoice::Kind::arrow: {
-        const auto &arrow = techicalChoice.asArrow();
+        const auto &arrow = technicalChoice.asArrow();
         parseMarkDataAttributes(arrow, outMarkData);
         outMarkData.name = technicalFunctionsArrowToSmuflName(arrow);
         return true;
     }
     case core::TechnicalChoice::Kind::handbell: {
-        const auto &handbell = techicalChoice.asHandbell();
+        const auto &handbell = technicalChoice.asHandbell();
         parseMarkDataAttributes(handbell, outMarkData);
         outMarkData.name = technicalFunctionsHandbellToSmuflName(handbell.value());
         return true;
     }
     case core::TechnicalChoice::Kind::brassBend: {
-        parseMarkDataAttributes(techicalChoice.asBrassBend(), outMarkData);
+        parseMarkDataAttributes(technicalChoice.asBrassBend(), outMarkData);
         outMarkData.name = "brass-bend";
         return true;
     }
     case core::TechnicalChoice::Kind::flip: {
-        parseMarkDataAttributes(techicalChoice.asFlip(), outMarkData);
+        parseMarkDataAttributes(technicalChoice.asFlip(), outMarkData);
         outMarkData.name = "flip";
         return true;
     }
     case core::TechnicalChoice::Kind::smear: {
-        parseMarkDataAttributes(techicalChoice.asSmear(), outMarkData);
+        parseMarkDataAttributes(technicalChoice.asSmear(), outMarkData);
         outMarkData.name = "smear";
         return true;
     }
     case core::TechnicalChoice::Kind::open: {
-        parseMarkDataAttributes(techicalChoice.asOpen(), outMarkData);
+        parseMarkDataAttributes(technicalChoice.asOpen(), outMarkData);
         outMarkData.name = "open";
         return true;
     }
     case core::TechnicalChoice::Kind::halfMuted: {
-        parseMarkDataAttributes(techicalChoice.asHalfMuted(), outMarkData);
+        parseMarkDataAttributes(technicalChoice.asHalfMuted(), outMarkData);
         outMarkData.name = "half-muted";
         return true;
     }
     case core::TechnicalChoice::Kind::harmonMute: {
-        parseMarkDataAttributes(techicalChoice.asHarmonMute(), outMarkData);
+        parseMarkDataAttributes(technicalChoice.asHarmonMute(), outMarkData);
         outMarkData.name = "harmon-mute";
         return true;
     }
     case core::TechnicalChoice::Kind::golpe: {
-        parseMarkDataAttributes(techicalChoice.asGolpe(), outMarkData);
+        parseMarkDataAttributes(technicalChoice.asGolpe(), outMarkData);
         outMarkData.name = "golpe";
         return true;
     }
     case core::TechnicalChoice::Kind::otherTechnical: {
-        const auto &oa = techicalChoice.asOtherTechnical();
+        const auto &oa = technicalChoice.asOtherTechnical();
         parseMarkDataAttributes(oa, outMarkData);
         outMarkData.name = oa.value();
         api::OtherMarkData payload;

--- a/src/private/mx/impl/TechnicalFunctions.h
+++ b/src/private/mx/impl/TechnicalFunctions.h
@@ -28,16 +28,16 @@ class TechnicalFunctions
 {
 
   public:
-    TechnicalFunctions(std::span<const core::TechnicalChoice> inTechincalChoiceSet, Cursor inCursor);
+    TechnicalFunctions(std::span<const core::TechnicalChoice> inTechnicalChoiceSet, Cursor inCursor);
 
     void parseTechnicalMarks(std::vector<api::MarkData> &outMarks) const;
 
   private:
-    std::span<const core::TechnicalChoice> myTechincalChoiceSet;
+    std::span<const core::TechnicalChoice> myTechnicalChoiceSet;
     const Cursor myCursor;
 
   private:
-    bool parseTechicalMark(const core::TechnicalChoice &techicalChoice, api::MarkData &outMarkData) const;
+    bool parseTechnicalMark(const core::TechnicalChoice &technicalChoice, api::MarkData &outMarkData) const;
 };
 } // namespace impl
 } // namespace mx

--- a/src/private/mxtest/api/ApiK016aMiscScoreData.h
+++ b/src/private/mxtest/api/ApiK016aMiscScoreData.h
@@ -14,9 +14,9 @@ inline mx::api::ScoreData apiK016aMiscScoreData()
     using namespace mx::api;
     ScoreData scoreData;
     scoreData.encoding.software.emplace_back("komp");
-    scoreData.encoding.miscelaneousFields.emplace_back("komp-version-major", "1");
-    scoreData.encoding.miscelaneousFields.emplace_back("komp-version-minor", "2");
-    scoreData.encoding.miscelaneousFields.emplace_back("komp-version-patch", "3");
+    scoreData.encoding.miscellaneousFields.emplace_back("komp-version-major", "1");
+    scoreData.encoding.miscellaneousFields.emplace_back("komp-version-minor", "2");
+    scoreData.encoding.miscellaneousFields.emplace_back("komp-version-patch", "3");
     scoreData.parts.emplace_back(PartData{});
     auto &part = scoreData.parts.back();
     part.name = "hello world";

--- a/src/private/mxtest/api/ApiLy43eScoreData.h
+++ b/src/private/mxtest/api/ApiLy43eScoreData.h
@@ -14,7 +14,7 @@ inline mx::api::ScoreData apiLy43eScoreData()
     ScoreData score;
     score.parts.emplace_back(PartData{});
     score.ticksPerQuarter = 8;
-    score.encoding.miscelaneousFields.emplace_back(
+    score.encoding.miscellaneousFields.emplace_back(
         "description", "A piano staff with dynamics and \n          clef changes, where each element (ffff, wedge and "
                        "clef changes) \n          applies only to one voice or one staff, respectively.");
 


### PR DESCRIPTION
## Human Summary

- Correct misspelling of field `miscellaneousFields`.
- Correct other typos found throughout repo.

## Summary

Two commits. The first is the field rename; the second sweeps up the other misspellings a dictionary pass over the identifiers turned up.

### `EncodingData::miscelaneousFields` -> `miscellaneousFields`

Missing an `l`. The class the vector holds, `MiscellaneousField`, was already spelled correctly, as are `core::Miscellaneous`, `core::MiscellaneousField`, and the `<miscellaneous-field>` element itself, so this member was the lone outlier. Eight occurrences in five files: the declaration and its `MXAPI_EQUALS_MEMBER` line, the reader and writer, and two test score-data builders.

Breaking: the member is public `mx::api`, so callers using the old spelling must rename. No compatibility alias is left behind, matching how the `ScoreData` `layout` -> `defaults` rename was handled in v0.5.0.

### Other misspellings

Checking whether any sibling had the same problem meant spell-checking every identifier in the tree. It was the only misspelled public field name, but four other things turned up. None is breaking -- they are private `mx::impl` names and comment text.

`TechnicalFunctions` had the same word misspelled two different ways, while the class itself was spelled correctly: `parseTechicalMark` and its `techicalChoice` parameter dropped the `n`, and the constructor parameter `inTechincalChoiceSet` and member `myTechincalChoiceSet` transposed it. `MeasureReader::isUserRequestedVoiceNumberConsistentAccrossAllVoices` had a doubled `c`.

Comment fixes in public headers: `alyways`, `convient`, `otherwords`, and `Clarient` in the `TransposeData` doc table, which is rendered documentation. The table is column-aligned and `Clarinet` is the same width, so the alignment holds.

`SoundID.h` is deliberately untouched. `brass.sackbutt` and `strings.violono.piccolo` look wrong but mirror the MusicXML standard sound-id strings and have to match the wire format.

The rename in `TechnicalFunctions.cpp` lengthened a signature by one character, so `make fmt` reindented that function's continuation lines. That is the only non-rename change in the second commit.

## Testing

- [x] Full api suite passes (5961 assertions in 535 test cases)
- [x] `make api-roundtrip` passes (364 of 364 pinned)
- [x] `make core-roundtrip-test` passes (839 test cases)
- [x] `make fmt-check` clean on touched files
- [x] `grep` for every corrected spelling returns nothing outside `core/generated`

Renames only -- no behaviour change, so no new tests. The existing `ApiK016aMisc` and `ApiLy43e` suites already exercise the renamed `EncodingData` member on both the read and write paths, and the technical-mark and voice-number paths are covered by the api suite.
