### PR TITLE
fix: consume implicit one-or-more placeholder in add

### DIFF
--- a/src/private/mx/core/OneOrMore.h
+++ b/src/private/mx/core/OneOrMore.h
@@ -20,11 +20,11 @@ namespace mx::core
 template <typename T> class OneOrMore
 {
   public:
-    OneOrMore() : m_items(1)
+    OneOrMore() : m_items(1), m_hasPlaceholder(true)
     {
     }
 
-    explicit OneOrMore(T first)
+    explicit OneOrMore(T first) : m_hasPlaceholder(false)
     {
         m_items.push_back(std::move(first));
     }
@@ -41,12 +41,21 @@ template <typename T> class OneOrMore
 
     void add(T item)
     {
-        m_items.push_back(std::move(item));
+        if (m_hasPlaceholder)
+        {
+            m_items.front() = std::move(item);
+            m_hasPlaceholder = false;
+        }
+        else
+        {
+            m_items.push_back(std::move(item));
+        }
     }
 
     /// Deterministic repair: an empty replacement becomes one default item.
     void setItems(std::vector<T> items)
     {
+        m_hasPlaceholder = items.empty();
         if (items.empty())
         {
             items.emplace_back();
@@ -66,6 +75,7 @@ template <typename T> class OneOrMore
 
   private:
     std::vector<T> m_items;
+    bool m_hasPlaceholder = false;
 };
 
 } // namespace mx::core

--- a/src/private/mxtest/core/ShapeTest.cpp
+++ b/src/private/mxtest/core/ShapeTest.cpp
@@ -11,6 +11,7 @@
 #include "cpul/cpulTestHarness.h"
 
 #include "mx/core/Error.h"
+#include "mx/core/OneOrMore.h"
 #include "mx/core/Xml.h"
 #include "mx/core/generated/Beam.h"
 #include "mx/core/generated/BeamValue.h"
@@ -86,6 +87,36 @@ TEST(DefaultConstructionIsValid, Shapes)
 {
     // The natural zero serializes schema-valid content recursively.
     CHECK_EQUAL(std::string{"<pitch><step>A</step><octave>0</octave></pitch>"}, toXml(Pitch{}));
+}
+
+TEST(OneOrMoreAddConsumesDefaultPlaceholder, Shapes)
+{
+    OneOrMore<int> items;
+    items.add(7);
+    CHECK_EQUAL(std::size_t{1}, items.items().size());
+    CHECK_EQUAL(7, items.front());
+
+    items.add(8);
+    CHECK_EQUAL(std::size_t{2}, items.items().size());
+    CHECK_EQUAL(8, items.items().back());
+}
+
+TEST(OneOrMoreAddPreservesExplicitFirstItem, Shapes)
+{
+    OneOrMore<int> items{0};
+    items.add(7);
+    CHECK_EQUAL(std::size_t{2}, items.items().size());
+    CHECK_EQUAL(0, items.items().front());
+    CHECK_EQUAL(7, items.items().back());
+}
+
+TEST(OneOrMoreEmptySetItemsCreatesPlaceholder, Shapes)
+{
+    OneOrMore<int> items{1};
+    items.setItems({});
+    items.add(7);
+    CHECK_EQUAL(std::size_t{1}, items.items().size());
+    CHECK_EQUAL(7, items.front());
 }
 
 TEST(VariantExclusivity, Shapes)


### PR DESCRIPTION
## Human Summary

While trying to build a fretboard diagram, discovered a bug in OneOrMore that could lead to an extra item being generated. This PR fixes that bug.

## Summary

`OneOrMore` now tracks its implicit default placeholder. The first item added to a default-constructed or empty-repaired collection replaces that placeholder; explicitly supplied first items are preserved. Added core regression tests and removed the exporter-specific workaround.

## Testing

- [x] Core unit tests: 221 assertions in 44 test cases
- [x] DirectionWriter tests: 30 assertions in 4 test cases
- [x] Changed files pass direct clang-format validation

## References

- No issue reference: GitHub issues are disabled for this repository.