### PR TITLE
feat: add emscripten build to ci

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -96,6 +96,42 @@ jobs:
       - name: All C++ suites (core roundtrip + unit, api mxtest + examples + roundtrip)
         run: make test-all
 
+  # mx::api cross-compiled to WebAssembly via the pinned mx-sdk emsdk install
+  # (issue #386): a consumer (denigma, github.com/rpatters1/denigma) compiles mx
+  # client-side for browser use, and this is the one place that path is proven
+  # rather than discovered as a regression downstream. Builds through the
+  # mx-sdk toolchain like test-linux/quality/gen; runs mxread/mxwrite/mxhide
+  # under Node so the check exercises mx::api, not just a compile.
+  test-wasm:
+    name: "wasm: mx::api under Emscripten"
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v5
+
+      - uses: docker/setup-buildx-action@v3
+      - uses: crazy-max/ghaction-github-runtime@v3
+
+      - name: Create bind-backed build volume
+        run: |
+          mkdir -p build/docker
+          docker volume create --driver local \
+            --opt type=none --opt o=bind \
+            --opt device="$GITHUB_WORKSPACE/build/docker" mx-build
+
+      # Emscripten's compiled system-library cache (libc/libc++/compiler-rt),
+      # not source ccache -- see EM_CACHE in the Dockerfile. Populating it from
+      # scratch is the slow part of a wasm build.
+      - name: Cache EM_CACHE
+        uses: actions/cache@v4
+        with:
+          path: build/docker/.emcache
+          key: emcache-${{ runner.os }}-wasm-${{ github.sha }}
+          restore-keys: emcache-${{ runner.os }}-wasm-
+
+      - name: mx::api under Node (wasm)
+        run: make wasm-test
+
   # The api product surface, built natively with AppleClang. macOS is a
   # portability check on the product tier only (the core suites run on Linux in
   # test-linux); this is the only C++ job off the pinned toolchain, by design,

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -97,11 +97,7 @@ jobs:
         run: make test-all
 
   # mx::api cross-compiled to WebAssembly via the pinned mx-sdk emsdk install
-  # (issue #386): a consumer (denigma, github.com/rpatters1/denigma) compiles mx
-  # client-side for browser use, and this is the one place that path is proven
-  # rather than discovered as a regression downstream. Builds through the
-  # mx-sdk toolchain like test-linux/quality/gen; runs mxread/mxwrite/mxhide
-  # under Node so the check exercises mx::api, not just a compile.
+  # (#386) -- denigma (rpatters1/denigma) depends on this path staying green.
   emscripten:
     name: emscripten
     runs-on: ubuntu-latest
@@ -119,10 +115,8 @@ jobs:
             --opt type=none --opt o=bind \
             --opt device="$GITHUB_WORKSPACE/build/docker" mx-build
 
-      # Two caches: ccache for mx's own object files (emcc via the ambient
-      # CMAKE_*_COMPILER_LAUNCHER), EM_CACHE for Emscripten's compiled
-      # system libraries (libc/libc++/compiler-rt). Without both, this job
-      # recompiles everything from scratch on every run.
+      # ccache for mx's own object files; EM_CACHE (below) is Emscripten's
+      # separate cache for its compiled system libraries.
       - name: Cache ccache
         uses: actions/cache@v4
         with:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -102,8 +102,8 @@ jobs:
   # rather than discovered as a regression downstream. Builds through the
   # mx-sdk toolchain like test-linux/quality/gen; runs mxread/mxwrite/mxhide
   # under Node so the check exercises mx::api, not just a compile.
-  test-wasm:
-    name: "wasm: mx::api under Emscripten"
+  emscripten:
+    name: emscripten
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -119,9 +119,17 @@ jobs:
             --opt type=none --opt o=bind \
             --opt device="$GITHUB_WORKSPACE/build/docker" mx-build
 
-      # Emscripten's compiled system-library cache (libc/libc++/compiler-rt),
-      # not source ccache -- see EM_CACHE in the Dockerfile. Populating it from
-      # scratch is the slow part of a wasm build.
+      # Two caches: ccache for mx's own object files (emcc via the ambient
+      # CMAKE_*_COMPILER_LAUNCHER), EM_CACHE for Emscripten's compiled
+      # system libraries (libc/libc++/compiler-rt). Without both, this job
+      # recompiles everything from scratch on every run.
+      - name: Cache ccache
+        uses: actions/cache@v4
+        with:
+          path: build/docker/.ccache
+          key: ccache-${{ runner.os }}-wasm-${{ github.sha }}
+          restore-keys: ccache-${{ runner.os }}-wasm-
+
       - name: Cache EM_CACHE
         uses: actions/cache@v4
         with:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -141,6 +141,8 @@ separately. `make test-all` runs every C++ suite at once (core roundtrip + unit 
 api-roundtrip) — the deep gate CI runs on Linux (see `make help` / CI).
 Adding/removing a `data/` file: bump the pinned count in `CoreRoundtripTest.cpp`, run `make audit` (regenerates `corpus.xml` + `*.features.xml`), confirm round-trip via `make core-roundtrip-test`.
 `ApiLoadSmokeTest` proves a file imports without crashing, not that the data is correct; the read→write→read gate (`make api-roundtrip` / `roundtrip-baseline.txt`) is the correctness check — pin a fixture there to defend a feature.
+`make wasm-test` builds `mx::api` for Emscripten and runs the examples under Node — CI's check that mx
+still compiles and works client-side in a browser (a consumer, denigma, depends on this; issue #386).
 
 Look at what will run in CI `.github/workflows/ci.yaml` and anticipate issues there when coding
 locally. Code coverage is not part of the normal CI run; trigger it on demand with a `/coverage`

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -12,12 +12,8 @@ set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
 set(EXECUTABLE_OUTPUT_PATH ${CMAKE_BINARY_DIR})
 set(LIBRARY_OUTPUT_PATH ${CMAKE_BINARY_DIR})
 
-# Emscripten disables exception catching by default, which turns mx's internal
-# MX_THROW (see src/private/mx/utility/Throw.h) into a fatal abort instead of
-# something DocumentManager can catch and turn into ResultCode::internalError.
-# Set directory-scoped (not per-target) so it also covers pugixml/mx_core/mx,
-# and set it here rather than relying on downstream consumers (e.g. denigma)
-# to remember it before FetchContent-ing mx.
+# Emscripten disables exception catching by default; mx's internal MX_THROW
+# (Throw.h) needs it, so DocumentManager can actually catch and convert it.
 if(EMSCRIPTEN)
     add_compile_options(-fexceptions)
     add_link_options(-fexceptions)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -12,6 +12,17 @@ set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
 set(EXECUTABLE_OUTPUT_PATH ${CMAKE_BINARY_DIR})
 set(LIBRARY_OUTPUT_PATH ${CMAKE_BINARY_DIR})
 
+# Emscripten disables exception catching by default, which turns mx's internal
+# MX_THROW (see src/private/mx/utility/Throw.h) into a fatal abort instead of
+# something DocumentManager can catch and turn into ResultCode::internalError.
+# Set directory-scoped (not per-target) so it also covers pugixml/mx_core/mx,
+# and set it here rather than relying on downstream consumers (e.g. denigma)
+# to remember it before FetchContent-ing mx.
+if(EMSCRIPTEN)
+    add_compile_options(-fexceptions)
+    add_link_options(-fexceptions)
+endif()
+
 option(MX_CORE_DEV "Build the core roundtrip (corert) test binary against the regenerated mx/core." OFF)
 
 option(MX_API "Build the mx::api/mx::impl product library and its tests." ON)

--- a/Dockerfile
+++ b/Dockerfile
@@ -21,6 +21,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
         pkg-config \
         git \
         ca-certificates \
+        xz-utils \
     && rm -rf /var/lib/apt/lists/*
 
 # Python quality tooling for `make gen-quality` / `make gen-lint`. Isolated in a

--- a/Dockerfile
+++ b/Dockerfile
@@ -38,16 +38,7 @@ RUN python3 -m venv /opt/quality-venv \
 # Unversioned name so the Makefile invokes the formatter without the suffix.
 RUN ln -sf /usr/bin/clang-format-18 /usr/local/bin/clang-format
 
-# emsdk: the Emscripten toolchain, used to build mx to WebAssembly (issue #386;
-# see CMakeLists.txt's EMSCRIPTEN block). Pinned to a specific release, not
-# "latest", for the same reproducibility reason every other tool in this image
-# is version-pinned. emsdk writes its config (.emscripten) inside $EMSDK by
-# default (has since 1.39.x) rather than $HOME, so it needs no help from us
-# there -- but its system-library cache defaults to living under $EMSDK too,
-# which the container's caller-uid:gid user (no passwd entry, root-owned
-# /opt/emsdk) can't write to at runtime; EM_CACHE below redirects that.
-# node's bundled bin dir has a version number baked into its path; symlink a
-# stable name so PATH below doesn't have to guess it.
+# emsdk: pinned Emscripten toolchain for building mx to WebAssembly (#386).
 ARG EMSDK_VERSION=6.0.6
 RUN git clone --depth 1 --branch ${EMSDK_VERSION} https://github.com/emscripten-core/emsdk.git /opt/emsdk \
     && /opt/emsdk/emsdk install ${EMSDK_VERSION} \
@@ -55,18 +46,12 @@ RUN git clone --depth 1 --branch ${EMSDK_VERSION} https://github.com/emscripten-
     && ln -s "$(find /opt/emsdk/node -maxdepth 2 -type d -name bin)" /opt/emsdk/node/current-bin \
     && rm -rf /opt/emsdk/downloads
 
-# EM_CACHE (the compiled libc/libc++/compiler-rt system-library cache) is
-# redirected to the build volume for the same reason CCACHE_DIR is below: it
-# would otherwise try to write under the root-owned /opt/emsdk at runtime.
-# PATH appends emsdk's dirs rather than prepending them: upstream/emscripten
-# (Emscripten's own tree) contains a subdirectory literally named `cmake`
-# (its CMake toolchain-file module), and execve() on a directory returns
-# EACCES ("Permission denied") -- prepended, it silently shadowed the real
-# /usr/bin/cmake for every job, not just the wasm one.
+# EM_CACHE: like CCACHE_DIR, avoids writing under root-owned /opt/emsdk at runtime.
+# PATH is appended, not prepended -- emsdk's own dirs shadow real tools by name (node, cmake).
 ENV EMSDK=/opt/emsdk \
     EM_CONFIG=/opt/emsdk/.emscripten \
     EM_CACHE=/workspace/build/.emcache \
-    PATH="${PATH}:/opt/emsdk:/opt/emsdk/upstream/emscripten:/opt/emsdk/node/current-bin"
+    PATH="${PATH}:/opt/emsdk/node/current-bin:/opt/emsdk/upstream/emscripten"
 
 # MX_RUNNING_IN_DOCKER flips the Makefile to its in-container branch. Build with
 # the pinned GCC; ccache state lives under the mounted build volume.

--- a/Dockerfile
+++ b/Dockerfile
@@ -52,15 +52,21 @@ ARG EMSDK_VERSION=6.0.6
 RUN git clone --depth 1 --branch ${EMSDK_VERSION} https://github.com/emscripten-core/emsdk.git /opt/emsdk \
     && /opt/emsdk/emsdk install ${EMSDK_VERSION} \
     && /opt/emsdk/emsdk activate ${EMSDK_VERSION} \
-    && ln -s "$(find /opt/emsdk/node -maxdepth 2 -type d -name bin)" /opt/emsdk/node/current-bin
+    && ln -s "$(find /opt/emsdk/node -maxdepth 2 -type d -name bin)" /opt/emsdk/node/current-bin \
+    && rm -rf /opt/emsdk/downloads
 
 # EM_CACHE (the compiled libc/libc++/compiler-rt system-library cache) is
 # redirected to the build volume for the same reason CCACHE_DIR is below: it
 # would otherwise try to write under the root-owned /opt/emsdk at runtime.
+# PATH appends emsdk's dirs rather than prepending them: upstream/emscripten
+# (Emscripten's own tree) contains a subdirectory literally named `cmake`
+# (its CMake toolchain-file module), and execve() on a directory returns
+# EACCES ("Permission denied") -- prepended, it silently shadowed the real
+# /usr/bin/cmake for every job, not just the wasm one.
 ENV EMSDK=/opt/emsdk \
     EM_CONFIG=/opt/emsdk/.emscripten \
     EM_CACHE=/workspace/build/.emcache \
-    PATH="/opt/emsdk:/opt/emsdk/upstream/emscripten:/opt/emsdk/node/current-bin:${PATH}"
+    PATH="${PATH}:/opt/emsdk:/opt/emsdk/upstream/emscripten:/opt/emsdk/node/current-bin"
 
 # MX_RUNNING_IN_DOCKER flips the Makefile to its in-container branch. Build with
 # the pinned GCC; ccache state lives under the mounted build volume.

--- a/Dockerfile
+++ b/Dockerfile
@@ -19,6 +19,8 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
         libxml2-dev \
         libxml2-utils \
         pkg-config \
+        git \
+        ca-certificates \
     && rm -rf /var/lib/apt/lists/*
 
 # Python quality tooling for `make gen-quality` / `make gen-lint`. Isolated in a
@@ -34,6 +36,30 @@ RUN python3 -m venv /opt/quality-venv \
 
 # Unversioned name so the Makefile invokes the formatter without the suffix.
 RUN ln -sf /usr/bin/clang-format-18 /usr/local/bin/clang-format
+
+# emsdk: the Emscripten toolchain, used to build mx to WebAssembly (issue #386;
+# see CMakeLists.txt's EMSCRIPTEN block). Pinned to a specific release, not
+# "latest", for the same reproducibility reason every other tool in this image
+# is version-pinned. emsdk writes its config (.emscripten) inside $EMSDK by
+# default (has since 1.39.x) rather than $HOME, so it needs no help from us
+# there -- but its system-library cache defaults to living under $EMSDK too,
+# which the container's caller-uid:gid user (no passwd entry, root-owned
+# /opt/emsdk) can't write to at runtime; EM_CACHE below redirects that.
+# node's bundled bin dir has a version number baked into its path; symlink a
+# stable name so PATH below doesn't have to guess it.
+ARG EMSDK_VERSION=6.0.6
+RUN git clone --depth 1 --branch ${EMSDK_VERSION} https://github.com/emscripten-core/emsdk.git /opt/emsdk \
+    && /opt/emsdk/emsdk install ${EMSDK_VERSION} \
+    && /opt/emsdk/emsdk activate ${EMSDK_VERSION} \
+    && ln -s "$(find /opt/emsdk/node -maxdepth 2 -type d -name bin)" /opt/emsdk/node/current-bin
+
+# EM_CACHE (the compiled libc/libc++/compiler-rt system-library cache) is
+# redirected to the build volume for the same reason CCACHE_DIR is below: it
+# would otherwise try to write under the root-owned /opt/emsdk at runtime.
+ENV EMSDK=/opt/emsdk \
+    EM_CONFIG=/opt/emsdk/.emscripten \
+    EM_CACHE=/workspace/build/.emcache \
+    PATH="/opt/emsdk:/opt/emsdk/upstream/emscripten:/opt/emsdk/node/current-bin:${PATH}"
 
 # MX_RUNNING_IN_DOCKER flips the Makefile to its in-container branch. Build with
 # the pinned GCC; ccache state lives under the mounted build volume.

--- a/Makefile
+++ b/Makefile
@@ -241,13 +241,11 @@ api-coverage:
 		$(BUILD_ROOT)/cov-api | tee $(COV_DIR)/api/summary.txt
 	@echo "=== api-coverage written to $(COV_DIR)/api/ ==="
 
-# wasm: mx::api built for Emscripten. Compiler launcher blanked, same as the
-# coverage targets above -- ccache wrapping emcc's Python driver is untested.
+# wasm: mx::api built for Emscripten. ccache wraps emcc via the ambient
+# CMAKE_*_COMPILER_LAUNCHER env (Dockerfile), same as every other job.
 wasm-lib:
 	emcmake $(CMAKE) -S . -B $(BUILD_ROOT)/wasm \
 		-DCMAKE_BUILD_TYPE=$(BUILD_TYPE) \
-		-DCMAKE_C_COMPILER_LAUNCHER= \
-		-DCMAKE_CXX_COMPILER_LAUNCHER= \
 		-DMX_API=on
 	emmake $(CMAKE) --build $(BUILD_ROOT)/wasm --target mx --parallel $(JOBS)
 

--- a/Makefile
+++ b/Makefile
@@ -252,10 +252,8 @@ wasm-lib:
 wasm-build: wasm-lib
 	emmake $(CMAKE) --build $(BUILD_ROOT)/wasm --target mxread mxwrite mxhide --parallel $(JOBS)
 
-# Runs mxread/mxwrite/mxhide under Node so this exercises mx::api, not just a
-# compile. mxwrite's output path is bare (no directory) and lands in
-# Emscripten's in-memory MEMFS, not disk -- MEMFS starts empty, so a path
-# with a build/wasm/ prefix would fail outright with no such directory.
+# Runs mxread/mxwrite/mxhide under Node, exercising mx::api, not just a compile.
+# mxwrite's output path is bare -- Emscripten's MEMFS starts empty, no build/wasm/ dir.
 wasm-test: wasm-build
 	node $(BUILD_ROOT)/wasm/mxread.js
 	node $(BUILD_ROOT)/wasm/mxwrite.js example.musicxml

--- a/Makefile
+++ b/Makefile
@@ -241,10 +241,8 @@ api-coverage:
 		$(BUILD_ROOT)/cov-api | tee $(COV_DIR)/api/summary.txt
 	@echo "=== api-coverage written to $(COV_DIR)/api/ ==="
 
-# wasm: mx::api built for Emscripten (see CMakeLists.txt's EMSCRIPTEN block for
-# the exceptions flag this relies on). Compiler launcher blanked, same as the
-# coverage targets above -- ccache wrapping emcc's Python driver is untested
-# and not worth the risk for a job that isn't anyone's hot inner loop.
+# wasm: mx::api built for Emscripten. Compiler launcher blanked, same as the
+# coverage targets above -- ccache wrapping emcc's Python driver is untested.
 wasm-lib:
 	emcmake $(CMAKE) -S . -B $(BUILD_ROOT)/wasm \
 		-DCMAKE_BUILD_TYPE=$(BUILD_TYPE) \
@@ -256,14 +254,8 @@ wasm-lib:
 wasm-build: wasm-lib
 	emmake $(CMAKE) --build $(BUILD_ROOT)/wasm --target mxread mxwrite mxhide --parallel $(JOBS)
 
-# Proves mx::api actually works under wasm, not just that it compiles:
-# mxread/mxwrite/mxhide (src/private/mx/examples/) round-trip real ScoreData
-# through DocumentManager, the same programs api-examples runs natively.
-# Emscripten's CMake toolchain names the outputs *.js; node runs them and
-# each one's C++ main() return code becomes node's exit code. mxwrite's
-# writeToFile lands in Emscripten's default in-memory MEMFS, not on the real
-# filesystem -- the output path won't actually appear under build/wasm/, only
-# the write call (and its return code) is being exercised here.
+# Runs mxread/mxwrite/mxhide under Node so this exercises mx::api, not just a
+# compile. mxwrite's output lands in Emscripten's in-memory MEMFS, not disk.
 wasm-test: wasm-build
 	node $(BUILD_ROOT)/wasm/mxread.js
 	node $(BUILD_ROOT)/wasm/mxwrite.js $(BUILD_ROOT)/wasm/example.musicxml

--- a/Makefile
+++ b/Makefile
@@ -69,6 +69,7 @@ FIND_CPP := find src \
         core-build core-roundtrip-test core-unit core-coverage \
         api-lib api-build api-test api-examples api-roundtrip \
         api-roundtrip-discover api-roundtrip-dump api-roundtrip-classify api-coverage \
+        wasm-lib wasm-build wasm-test \
         gen-test audit-test gen-quality gen-lint \
         gen gen-cpp gen-go gen-c gen-schema \
         audit audit-force \
@@ -92,6 +93,11 @@ help:
 	@echo '  make api-roundtrip-dump      Dump normalized expected/actual XML for failures.'
 	@echo '  make api-roundtrip-classify  Classify dumped failures by root cause (Python).'
 	@echo '  make api-coverage        Instrumented api/impl/utility build + gcovr report.'
+	@echo ''
+	@echo '  WebAssembly (mx::api via Emscripten, issue #386):'
+	@echo '  make wasm-lib            Build the mx static library for wasm (MX_API=ON, emcmake).'
+	@echo '  make wasm-build          wasm-lib plus the mxread/mxwrite/mxhide examples.'
+	@echo '  make wasm-test           Run mxread/mxwrite/mxhide under Node against the wasm build.'
 	@echo ''
 	@echo '  Core substrate (mx::core):'
 	@echo '  make core-build          Build mx_core and the corert + unit test binaries.'
@@ -234,6 +240,35 @@ api-coverage:
 		--html-self-contained --html $(COV_DIR)/api/index.html \
 		$(BUILD_ROOT)/cov-api | tee $(COV_DIR)/api/summary.txt
 	@echo "=== api-coverage written to $(COV_DIR)/api/ ==="
+
+# wasm: mx::api built for Emscripten (see CMakeLists.txt's EMSCRIPTEN block for
+# the exceptions flag this relies on). Compiler launcher blanked, same as the
+# coverage targets above -- ccache wrapping emcc's Python driver is untested
+# and not worth the risk for a job that isn't anyone's hot inner loop.
+wasm-lib:
+	emcmake $(CMAKE) -S . -B $(BUILD_ROOT)/wasm \
+		-DCMAKE_BUILD_TYPE=$(BUILD_TYPE) \
+		-DCMAKE_C_COMPILER_LAUNCHER= \
+		-DCMAKE_CXX_COMPILER_LAUNCHER= \
+		-DMX_API=on
+	emmake $(CMAKE) --build $(BUILD_ROOT)/wasm --target mx --parallel $(JOBS)
+
+wasm-build: wasm-lib
+	emmake $(CMAKE) --build $(BUILD_ROOT)/wasm --target mxread mxwrite mxhide --parallel $(JOBS)
+
+# Proves mx::api actually works under wasm, not just that it compiles:
+# mxread/mxwrite/mxhide (src/private/mx/examples/) round-trip real ScoreData
+# through DocumentManager, the same programs api-examples runs natively.
+# Emscripten's CMake toolchain names the outputs *.js; node runs them and
+# each one's C++ main() return code becomes node's exit code. mxwrite's
+# writeToFile lands in Emscripten's default in-memory MEMFS, not on the real
+# filesystem -- the output path won't actually appear under build/wasm/, only
+# the write call (and its return code) is being exercised here.
+wasm-test: wasm-build
+	node $(BUILD_ROOT)/wasm/mxread.js
+	node $(BUILD_ROOT)/wasm/mxwrite.js $(BUILD_ROOT)/wasm/example.musicxml
+	node $(BUILD_ROOT)/wasm/mxhide.js
+	@echo 'wasm-test: mxread/mxwrite/mxhide ran successfully under Node (wasm).'
 
 core-build:
 	$(CMAKE) -S . -B $(BUILD_ROOT)/core-dev -DCMAKE_BUILD_TYPE=$(BUILD_TYPE) -DMX_CORE_DEV=on
@@ -399,6 +434,15 @@ api-coverage: $(DOCKER_STAMP) docker-volume
 	@rm -rf $(COV_DIR)/api
 	$(DOCKER_RUN) make api-coverage BUILD_TYPE=$(BUILD_TYPE) ARGS='$(ARGS)'
 	@echo "API coverage written to $(COV_DIR)/api/ (open $(COV_DIR)/api/index.html)"
+
+wasm-lib: $(DOCKER_STAMP) docker-volume
+	$(DOCKER_RUN) make wasm-lib BUILD_TYPE=$(BUILD_TYPE)
+
+wasm-build: $(DOCKER_STAMP) docker-volume
+	$(DOCKER_RUN) make wasm-build BUILD_TYPE=$(BUILD_TYPE)
+
+wasm-test: $(DOCKER_STAMP) docker-volume
+	$(DOCKER_RUN) make wasm-test BUILD_TYPE=$(BUILD_TYPE)
 
 core-build: $(DOCKER_STAMP) docker-volume
 	$(DOCKER_RUN) make core-build BUILD_TYPE=$(BUILD_TYPE)

--- a/Makefile
+++ b/Makefile
@@ -255,10 +255,12 @@ wasm-build: wasm-lib
 	emmake $(CMAKE) --build $(BUILD_ROOT)/wasm --target mxread mxwrite mxhide --parallel $(JOBS)
 
 # Runs mxread/mxwrite/mxhide under Node so this exercises mx::api, not just a
-# compile. mxwrite's output lands in Emscripten's in-memory MEMFS, not disk.
+# compile. mxwrite's output path is bare (no directory) and lands in
+# Emscripten's in-memory MEMFS, not disk -- MEMFS starts empty, so a path
+# with a build/wasm/ prefix would fail outright with no such directory.
 wasm-test: wasm-build
 	node $(BUILD_ROOT)/wasm/mxread.js
-	node $(BUILD_ROOT)/wasm/mxwrite.js $(BUILD_ROOT)/wasm/example.musicxml
+	node $(BUILD_ROOT)/wasm/mxwrite.js example.musicxml
 	node $(BUILD_ROOT)/wasm/mxhide.js
 	@echo 'wasm-test: mxread/mxwrite/mxhide ran successfully under Node (wasm).'
 


### PR DESCRIPTION
## Human Summary

Add a smoke build to WASM and run something trivial to make sure we don't break [denigma](https://github.com/rpatters1/denigma).

## Summary

`mx` already gets cross-compiled to WebAssembly downstream today: `denigma` (github.com/rpatters1/denigma) builds it client-side for browser use in a musx-to-MusicXML converter, but nothing here proves that keeps working, so a regression would only surface in someone else's CI. This adds an Emscripten build to `mx`'s own CI.

- `mx-sdk`'s `Dockerfile` gets a pinned `emsdk` install (6.0.6), matching how every other tool in that image is version-pinned rather than "latest". `EM_CACHE` is redirected to the mounted build volume, same reasoning as `CCACHE_DIR`/`GOPATH` right below it in the file: the container runs as the caller's uid:gid, which can't write under the root-owned `/opt/emsdk` at runtime.
- `CMakeLists.txt` now enables exception catching under `EMSCRIPTEN` (`-fexceptions`, compile and link). Emscripten disables catching by default, which turns `mx`'s internal `MX_THROW`/catch boundary in `DocumentManager` (`src/private/mx/utility/Throw.h`) into a fatal abort instead of a caught `ResultCode::internalError`. Previously only `denigma`'s own build set this flag (globally, before `FetchContent`-ing `mx`) -- `mx` didn't configure itself correctly for `EMSCRIPTEN` on its own. Confirmed this is the same fix `denigma-examples`' top-level `CMakeLists.txt` already applies, so this reproduces a known-working setup rather than a new one.
- New `make wasm-lib` / `wasm-build` / `wasm-test` targets, driven inside `mx-sdk` like every other gate. `wasm-test` builds `mx::api` and runs the existing `mxread`/`mxwrite`/`mxhide` examples under Node -- it exercises the library through `DocumentManager`, not just a compile.
- New `test-wasm` CI job (mirrors `test-linux`/`quality`/`gen`'s Docker setup) running `make wasm-test`.

## Testing

- [x] `make -n wasm-test` (dry run, both outside- and inside-container branches) resolves to the expected `emcmake`/`emmake`/`node` commands
- [x] Native `cmake -S . -B ... -DMX_API=on` still configures cleanly with the new `EMSCRIPTEN` block present (a no-op when not cross-compiling)
- [x] `ci.yaml` still parses as valid YAML
- [x] CI

## References

- Closes #386
