### PR TITLE
feat: expose musicxml id attributes in mx::api

### DIFF
--- a/src/include/mx/api/AccordionRegistrationData.h
+++ b/src/include/mx/api/AccordionRegistrationData.h
@@ -7,6 +7,7 @@
 #include "mx/api/ApiCommon.h"
 #include "mx/api/ColorData.h"
 #include "mx/api/FontData.h"
+#include "mx/api/Id.h"
 #include "mx/api/PositionData.h"
 
 #include <optional>
@@ -31,7 +32,7 @@ class AccordionRegistrationData
     PositionData positionData;
     FontData fontData;
     std::optional<ColorData> color;
-    std::optional<std::string> id;
+    std::optional<Id> id;
 
     AccordionRegistrationData() : high{false}, middle{}, low{false}, positionData{}, fontData{}, color{}, id{}
     {

--- a/src/include/mx/api/ApiCommon.h
+++ b/src/include/mx/api/ApiCommon.h
@@ -32,17 +32,6 @@ constexpr int NUMBER_LEVEL_UNSPECIFIED = -1; // MusicXML 'number' attributes, e.
 constexpr int VALUE_UNSPECIFIED = -1;        // other absent-able ints, e.g. DirectionData::voice
 constexpr Double DOUBLE_UNSPECIFIED = -1.0;  // absent-able doubles, e.g. StaffData::staffSize
 
-// MusicXML lets most elements carry an optional id attribute, a name that identifies that one
-// element within the document. Software uses it to point at a particular note, measure, or
-// marking -- to line playback up with the score, to hang an annotation on a note, or to link one
-// file to another. Every mx::api type that models such an element has an `id` member. Leave it
-// empty and no id attribute is written.
-//
-// An id must be unique within the document and must follow the XML name rules: a letter or an
-// underscore first, then letters, digits, dots, hyphens, or underscores. mx repairs an id that
-// breaks the name rules when it writes the file, but it does not check uniqueness, so an id you
-// invent must not collide with one already in the score.
-
 // Intentional ternary: absent-able bools use Bool::unspecified, not std::optional<bool>.
 // See "mx::api conventions" in AGENTS.md.
 enum class Bool

--- a/src/include/mx/api/ApiCommon.h
+++ b/src/include/mx/api/ApiCommon.h
@@ -32,6 +32,17 @@ constexpr int NUMBER_LEVEL_UNSPECIFIED = -1; // MusicXML 'number' attributes, e.
 constexpr int VALUE_UNSPECIFIED = -1;        // other absent-able ints, e.g. DirectionData::voice
 constexpr Double DOUBLE_UNSPECIFIED = -1.0;  // absent-able doubles, e.g. StaffData::staffSize
 
+// MusicXML lets most elements carry an optional id attribute, a name that identifies that one
+// element within the document. Software uses it to point at a particular note, measure, or
+// marking -- to line playback up with the score, to hang an annotation on a note, or to link one
+// file to another. Every mx::api type that models such an element has an `id` member. Leave it
+// empty and no id attribute is written.
+//
+// An id must be unique within the document and must follow the XML name rules: a letter or an
+// underscore first, then letters, digits, dots, hyphens, or underscores. mx repairs an id that
+// breaks the name rules when it writes the file, but it does not check uniqueness, so an id you
+// invent must not collide with one already in the score.
+
 // Intentional ternary: absent-able bools use Bool::unspecified, not std::optional<bool>.
 // See "mx::api conventions" in AGENTS.md.
 enum class Bool

--- a/src/include/mx/api/BarlineData.h
+++ b/src/include/mx/api/BarlineData.h
@@ -5,6 +5,7 @@
 #pragma once
 
 #include "mx/api/ApiCommon.h"
+#include "mx/api/Id.h"
 #include "mx/api/PositionData.h"
 
 #include <optional>
@@ -116,8 +117,8 @@ class BarlineData
     RepeatWinged repeatWinged;
     HorizontalAlignment location;
 
-    // The <barline> element's id attribute (see ApiCommon.h).
-    std::optional<std::string> id;
+    // The <barline> element's id attribute (see Id.h).
+    std::optional<Id> id;
 
     BarlineData()
         : tickTimePosition{0}, barlineType{BarlineType::normal}, ending{}, repeat{false}, repeatTimes{0},

--- a/src/include/mx/api/BarlineData.h
+++ b/src/include/mx/api/BarlineData.h
@@ -116,10 +116,13 @@ class BarlineData
     RepeatWinged repeatWinged;
     HorizontalAlignment location;
 
+    // The <barline> element's id attribute (see ApiCommon.h).
+    std::optional<std::string> id;
+
     BarlineData()
         : tickTimePosition{0}, barlineType{BarlineType::normal}, ending{}, repeat{false}, repeatTimes{0},
           repeatDirection{RepeatDirection::unspecified}, repeatAfterJump{Bool::unspecified},
-          repeatWinged{RepeatWinged::unspecified}, location{HorizontalAlignment::unspecified}
+          repeatWinged{RepeatWinged::unspecified}, location{HorizontalAlignment::unspecified}, id{}
     {
     }
 };
@@ -134,6 +137,7 @@ MXAPI_EQUALS_MEMBER(repeatDirection)
 MXAPI_EQUALS_MEMBER(repeatAfterJump)
 MXAPI_EQUALS_MEMBER(repeatWinged)
 MXAPI_EQUALS_MEMBER(location)
+MXAPI_EQUALS_MEMBER(id)
 MXAPI_EQUALS_END;
 MXAPI_NOT_EQUALS_AND_VECTORS(BarlineData);
 } // namespace api

--- a/src/include/mx/api/ClefData.h
+++ b/src/include/mx/api/ClefData.h
@@ -6,6 +6,9 @@
 
 #include "mx/api/ApiCommon.h"
 
+#include <optional>
+#include <string>
+
 namespace mx
 {
 namespace api
@@ -67,6 +70,10 @@ class ClefData
     // Visibility of the clef via the MusicXML print-object attribute.
     // unspecified -> omit the attribute, yes/no -> write print-object verbatim.
     Bool printObject;
+
+    // The <clef> element's id attribute (see ApiCommon.h).
+    std::optional<std::string> id;
+
     std::string toString() const;
 
     // convenience - set symbol, line and octave for common clefs
@@ -99,6 +106,7 @@ MXAPI_EQUALS_MEMBER(tickTimePosition)
 MXAPI_EQUALS_MEMBER(location)
 MXAPI_EQUALS_MEMBER(additional)
 MXAPI_EQUALS_MEMBER(printObject)
+MXAPI_EQUALS_MEMBER(id)
 MXAPI_EQUALS_END;
 MXAPI_NOT_EQUALS_AND_VECTORS(ClefData);
 } // namespace api

--- a/src/include/mx/api/ClefData.h
+++ b/src/include/mx/api/ClefData.h
@@ -5,6 +5,7 @@
 #pragma once
 
 #include "mx/api/ApiCommon.h"
+#include "mx/api/Id.h"
 
 #include <optional>
 #include <string>
@@ -71,8 +72,8 @@ class ClefData
     // unspecified -> omit the attribute, yes/no -> write print-object verbatim.
     Bool printObject;
 
-    // The <clef> element's id attribute (see ApiCommon.h).
-    std::optional<std::string> id;
+    // The <clef> element's id attribute (see Id.h).
+    std::optional<Id> id;
 
     std::string toString() const;
 

--- a/src/include/mx/api/CodaData.h
+++ b/src/include/mx/api/CodaData.h
@@ -7,8 +7,10 @@
 #include "mx/api/ApiCommon.h"
 #include "mx/api/ColorData.h"
 #include "mx/api/FontData.h"
+#include "mx/api/Id.h"
 #include "mx/api/PositionData.h"
 
+#include <optional>
 #include <string>
 
 namespace mx
@@ -28,12 +30,12 @@ class CodaData
     ColorData colorData;
     bool isSmuflSpecified;
     std::string smufl;
-    bool isIdSpecified;
-    std::string id;
+
+    // The <coda> element's id attribute (see Id.h).
+    std::optional<Id> id;
 
     CodaData()
-        : positionData{}, fontData{}, isColorSpecified{false}, colorData{}, isSmuflSpecified{false}, smufl{},
-          isIdSpecified{false}, id{}
+        : positionData{}, fontData{}, isColorSpecified{false}, colorData{}, isSmuflSpecified{false}, smufl{}, id{}
     {
     }
 };
@@ -45,7 +47,6 @@ MXAPI_EQUALS_MEMBER(isColorSpecified)
 MXAPI_EQUALS_MEMBER(colorData)
 MXAPI_EQUALS_MEMBER(isSmuflSpecified)
 MXAPI_EQUALS_MEMBER(smufl)
-MXAPI_EQUALS_MEMBER(isIdSpecified)
 MXAPI_EQUALS_MEMBER(id)
 MXAPI_EQUALS_END;
 MXAPI_NOT_EQUALS_AND_VECTORS(CodaData);

--- a/src/include/mx/api/CurveData.h
+++ b/src/include/mx/api/CurveData.h
@@ -10,6 +10,9 @@
 #include "mx/api/PositionData.h"
 #include "mx/api/SpannerNumber.h"
 
+#include <optional>
+#include <string>
+
 // MusicXML Documentation for Bezier Attributes Group
 // The bezier attribute group is used to indicate the curvature of slurs
 // and ties, representing the control points for a cubic bezier curve.
@@ -100,9 +103,13 @@ struct CurveStart
     bool isColorSpecified;
     ColorData colorData;
 
+    // The id attribute of the element this curve end is written as -- <slur> for a slur,
+    // <tied> for a tie (see ApiCommon.h).
+    std::optional<std::string> id;
+
     CurveStart(CurveType inCurveType)
         : curveType{inCurveType}, number{}, curvePoints{}, curveOrientation{CurveOrientation::unspecified},
-          placement{Placement::unspecified}, lineData{}, isColorSpecified{false}, colorData{}
+          placement{Placement::unspecified}, lineData{}, isColorSpecified{false}, colorData{}, id{}
     {
     }
 };
@@ -119,9 +126,13 @@ struct CurveContinue
     bool isBezierOffset2Specified;
     double bezierOffset2;
 
+    // The id attribute of the element this curve end is written as -- <slur> for a slur,
+    // <tied> for a tie (see ApiCommon.h).
+    std::optional<std::string> id;
+
     CurveContinue(CurveType inCurveType)
         : curveType{inCurveType}, number{}, curvePoints{}, isBezierX2Specified{false}, bezierX2{0.0},
-          isBezierY2Specified{false}, bezierY2{0.0}, isBezierOffset2Specified{false}, bezierOffset2{0.0}
+          isBezierY2Specified{false}, bezierY2{0.0}, isBezierOffset2Specified{false}, bezierOffset2{0.0}, id{}
     {
     }
 };
@@ -132,7 +143,11 @@ struct CurveStop
     SpannerNumber number;
     CurvePoints curvePoints;
 
-    CurveStop(CurveType inCurveType) : curveType{inCurveType}, number{}, curvePoints{}
+    // The id attribute of the element this curve end is written as -- <slur> for a slur,
+    // <tied> for a tie (see ApiCommon.h).
+    std::optional<std::string> id;
+
+    CurveStop(CurveType inCurveType) : curveType{inCurveType}, number{}, curvePoints{}, id{}
     {
     }
 };
@@ -157,6 +172,7 @@ MXAPI_EQUALS_MEMBER(placement)
 MXAPI_EQUALS_MEMBER(lineData)
 MXAPI_EQUALS_MEMBER(isColorSpecified)
 MXAPI_EQUALS_MEMBER(colorData)
+MXAPI_EQUALS_MEMBER(id)
 MXAPI_EQUALS_END;
 MXAPI_NOT_EQUALS_AND_VECTORS(CurveStart);
 
@@ -170,6 +186,7 @@ MXAPI_EQUALS_MEMBER(isBezierY2Specified)
 MXAPI_EQUALS_MEMBER(bezierY2)
 MXAPI_EQUALS_MEMBER(isBezierOffset2Specified)
 MXAPI_EQUALS_MEMBER(bezierOffset2)
+MXAPI_EQUALS_MEMBER(id)
 MXAPI_EQUALS_END;
 MXAPI_NOT_EQUALS_AND_VECTORS(CurveContinue);
 
@@ -177,6 +194,7 @@ MXAPI_EQUALS_BEGIN(CurveStop)
 MXAPI_EQUALS_MEMBER(curveType)
 MXAPI_EQUALS_MEMBER(number)
 MXAPI_EQUALS_MEMBER(curvePoints)
+MXAPI_EQUALS_MEMBER(id)
 MXAPI_EQUALS_END;
 MXAPI_NOT_EQUALS_AND_VECTORS(CurveStop);
 } // namespace api

--- a/src/include/mx/api/CurveData.h
+++ b/src/include/mx/api/CurveData.h
@@ -6,6 +6,7 @@
 
 #include "mx/api/ApiCommon.h"
 #include "mx/api/ColorData.h"
+#include "mx/api/Id.h"
 #include "mx/api/LineData.h"
 #include "mx/api/PositionData.h"
 #include "mx/api/SpannerNumber.h"
@@ -104,8 +105,8 @@ struct CurveStart
     ColorData colorData;
 
     // The id attribute of the element this curve end is written as -- <slur> for a slur,
-    // <tied> for a tie (see ApiCommon.h).
-    std::optional<std::string> id;
+    // <tied> for a tie (see Id.h).
+    std::optional<Id> id;
 
     CurveStart(CurveType inCurveType)
         : curveType{inCurveType}, number{}, curvePoints{}, curveOrientation{CurveOrientation::unspecified},
@@ -127,8 +128,8 @@ struct CurveContinue
     double bezierOffset2;
 
     // The id attribute of the element this curve end is written as -- <slur> for a slur,
-    // <tied> for a tie (see ApiCommon.h).
-    std::optional<std::string> id;
+    // <tied> for a tie (see Id.h).
+    std::optional<Id> id;
 
     CurveContinue(CurveType inCurveType)
         : curveType{inCurveType}, number{}, curvePoints{}, isBezierX2Specified{false}, bezierX2{0.0},
@@ -144,8 +145,8 @@ struct CurveStop
     CurvePoints curvePoints;
 
     // The id attribute of the element this curve end is written as -- <slur> for a slur,
-    // <tied> for a tie (see ApiCommon.h).
-    std::optional<std::string> id;
+    // <tied> for a tie (see Id.h).
+    std::optional<Id> id;
 
     CurveStop(CurveType inCurveType) : curveType{inCurveType}, number{}, curvePoints{}, id{}
     {

--- a/src/include/mx/api/DampData.h
+++ b/src/include/mx/api/DampData.h
@@ -7,6 +7,7 @@
 #include "mx/api/ApiCommon.h"
 #include "mx/api/ColorData.h"
 #include "mx/api/FontData.h"
+#include "mx/api/Id.h"
 #include "mx/api/PositionData.h"
 
 #include <optional>
@@ -26,7 +27,7 @@ class DampData
     PositionData positionData;
     FontData fontData;
     std::optional<ColorData> color;
-    std::optional<std::string> id;
+    std::optional<Id> id;
 
     DampData() : positionData{}, fontData{}, color{}, id{}
     {
@@ -49,7 +50,7 @@ class DampAllData
     PositionData positionData;
     FontData fontData;
     std::optional<ColorData> color;
-    std::optional<std::string> id;
+    std::optional<Id> id;
 
     DampAllData() : positionData{}, fontData{}, color{}, id{}
     {

--- a/src/include/mx/api/DirectionData.h
+++ b/src/include/mx/api/DirectionData.h
@@ -11,6 +11,7 @@
 #include "mx/api/SoundData.h"
 
 #include <optional>
+#include <string>
 
 namespace mx
 {
@@ -80,10 +81,13 @@ struct DirectionData
     // serialize as their own <figured-bass> elements, not as direction-type content.
     std::vector<FiguredBassData> figuredBasses;
 
+    // The <direction> element's id attribute (see ApiCommon.h).
+    std::optional<std::string> id;
+
     DirectionData()
         : tickTimePosition{0}, placement{Placement::unspecified}, systemRelation{SystemRelation::unspecified}, offset{},
           voice{VALUE_UNSPECIFIED}, isStaffValueSpecified{true}, isSoundDataSpecified{false}, soundData{},
-          directionTypes{}, chords{}, figuredBasses{}
+          directionTypes{}, chords{}, figuredBasses{}, id{}
     {
     }
 };
@@ -106,6 +110,7 @@ MXAPI_EQUALS_MEMBER(soundData)
 MXAPI_EQUALS_MEMBER(directionTypes)
 MXAPI_EQUALS_MEMBER(chords)
 MXAPI_EQUALS_MEMBER(figuredBasses)
+MXAPI_EQUALS_MEMBER(id)
 MXAPI_EQUALS_END;
 MXAPI_NOT_EQUALS_AND_VECTORS(DirectionData);
 } // namespace api

--- a/src/include/mx/api/DirectionData.h
+++ b/src/include/mx/api/DirectionData.h
@@ -8,6 +8,7 @@
 #include "mx/api/ChordData.h"
 #include "mx/api/DirectionChoice.h"
 #include "mx/api/FiguredBassData.h"
+#include "mx/api/Id.h"
 #include "mx/api/SoundData.h"
 
 #include <optional>
@@ -81,8 +82,8 @@ struct DirectionData
     // serialize as their own <figured-bass> elements, not as direction-type content.
     std::vector<FiguredBassData> figuredBasses;
 
-    // The <direction> element's id attribute (see ApiCommon.h).
-    std::optional<std::string> id;
+    // The <direction> element's id attribute (see Id.h).
+    std::optional<Id> id;
 
     DirectionData()
         : tickTimePosition{0}, placement{Placement::unspecified}, systemRelation{SystemRelation::unspecified}, offset{},

--- a/src/include/mx/api/EyeglassesData.h
+++ b/src/include/mx/api/EyeglassesData.h
@@ -7,6 +7,7 @@
 #include "mx/api/ApiCommon.h"
 #include "mx/api/ColorData.h"
 #include "mx/api/FontData.h"
+#include "mx/api/Id.h"
 #include "mx/api/PositionData.h"
 
 #include <optional>
@@ -27,7 +28,7 @@ class EyeglassesData
     PositionData positionData;
     FontData fontData;
     std::optional<ColorData> color;
-    std::optional<std::string> id;
+    std::optional<Id> id;
 
     EyeglassesData() : positionData{}, fontData{}, color{}, id{}
     {

--- a/src/include/mx/api/FiguredBassData.h
+++ b/src/include/mx/api/FiguredBassData.h
@@ -6,6 +6,7 @@
 
 #include "mx/api/ApiCommon.h"
 
+#include <optional>
 #include <string>
 #include <vector>
 
@@ -48,7 +49,10 @@ class FiguredBassData
     // The optional <duration>, in ticks. A value less than 0 means 'unspecified' (no duration child).
     int durationTimeTicks;
 
-    FiguredBassData() : figures{}, parentheses{Bool::unspecified}, durationTimeTicks{VALUE_UNSPECIFIED}
+    // The <figured-bass> element's id attribute (see ApiCommon.h).
+    std::optional<std::string> id;
+
+    FiguredBassData() : figures{}, parentheses{Bool::unspecified}, durationTimeTicks{VALUE_UNSPECIFIED}, id{}
     {
     }
 };
@@ -57,6 +61,7 @@ MXAPI_EQUALS_BEGIN(FiguredBassData)
 MXAPI_EQUALS_MEMBER(figures)
 MXAPI_EQUALS_MEMBER(parentheses)
 MXAPI_EQUALS_MEMBER(durationTimeTicks)
+MXAPI_EQUALS_MEMBER(id)
 MXAPI_EQUALS_END;
 MXAPI_NOT_EQUALS_AND_VECTORS(FiguredBassData);
 

--- a/src/include/mx/api/FiguredBassData.h
+++ b/src/include/mx/api/FiguredBassData.h
@@ -5,6 +5,7 @@
 #pragma once
 
 #include "mx/api/ApiCommon.h"
+#include "mx/api/Id.h"
 
 #include <optional>
 #include <string>
@@ -49,8 +50,8 @@ class FiguredBassData
     // The optional <duration>, in ticks. A value less than 0 means 'unspecified' (no duration child).
     int durationTimeTicks;
 
-    // The <figured-bass> element's id attribute (see ApiCommon.h).
-    std::optional<std::string> id;
+    // The <figured-bass> element's id attribute (see Id.h).
+    std::optional<Id> id;
 
     FiguredBassData() : figures{}, parentheses{Bool::unspecified}, durationTimeTicks{VALUE_UNSPECIFIED}, id{}
     {

--- a/src/include/mx/api/HarpPedalsData.h
+++ b/src/include/mx/api/HarpPedalsData.h
@@ -7,6 +7,7 @@
 #include "mx/api/ApiCommon.h"
 #include "mx/api/ColorData.h"
 #include "mx/api/FontData.h"
+#include "mx/api/Id.h"
 #include "mx/api/PitchData.h"
 #include "mx/api/PositionData.h"
 
@@ -57,7 +58,7 @@ class HarpPedalsData
     PositionData positionData;
     FontData fontData;
     std::optional<ColorData> color;
-    std::optional<std::string> id;
+    std::optional<Id> id;
 
     HarpPedalsData() : pedalTunings{}, positionData{}, fontData{}, color{}, id{}
     {

--- a/src/include/mx/api/Id.h
+++ b/src/include/mx/api/Id.h
@@ -1,0 +1,103 @@
+// MusicXML Class Library
+// Copyright (c) by Matthew James Briggs
+// Distributed under the MIT License
+
+#pragma once
+
+#include "mx/api/ApiCommon.h"
+
+#include <cstddef>
+#include <functional>
+#include <memory>
+#include <string>
+
+namespace mx
+{
+namespace api
+{
+
+// The id attribute of a MusicXML element. An id is a name that identifies one element within the
+// document. Software uses it to point at a particular note, measure, or marking -- to line playback
+// up with the score, to hang an annotation on a note, or to link one file to another.
+//
+// An id must follow the XML name rules. The first character is a letter or an underscore. The rest
+// are letters, digits, dots, hyphens, or underscores. Building an Id scrubs out anything else, so
+// an id that breaks the rules cannot exist. Text with nothing usable left, empty text included,
+// becomes "X". Building the Id is the only place this happens: mx writes the id exactly as the Id
+// holds it.
+//
+// Scrubbing is silent. To find out whether your text was already a legal id, compare it with the
+// id you built:
+//
+//     const auto id = Id{myText};
+//     if (id.value() != myText)
+//     {
+//         // myText was not a legal id; decide what to do about it
+//     }
+//
+// An id must also be unique within the document. Uniqueness is a property of the whole score, not
+// of one name, so Id cannot check it. An id you invent must not collide with one already in the
+// score.
+//
+// To write no id attribute at all, leave the std::optional that holds the Id empty.
+//
+// Copy, assign, compare, sort, and hash an Id the way you would any other value. Two Ids are equal
+// when their text is equal, and std::hash is specialized for Id, so an Id works as a key in both
+// std::map and std::unordered_map.
+class Id
+{
+  public:
+    Id(std::string text);
+    Id(const char *text);
+
+    Id(const Id &other);
+    Id(Id &&other) noexcept;
+    Id &operator=(const Id &other);
+    Id &operator=(Id &&other) noexcept;
+    ~Id();
+
+    const std::string &value() const;
+
+    bool operator==(const Id &other) const;
+    bool operator<(const Id &other) const;
+
+  private:
+    // Holds the same type mx writes the attribute with, which is why the text cannot be scrubbed a
+    // second time. The definition is private to mx.
+    class Impl;
+    explicit Id(std::shared_ptr<const Impl> impl);
+    friend struct IdAccess;
+
+    std::shared_ptr<const Impl> myImpl;
+};
+
+MXAPI_NOT_EQUALS_AND_VECTORS(Id);
+
+inline bool operator>(const Id &lhs, const Id &rhs)
+{
+    return rhs < lhs;
+}
+
+inline bool operator<=(const Id &lhs, const Id &rhs)
+{
+    return !(rhs < lhs);
+}
+
+inline bool operator>=(const Id &lhs, const Id &rhs)
+{
+    return !(lhs < rhs);
+}
+
+} // namespace api
+} // namespace mx
+
+namespace std
+{
+template <> struct hash<mx::api::Id>
+{
+    std::size_t operator()(const mx::api::Id &id) const noexcept
+    {
+        return std::hash<std::string>{}(id.value());
+    }
+};
+} // namespace std

--- a/src/include/mx/api/ImageData.h
+++ b/src/include/mx/api/ImageData.h
@@ -5,6 +5,7 @@
 #pragma once
 
 #include "mx/api/ApiCommon.h"
+#include "mx/api/Id.h"
 #include "mx/api/PositionData.h"
 
 #include <optional>
@@ -29,7 +30,7 @@ class ImageData
     std::optional<double> height;
     std::optional<double> width;
     PositionData positionData;
-    std::optional<std::string> id;
+    std::optional<Id> id;
 
     ImageData() : source{}, type{}, height{}, width{}, positionData{}, id{}
     {

--- a/src/include/mx/api/KeyData.h
+++ b/src/include/mx/api/KeyData.h
@@ -6,6 +6,9 @@
 #include "mx/api/ApiCommon.h"
 #include "mx/api/KeyComponent.h"
 
+#include <optional>
+#include <string>
+
 namespace mx
 {
 namespace api
@@ -121,9 +124,12 @@ struct KeyData
     // alterations. When custom is non-empty, then fifths and mode are ignored.
     std::vector<KeyComponent> nonTraditional;
 
+    // The <key> element's id attribute (see ApiCommon.h).
+    std::optional<std::string> id;
+
     KeyData()
         : fifths{0}, cancel{0}, cancelLocation{CancelLocation::unspecified}, mode{KeyMode::unspecified},
-          tickTimePosition{0}, staffIndex{INDEX_UNSPECIFIED}, nonTraditional{}
+          tickTimePosition{0}, staffIndex{INDEX_UNSPECIFIED}, nonTraditional{}, id{}
     {
     }
 };
@@ -136,6 +142,7 @@ MXAPI_EQUALS_MEMBER(mode)
 MXAPI_EQUALS_MEMBER(tickTimePosition)
 MXAPI_EQUALS_MEMBER(staffIndex)
 MXAPI_EQUALS_MEMBER(nonTraditional)
+MXAPI_EQUALS_MEMBER(id)
 MXAPI_EQUALS_END;
 
 MXAPI_NOT_EQUALS_AND_VECTORS(KeyData);

--- a/src/include/mx/api/KeyData.h
+++ b/src/include/mx/api/KeyData.h
@@ -4,6 +4,7 @@
 
 #pragma once
 #include "mx/api/ApiCommon.h"
+#include "mx/api/Id.h"
 #include "mx/api/KeyComponent.h"
 
 #include <optional>
@@ -124,8 +125,8 @@ struct KeyData
     // alterations. When custom is non-empty, then fifths and mode are ignored.
     std::vector<KeyComponent> nonTraditional;
 
-    // The <key> element's id attribute (see ApiCommon.h).
-    std::optional<std::string> id;
+    // The <key> element's id attribute (see Id.h).
+    std::optional<Id> id;
 
     KeyData()
         : fifths{0}, cancel{0}, cancelLocation{CancelLocation::unspecified}, mode{KeyMode::unspecified},

--- a/src/include/mx/api/LyricData.h
+++ b/src/include/mx/api/LyricData.h
@@ -5,6 +5,7 @@
 #pragma once
 
 #include "mx/api/ApiCommon.h"
+#include "mx/api/Id.h"
 #include "mx/api/PositionData.h"
 #include "mx/api/PrintData.h"
 
@@ -54,8 +55,8 @@ class LyricData
     PositionData positionData;
     PrintData printData;
 
-    // The <lyric> element's id attribute (see ApiCommon.h).
-    std::optional<std::string> id;
+    // The <lyric> element's id attribute (see Id.h).
+    std::optional<Id> id;
 };
 
 MXAPI_EQUALS_BEGIN(LyricData)

--- a/src/include/mx/api/LyricData.h
+++ b/src/include/mx/api/LyricData.h
@@ -8,6 +8,9 @@
 #include "mx/api/PositionData.h"
 #include "mx/api/PrintData.h"
 
+#include <optional>
+#include <string>
+
 namespace mx
 {
 namespace api
@@ -38,7 +41,7 @@ class LyricData
   public:
     LyricData()
         : text{}, verseNumber{}, verseName{}, syllabic{LyricSyllabic::unspecified}, hasExtend{false},
-          extendType{LyricExtendType::unspecified}, positionData{}, printData{}
+          extendType{LyricExtendType::unspecified}, positionData{}, printData{}, id{}
     {
     }
 
@@ -50,6 +53,9 @@ class LyricData
     LyricExtendType extendType;
     PositionData positionData;
     PrintData printData;
+
+    // The <lyric> element's id attribute (see ApiCommon.h).
+    std::optional<std::string> id;
 };
 
 MXAPI_EQUALS_BEGIN(LyricData)
@@ -61,6 +67,7 @@ MXAPI_EQUALS_MEMBER(hasExtend)
 MXAPI_EQUALS_MEMBER(extendType)
 MXAPI_EQUALS_MEMBER(positionData)
 MXAPI_EQUALS_MEMBER(printData)
+MXAPI_EQUALS_MEMBER(id)
 MXAPI_EQUALS_END;
 MXAPI_NOT_EQUALS_AND_VECTORS(LyricData);
 } // namespace api

--- a/src/include/mx/api/MarkDataChoice.h
+++ b/src/include/mx/api/MarkDataChoice.h
@@ -6,6 +6,7 @@
 
 #include "mx/api/ApiCommon.h"
 #include "mx/api/DynamicsData.h"
+#include "mx/api/Id.h"
 
 #include <optional>
 #include <string>
@@ -59,7 +60,7 @@ struct ArpeggiateMarkData
     Bool unbroken = Bool::unspecified;
 
     // The element's `id` attribute (MusicXML 3.1).
-    std::optional<std::string> id;
+    std::optional<Id> id;
 };
 
 MXAPI_EQUALS_BEGIN(ArpeggiateMarkData)
@@ -89,7 +90,7 @@ struct NonArpeggiateMarkData
     std::optional<int> number;
 
     // The element's `id` attribute (MusicXML 3.1).
-    std::optional<std::string> id;
+    std::optional<Id> id;
 };
 
 MXAPI_EQUALS_BEGIN(NonArpeggiateMarkData)
@@ -126,7 +127,7 @@ struct OtherNotationMarkData
     OtherNotationType type = OtherNotationType::single;
     std::optional<int> number;
     std::optional<std::string> smufl;
-    std::optional<std::string> id;
+    std::optional<Id> id;
 };
 
 MXAPI_EQUALS_BEGIN(OtherNotationMarkData)

--- a/src/include/mx/api/MeasureData.h
+++ b/src/include/mx/api/MeasureData.h
@@ -111,6 +111,9 @@ class MeasureData
     // before this field existed.
     std::vector<TransposeData> transpositions;
 
+    // The <measure> element's id attribute (see ApiCommon.h).
+    std::optional<std::string> id;
+
     MeasureData()
         : staves{}, timeSignature{}, number{}, measureNumbering{MeasureNumbering::unspecified},
           measureNumberingMultipleRestAlways{Bool::unspecified}, measureNumberingMultipleRestRange{Bool::unspecified},
@@ -141,6 +144,7 @@ MXAPI_EQUALS_MEMBER(keys)
 MXAPI_EQUALS_MEMBER(barlines)
 MXAPI_EQUALS_MEMBER(partSymbol)
 MXAPI_EQUALS_MEMBER(transpositions)
+MXAPI_EQUALS_MEMBER(id)
 MXAPI_EQUALS_END;
 MXAPI_NOT_EQUALS_AND_VECTORS(MeasureData);
 } // namespace api

--- a/src/include/mx/api/MeasureData.h
+++ b/src/include/mx/api/MeasureData.h
@@ -6,6 +6,7 @@
 
 #include "mx/api/ApiCommon.h"
 #include "mx/api/BarlineData.h"
+#include "mx/api/Id.h"
 #include "mx/api/KeyData.h"
 #include "mx/api/PartSymbolData.h"
 #include "mx/api/StaffData.h"
@@ -111,8 +112,8 @@ class MeasureData
     // before this field existed.
     std::vector<TransposeData> transpositions;
 
-    // The <measure> element's id attribute (see ApiCommon.h).
-    std::optional<std::string> id;
+    // The <measure> element's id attribute (see Id.h).
+    std::optional<Id> id;
 
     MeasureData()
         : staves{}, timeSignature{}, number{}, measureNumbering{MeasureNumbering::unspecified},

--- a/src/include/mx/api/NoteData.h
+++ b/src/include/mx/api/NoteData.h
@@ -6,6 +6,7 @@
 
 #include "mx/api/CurveData.h"
 #include "mx/api/DurationData.h"
+#include "mx/api/Id.h"
 #include "mx/api/LyricData.h"
 #include "mx/api/NoteAttachmentData.h"
 #include "mx/api/PitchData.h"
@@ -82,8 +83,8 @@ struct TieLetRing
     bool isColorSpecified;
     ColorData colorData;
 
-    // The <tied> element's id attribute (see ApiCommon.h).
-    std::optional<std::string> id;
+    // The <tied> element's id attribute (see Id.h).
+    std::optional<Id> id;
 
     TieLetRing()
         : positionData{}, curveOrientation{CurveOrientation::unspecified}, isColorSpecified{false}, colorData{}, id{}
@@ -208,8 +209,8 @@ class NoteData
     // will be parsed into these strings. do not use commas in your misc
     // data strings as these are the delimiter
 
-    // The <note> element's id attribute (see ApiCommon.h).
-    std::optional<std::string> id;
+    // The <note> element's id attribute (see Id.h).
+    std::optional<Id> id;
     std::vector<std::string> miscData;
 };
 

--- a/src/include/mx/api/NoteData.h
+++ b/src/include/mx/api/NoteData.h
@@ -82,7 +82,11 @@ struct TieLetRing
     bool isColorSpecified;
     ColorData colorData;
 
-    TieLetRing() : positionData{}, curveOrientation{CurveOrientation::unspecified}, isColorSpecified{false}, colorData{}
+    // The <tied> element's id attribute (see ApiCommon.h).
+    std::optional<std::string> id;
+
+    TieLetRing()
+        : positionData{}, curveOrientation{CurveOrientation::unspecified}, isColorSpecified{false}, colorData{}, id{}
     {
     }
 };
@@ -92,6 +96,7 @@ MXAPI_EQUALS_MEMBER(positionData)
 MXAPI_EQUALS_MEMBER(curveOrientation)
 MXAPI_EQUALS_MEMBER(isColorSpecified)
 MXAPI_EQUALS_MEMBER(colorData)
+MXAPI_EQUALS_MEMBER(id)
 MXAPI_EQUALS_END;
 MXAPI_NOT_EQUALS_AND_VECTORS(TieLetRing);
 
@@ -202,6 +207,9 @@ class NoteData
     // similarly when parsing if we see ##misc-data## in this element, it
     // will be parsed into these strings. do not use commas in your misc
     // data strings as these are the delimiter
+
+    // The <note> element's id attribute (see ApiCommon.h).
+    std::optional<std::string> id;
     std::vector<std::string> miscData;
 };
 
@@ -234,6 +242,7 @@ MXAPI_EQUALS_MEMBER(printData)
 MXAPI_EQUALS_MEMBER(noteAttachmentData)
 MXAPI_EQUALS_MEMBER(lyrics)
 MXAPI_EQUALS_MEMBER(miscData)
+MXAPI_EQUALS_MEMBER(id)
 MXAPI_EQUALS_END;
 MXAPI_NOT_EQUALS_AND_VECTORS(NoteData);
 } // namespace api

--- a/src/include/mx/api/OtherDirectionData.h
+++ b/src/include/mx/api/OtherDirectionData.h
@@ -7,6 +7,7 @@
 #include "mx/api/ApiCommon.h"
 #include "mx/api/ColorData.h"
 #include "mx/api/FontData.h"
+#include "mx/api/Id.h"
 #include "mx/api/PositionData.h"
 
 #include <optional>
@@ -30,7 +31,7 @@ class OtherDirectionData
     PositionData positionData;
     FontData fontData;
     std::optional<ColorData> color;
-    std::optional<std::string> id;
+    std::optional<Id> id;
 
     OtherDirectionData() : text{}, printObject{Bool::unspecified}, smufl{}, positionData{}, fontData{}, color{}, id{}
     {

--- a/src/include/mx/api/PedalLineData.h
+++ b/src/include/mx/api/PedalLineData.h
@@ -5,6 +5,7 @@
 #pragma once
 
 #include "mx/api/ApiCommon.h"
+#include "mx/api/Id.h"
 #include "mx/api/PositionData.h"
 
 #include <optional>
@@ -53,8 +54,8 @@ struct PedalLineData
     int tickTimePosition;
     PositionData positionData;
 
-    // The <pedal> element's id attribute (see ApiCommon.h).
-    std::optional<std::string> id;
+    // The <pedal> element's id attribute (see Id.h).
+    std::optional<Id> id;
 
     PedalLineData() : kind{PedalLineKind::unspecified}, tickTimePosition{0}, positionData{}, id{}
     {

--- a/src/include/mx/api/PedalLineData.h
+++ b/src/include/mx/api/PedalLineData.h
@@ -7,6 +7,9 @@
 #include "mx/api/ApiCommon.h"
 #include "mx/api/PositionData.h"
 
+#include <optional>
+#include <string>
+
 namespace mx
 {
 namespace api
@@ -50,11 +53,14 @@ struct PedalLineData
     int tickTimePosition;
     PositionData positionData;
 
-    PedalLineData() : kind{PedalLineKind::unspecified}, tickTimePosition{0}, positionData{}
+    // The <pedal> element's id attribute (see ApiCommon.h).
+    std::optional<std::string> id;
+
+    PedalLineData() : kind{PedalLineKind::unspecified}, tickTimePosition{0}, positionData{}, id{}
     {
     }
 
-    PedalLineData(PedalLineKind inKind) : kind{inKind}, tickTimePosition{0}, positionData{}
+    PedalLineData(PedalLineKind inKind) : kind{inKind}, tickTimePosition{0}, positionData{}, id{}
     {
     }
 };
@@ -63,6 +69,7 @@ MXAPI_EQUALS_BEGIN(PedalLineData)
 MXAPI_EQUALS_MEMBER(kind)
 MXAPI_EQUALS_MEMBER(tickTimePosition)
 MXAPI_EQUALS_MEMBER(positionData)
+MXAPI_EQUALS_MEMBER(id)
 MXAPI_EQUALS_END;
 MXAPI_NOT_EQUALS_AND_VECTORS(PedalLineData);
 } // namespace api

--- a/src/include/mx/api/PercussionData.h
+++ b/src/include/mx/api/PercussionData.h
@@ -7,6 +7,7 @@
 #include "mx/api/ApiCommon.h"
 #include "mx/api/ColorData.h"
 #include "mx/api/FontData.h"
+#include "mx/api/Id.h"
 #include "mx/api/PositionData.h"
 
 #include <optional>
@@ -482,7 +483,7 @@ class PercussionData
     PositionData positionData;
     FontData fontData;
     std::optional<ColorData> color;
-    std::optional<std::string> id;
+    std::optional<Id> id;
 
     PercussionData() : choice{}, enclosure{Enclosure::unspecified}, positionData{}, fontData{}, color{}, id{}
     {

--- a/src/include/mx/api/PrincipalVoiceData.h
+++ b/src/include/mx/api/PrincipalVoiceData.h
@@ -7,6 +7,7 @@
 #include "mx/api/ApiCommon.h"
 #include "mx/api/ColorData.h"
 #include "mx/api/FontData.h"
+#include "mx/api/Id.h"
 #include "mx/api/PositionData.h"
 
 #include <optional>
@@ -49,7 +50,7 @@ class PrincipalVoiceData
     PositionData positionData;
     FontData fontData;
     std::optional<ColorData> color;
-    std::optional<std::string> id;
+    std::optional<Id> id;
 
     PrincipalVoiceData()
         : type{PrincipalVoiceType::start}, symbol{PrincipalVoiceSymbol::hauptstimme}, text{}, positionData{},

--- a/src/include/mx/api/RehearsalData.h
+++ b/src/include/mx/api/RehearsalData.h
@@ -7,6 +7,7 @@
 #include "mx/api/ApiCommon.h"
 #include "mx/api/ColorData.h"
 #include "mx/api/FontData.h"
+#include "mx/api/Id.h"
 #include "mx/api/PositionData.h"
 
 #include <optional>
@@ -35,8 +36,8 @@ class RehearsalData
     // and says which edge of the text the position refers to; MusicXML defines both.
     HorizontalAlignment justify;
 
-    // The <rehearsal> element's id attribute (see ApiCommon.h).
-    std::optional<std::string> id;
+    // The <rehearsal> element's id attribute (see Id.h).
+    std::optional<Id> id;
 
     RehearsalData()
         : text{}, positionData{}, isColorSpecified{false}, colorData{}, fontData{}, enclosure{Enclosure::unspecified},

--- a/src/include/mx/api/RehearsalData.h
+++ b/src/include/mx/api/RehearsalData.h
@@ -9,6 +9,9 @@
 #include "mx/api/FontData.h"
 #include "mx/api/PositionData.h"
 
+#include <optional>
+#include <string>
+
 namespace mx
 {
 namespace api
@@ -32,9 +35,12 @@ class RehearsalData
     // and says which edge of the text the position refers to; MusicXML defines both.
     HorizontalAlignment justify;
 
+    // The <rehearsal> element's id attribute (see ApiCommon.h).
+    std::optional<std::string> id;
+
     RehearsalData()
         : text{}, positionData{}, isColorSpecified{false}, colorData{}, fontData{}, enclosure{Enclosure::unspecified},
-          justify{HorizontalAlignment::unspecified}
+          justify{HorizontalAlignment::unspecified}, id{}
     {
     }
 };
@@ -47,6 +53,7 @@ MXAPI_EQUALS_MEMBER(colorData)
 MXAPI_EQUALS_MEMBER(fontData)
 MXAPI_EQUALS_MEMBER(enclosure)
 MXAPI_EQUALS_MEMBER(justify)
+MXAPI_EQUALS_MEMBER(id)
 MXAPI_EQUALS_END;
 MXAPI_NOT_EQUALS_AND_VECTORS(RehearsalData);
 } // namespace api

--- a/src/include/mx/api/ScordaturaData.h
+++ b/src/include/mx/api/ScordaturaData.h
@@ -5,6 +5,7 @@
 #pragma once
 
 #include "mx/api/ApiCommon.h"
+#include "mx/api/Id.h"
 #include "mx/api/PitchData.h"
 
 #include <optional>
@@ -49,7 +50,7 @@ class ScordaturaData
 {
   public:
     std::vector<AccordData> accords;
-    std::optional<std::string> id;
+    std::optional<Id> id;
 
     ScordaturaData() : accords{}, id{}
     {

--- a/src/include/mx/api/SegnoData.h
+++ b/src/include/mx/api/SegnoData.h
@@ -7,8 +7,10 @@
 #include "mx/api/ApiCommon.h"
 #include "mx/api/ColorData.h"
 #include "mx/api/FontData.h"
+#include "mx/api/Id.h"
 #include "mx/api/PositionData.h"
 
+#include <optional>
 #include <string>
 
 namespace mx
@@ -28,12 +30,12 @@ class SegnoData
     ColorData colorData;
     bool isSmuflSpecified;
     std::string smufl;
-    bool isIdSpecified;
-    std::string id;
+
+    // The <segno> element's id attribute (see Id.h).
+    std::optional<Id> id;
 
     SegnoData()
-        : positionData{}, fontData{}, isColorSpecified{false}, colorData{}, isSmuflSpecified{false}, smufl{},
-          isIdSpecified{false}, id{}
+        : positionData{}, fontData{}, isColorSpecified{false}, colorData{}, isSmuflSpecified{false}, smufl{}, id{}
     {
     }
 };
@@ -45,7 +47,6 @@ MXAPI_EQUALS_MEMBER(isColorSpecified)
 MXAPI_EQUALS_MEMBER(colorData)
 MXAPI_EQUALS_MEMBER(isSmuflSpecified)
 MXAPI_EQUALS_MEMBER(smufl)
-MXAPI_EQUALS_MEMBER(isIdSpecified)
 MXAPI_EQUALS_MEMBER(id)
 MXAPI_EQUALS_END;
 MXAPI_NOT_EQUALS_AND_VECTORS(SegnoData);

--- a/src/include/mx/api/SoundData.h
+++ b/src/include/mx/api/SoundData.h
@@ -5,6 +5,7 @@
 #pragma once
 
 #include "mx/api/ApiCommon.h"
+#include "mx/api/Id.h"
 
 #include <optional>
 #include <string>
@@ -87,8 +88,8 @@ struct SoundData
 
     std::optional<SwingData> swing;
 
-    // The <sound> element's id attribute (see ApiCommon.h).
-    std::optional<std::string> id;
+    // The <sound> element's id attribute (see Id.h).
+    std::optional<Id> id;
 
     SoundData()
         : tempo{DOUBLE_UNSPECIFIED}, dynamics{DOUBLE_UNSPECIFIED}, dacapo{Bool::unspecified},

--- a/src/include/mx/api/SoundData.h
+++ b/src/include/mx/api/SoundData.h
@@ -87,10 +87,13 @@ struct SoundData
 
     std::optional<SwingData> swing;
 
+    // The <sound> element's id attribute (see ApiCommon.h).
+    std::optional<std::string> id;
+
     SoundData()
         : tempo{DOUBLE_UNSPECIFIED}, dynamics{DOUBLE_UNSPECIFIED}, dacapo{Bool::unspecified},
           forwardRepeat{Bool::unspecified}, pizzicato{Bool::unspecified}, segno{}, dalsegno{}, coda{}, tocoda{}, fine{},
-          swing{}
+          swing{}, id{}
     {
     }
 
@@ -98,7 +101,7 @@ struct SoundData
     {
         return tempo >= 0.0 || dynamics >= 0.0 || dacapo != Bool::unspecified || forwardRepeat != Bool::unspecified ||
                pizzicato != Bool::unspecified || !segno.empty() || !dalsegno.empty() || !coda.empty() ||
-               !tocoda.empty() || !fine.empty() || swing.has_value();
+               !tocoda.empty() || !fine.empty() || swing.has_value() || id.has_value();
     }
 };
 
@@ -123,6 +126,7 @@ MXAPI_EQUALS_MEMBER(coda)
 MXAPI_EQUALS_MEMBER(tocoda)
 MXAPI_EQUALS_MEMBER(fine)
 MXAPI_EQUALS_MEMBER(swing)
+MXAPI_EQUALS_MEMBER(id)
 MXAPI_EQUALS_END;
 MXAPI_NOT_EQUALS_AND_VECTORS(SoundData);
 } // namespace api

--- a/src/include/mx/api/SpannerData.h
+++ b/src/include/mx/api/SpannerData.h
@@ -5,6 +5,7 @@
 #pragma once
 
 #include "mx/api/ApiCommon.h"
+#include "mx/api/Id.h"
 #include "mx/api/LineData.h"
 #include "mx/api/PositionData.h"
 #include "mx/api/PrintData.h"
@@ -27,8 +28,8 @@ struct SpannerStart
     LineData lineData;
 
     // The id attribute of the element this spanner end is written as -- <bracket>,
-    // <dashes>, or <octave-shift> (see ApiCommon.h).
-    std::optional<std::string> id;
+    // <dashes>, or <octave-shift> (see Id.h).
+    std::optional<Id> id;
 
     SpannerStart() : number{}, tickTimePosition{0}, positionData{}, printData{}, lineData{}, id{}
     {
@@ -43,8 +44,8 @@ struct SpannerStop
     LineData lineData;
 
     // The id attribute of the element this spanner end is written as -- <bracket>,
-    // <dashes>, or <octave-shift> (see ApiCommon.h).
-    std::optional<std::string> id;
+    // <dashes>, or <octave-shift> (see Id.h).
+    std::optional<Id> id;
 
     SpannerStop() : number{}, tickTimePosition{0}, positionData{}, lineData{}, id{}
     {

--- a/src/include/mx/api/SpannerData.h
+++ b/src/include/mx/api/SpannerData.h
@@ -10,6 +10,7 @@
 #include "mx/api/PrintData.h"
 #include "mx/api/SpannerNumber.h"
 
+#include <optional>
 #include <string>
 
 namespace mx
@@ -25,7 +26,11 @@ struct SpannerStart
     PrintData printData;
     LineData lineData;
 
-    SpannerStart() : number{}, tickTimePosition{0}, positionData{}, printData{}, lineData{}
+    // The id attribute of the element this spanner end is written as -- <bracket>,
+    // <dashes>, or <octave-shift> (see ApiCommon.h).
+    std::optional<std::string> id;
+
+    SpannerStart() : number{}, tickTimePosition{0}, positionData{}, printData{}, lineData{}, id{}
     {
     }
 };
@@ -37,7 +42,11 @@ struct SpannerStop
     PositionData positionData;
     LineData lineData;
 
-    SpannerStop() : number{}, tickTimePosition{0}, positionData{}, lineData{}
+    // The id attribute of the element this spanner end is written as -- <bracket>,
+    // <dashes>, or <octave-shift> (see ApiCommon.h).
+    std::optional<std::string> id;
+
+    SpannerStop() : number{}, tickTimePosition{0}, positionData{}, lineData{}, id{}
     {
     }
 };
@@ -48,6 +57,7 @@ MXAPI_EQUALS_MEMBER(tickTimePosition)
 MXAPI_EQUALS_MEMBER(positionData)
 MXAPI_EQUALS_MEMBER(printData)
 MXAPI_EQUALS_MEMBER(lineData)
+MXAPI_EQUALS_MEMBER(id)
 MXAPI_EQUALS_END;
 MXAPI_NOT_EQUALS_AND_VECTORS(SpannerStart);
 
@@ -56,6 +66,7 @@ MXAPI_EQUALS_MEMBER(number)
 MXAPI_EQUALS_MEMBER(tickTimePosition)
 MXAPI_EQUALS_MEMBER(positionData)
 MXAPI_EQUALS_MEMBER(lineData)
+MXAPI_EQUALS_MEMBER(id)
 MXAPI_EQUALS_END;
 MXAPI_NOT_EQUALS_AND_VECTORS(SpannerStop);
 } // namespace api

--- a/src/include/mx/api/StaffDivideData.h
+++ b/src/include/mx/api/StaffDivideData.h
@@ -7,6 +7,7 @@
 #include "mx/api/ApiCommon.h"
 #include "mx/api/ColorData.h"
 #include "mx/api/FontData.h"
+#include "mx/api/Id.h"
 #include "mx/api/PositionData.h"
 
 #include <optional>
@@ -37,7 +38,7 @@ class StaffDivideData
     PositionData positionData;
     FontData fontData;
     std::optional<ColorData> color;
-    std::optional<std::string> id;
+    std::optional<Id> id;
 
     StaffDivideData() : type{StaffDivideType::down}, positionData{}, fontData{}, color{}, id{}
     {

--- a/src/include/mx/api/StringMuteData.h
+++ b/src/include/mx/api/StringMuteData.h
@@ -7,6 +7,7 @@
 #include "mx/api/ApiCommon.h"
 #include "mx/api/ColorData.h"
 #include "mx/api/FontData.h"
+#include "mx/api/Id.h"
 #include "mx/api/PositionData.h"
 
 #include <optional>
@@ -34,7 +35,7 @@ class StringMuteData
     PositionData positionData;
     FontData fontData;
     std::optional<ColorData> color;
-    std::optional<std::string> id;
+    std::optional<Id> id;
 
     StringMuteData() : type{StringMuteType::on}, positionData{}, fontData{}, color{}, id{}
     {

--- a/src/include/mx/api/SymbolData.h
+++ b/src/include/mx/api/SymbolData.h
@@ -41,9 +41,12 @@ class SymbolData
     // symbol-formatting attributes mirror the text-formatting ones on `<words>`.
     HorizontalAlignment justify;
 
+    // The <symbol> element's id attribute (see ApiCommon.h).
+    std::optional<std::string> id;
+
     SymbolData()
         : smufl{}, positionData{}, fontData{}, color{}, enclosure{Enclosure::unspecified},
-          justify{HorizontalAlignment::unspecified}
+          justify{HorizontalAlignment::unspecified}, id{}
     {
     }
 };
@@ -55,6 +58,7 @@ MXAPI_EQUALS_MEMBER(fontData)
 MXAPI_EQUALS_MEMBER(color)
 MXAPI_EQUALS_MEMBER(enclosure)
 MXAPI_EQUALS_MEMBER(justify)
+MXAPI_EQUALS_MEMBER(id)
 MXAPI_EQUALS_END;
 MXAPI_NOT_EQUALS_AND_VECTORS(SymbolData);
 } // namespace api

--- a/src/include/mx/api/SymbolData.h
+++ b/src/include/mx/api/SymbolData.h
@@ -7,6 +7,7 @@
 #include "mx/api/ApiCommon.h"
 #include "mx/api/ColorData.h"
 #include "mx/api/FontData.h"
+#include "mx/api/Id.h"
 #include "mx/api/PositionData.h"
 
 #include <optional>
@@ -41,8 +42,8 @@ class SymbolData
     // symbol-formatting attributes mirror the text-formatting ones on `<words>`.
     HorizontalAlignment justify;
 
-    // The <symbol> element's id attribute (see ApiCommon.h).
-    std::optional<std::string> id;
+    // The <symbol> element's id attribute (see Id.h).
+    std::optional<Id> id;
 
     SymbolData()
         : smufl{}, positionData{}, fontData{}, color{}, enclosure{Enclosure::unspecified},

--- a/src/include/mx/api/TempoData.h
+++ b/src/include/mx/api/TempoData.h
@@ -7,6 +7,7 @@
 #include "mx/api/ColorData.h"
 #include "mx/api/DurationData.h"
 #include "mx/api/FontData.h"
+#include "mx/api/Id.h"
 #include "mx/api/NoteRelationData.h"
 #include "mx/api/PositionData.h"
 #include "mx/api/PrintData.h"
@@ -126,7 +127,7 @@ class TempoData
     PositionData positionData;
     FontData fontData;
     std::optional<ColorData> color;
-    std::optional<std::string> id;
+    std::optional<Id> id;
     HorizontalAlignment justify;
     Bool printObject;
     TempoChoice choice;

--- a/src/include/mx/api/TimeChoice.h
+++ b/src/include/mx/api/TimeChoice.h
@@ -8,6 +8,8 @@
 #include "mx/api/ComplexTimeSignature.h"
 #include "mx/api/TimeSignatureData.h"
 
+#include <optional>
+#include <string>
 #include <variant>
 
 namespace mx
@@ -56,6 +58,10 @@ class TimeChoice
 
     // Print/hide the time signature (<time print-object=...>). Ignored when isImplicit.
     Bool display{Bool::unspecified};
+
+    // The <time> element's id attribute (see ApiCommon.h). Only the measure that states the time
+    // signature carries it; a measure that inherits the signature (isImplicit) has no id.
+    std::optional<std::string> id;
 
     // Defaults to a simple, implicit 4/4.
     TimeChoice();

--- a/src/include/mx/api/TimeChoice.h
+++ b/src/include/mx/api/TimeChoice.h
@@ -6,6 +6,7 @@
 
 #include "mx/api/ApiCommon.h"
 #include "mx/api/ComplexTimeSignature.h"
+#include "mx/api/Id.h"
 #include "mx/api/TimeSignatureData.h"
 
 #include <optional>
@@ -59,9 +60,9 @@ class TimeChoice
     // Print/hide the time signature (<time print-object=...>). Ignored when isImplicit.
     Bool display{Bool::unspecified};
 
-    // The <time> element's id attribute (see ApiCommon.h). Only the measure that states the time
+    // The <time> element's id attribute (see Id.h). Only the measure that states the time
     // signature carries it; a measure that inherits the signature (isImplicit) has no id.
-    std::optional<std::string> id;
+    std::optional<Id> id;
 
     // Defaults to a simple, implicit 4/4.
     TimeChoice();

--- a/src/include/mx/api/TransposeData.h
+++ b/src/include/mx/api/TransposeData.h
@@ -5,6 +5,7 @@
 #pragma once
 
 #include "mx/api/ApiCommon.h"
+#include "mx/api/Id.h"
 
 #include <optional>
 #include <string>
@@ -73,8 +74,8 @@ class TransposeData
     /// Supports a transposition change somewhere other than at the start of a measure.
     int tickTimePosition = 0;
 
-    /// The <transpose> element's id attribute (see ApiCommon.h).
-    std::optional<std::string> id;
+    /// The <transpose> element's id attribute (see Id.h).
+    std::optional<Id> id;
 
     /// If both chromatic and diatonic are zero, then TransposeData is unused (i.e. it need
     /// not be encoded in the MusicXML output).

--- a/src/include/mx/api/TransposeData.h
+++ b/src/include/mx/api/TransposeData.h
@@ -6,6 +6,9 @@
 
 #include "mx/api/ApiCommon.h"
 
+#include <optional>
+#include <string>
+
 namespace mx
 {
 namespace api
@@ -70,6 +73,9 @@ class TransposeData
     /// Supports a transposition change somewhere other than at the start of a measure.
     int tickTimePosition = 0;
 
+    /// The <transpose> element's id attribute (see ApiCommon.h).
+    std::optional<std::string> id;
+
     /// If both chromatic and diatonic are zero, then TransposeData is unused (i.e. it need
     /// not be encoded in the MusicXML output).
     inline bool isUsed() const
@@ -83,6 +89,7 @@ MXAPI_EQUALS_MEMBER(chromatic)
 MXAPI_EQUALS_MEMBER(diatonic)
 MXAPI_EQUALS_MEMBER(staffIndex)
 MXAPI_EQUALS_MEMBER(tickTimePosition)
+MXAPI_EQUALS_MEMBER(id)
 MXAPI_EQUALS_END;
 MXAPI_NOT_EQUALS_AND_VECTORS(TransposeData);
 } // namespace api

--- a/src/include/mx/api/TupletData.h
+++ b/src/include/mx/api/TupletData.h
@@ -9,6 +9,9 @@
 #include "mx/api/LineData.h"
 #include "mx/api/PositionData.h"
 
+#include <optional>
+#include <string>
+
 namespace mx
 {
 namespace api
@@ -46,12 +49,15 @@ class TupletStart
 
     Bool bracket;
 
+    // The <tuplet> element's id attribute (see ApiCommon.h).
+    std::optional<std::string> id;
+
     TupletStart()
         : numberLevel{NUMBER_LEVEL_UNSPECIFIED}, positionData{}, actualNumber{VALUE_UNSPECIFIED},
           actualDurationName{api::DurationName::unspecified}, actualDots{VALUE_UNSPECIFIED},
           normalNumber{VALUE_UNSPECIFIED}, normalDurationName{api::DurationName::unspecified},
           normalDots{VALUE_UNSPECIFIED}, showActualNumber{Bool::unspecified}, showNormalNumber{Bool::unspecified},
-          bracket{Bool::unspecified}
+          bracket{Bool::unspecified}, id{}
     {
     }
 };
@@ -65,7 +71,10 @@ class TupletStop
 
     PositionData positionData;
 
-    TupletStop() : numberLevel{NUMBER_LEVEL_UNSPECIFIED}, positionData{}
+    // The <tuplet> element's id attribute (see ApiCommon.h).
+    std::optional<std::string> id;
+
+    TupletStop() : numberLevel{NUMBER_LEVEL_UNSPECIFIED}, positionData{}, id{}
     {
     }
 };
@@ -82,12 +91,14 @@ MXAPI_EQUALS_MEMBER(normalDots)
 MXAPI_EQUALS_MEMBER(showActualNumber)
 MXAPI_EQUALS_MEMBER(showNormalNumber)
 MXAPI_EQUALS_MEMBER(bracket)
+MXAPI_EQUALS_MEMBER(id)
 MXAPI_EQUALS_END;
 MXAPI_NOT_EQUALS_AND_VECTORS(TupletStart);
 
 MXAPI_EQUALS_BEGIN(TupletStop)
 MXAPI_EQUALS_MEMBER(numberLevel)
 MXAPI_EQUALS_MEMBER(positionData)
+MXAPI_EQUALS_MEMBER(id)
 MXAPI_EQUALS_END;
 MXAPI_NOT_EQUALS_AND_VECTORS(TupletStop);
 } // namespace api

--- a/src/include/mx/api/TupletData.h
+++ b/src/include/mx/api/TupletData.h
@@ -6,6 +6,7 @@
 
 #include "mx/api/ApiCommon.h"
 #include "mx/api/DurationData.h"
+#include "mx/api/Id.h"
 #include "mx/api/LineData.h"
 #include "mx/api/PositionData.h"
 
@@ -49,8 +50,8 @@ class TupletStart
 
     Bool bracket;
 
-    // The <tuplet> element's id attribute (see ApiCommon.h).
-    std::optional<std::string> id;
+    // The <tuplet> element's id attribute (see Id.h).
+    std::optional<Id> id;
 
     TupletStart()
         : numberLevel{NUMBER_LEVEL_UNSPECIFIED}, positionData{}, actualNumber{VALUE_UNSPECIFIED},
@@ -71,8 +72,8 @@ class TupletStop
 
     PositionData positionData;
 
-    // The <tuplet> element's id attribute (see ApiCommon.h).
-    std::optional<std::string> id;
+    // The <tuplet> element's id attribute (see Id.h).
+    std::optional<Id> id;
 
     TupletStop() : numberLevel{NUMBER_LEVEL_UNSPECIFIED}, positionData{}, id{}
     {

--- a/src/include/mx/api/WedgeData.h
+++ b/src/include/mx/api/WedgeData.h
@@ -10,6 +10,9 @@
 #include "mx/api/PositionData.h"
 #include "mx/api/SpannerNumber.h"
 
+#include <optional>
+#include <string>
+
 namespace mx
 {
 namespace api
@@ -32,9 +35,12 @@ struct WedgeStart
     bool isColorSpecified;
     ColorData colorData;
 
+    // The <wedge> element's id attribute (see ApiCommon.h).
+    std::optional<std::string> id;
+
     WedgeStart()
         : number{}, wedgeType{WedgeType::unspecified}, isSpreadSpecified{false}, spread{0.0}, lineData{},
-          positionData{}, isColorSpecified{false}, colorData{}
+          positionData{}, isColorSpecified{false}, colorData{}, id{}
     {
     }
 };
@@ -46,7 +52,10 @@ struct WedgeStop
     bool isSpreadSpecified;
     double spread;
 
-    WedgeStop() : number{}, positionData{}, isSpreadSpecified{false}, spread{0.0}
+    // The <wedge> element's id attribute (see ApiCommon.h).
+    std::optional<std::string> id;
+
+    WedgeStop() : number{}, positionData{}, isSpreadSpecified{false}, spread{0.0}, id{}
     {
     }
 };
@@ -60,6 +69,7 @@ MXAPI_EQUALS_MEMBER(lineData)
 MXAPI_EQUALS_MEMBER(positionData)
 MXAPI_EQUALS_MEMBER(isColorSpecified)
 MXAPI_EQUALS_MEMBER(colorData)
+MXAPI_EQUALS_MEMBER(id)
 MXAPI_EQUALS_END;
 MXAPI_NOT_EQUALS_AND_VECTORS(WedgeStart);
 
@@ -68,6 +78,7 @@ MXAPI_EQUALS_MEMBER(number)
 MXAPI_EQUALS_MEMBER(positionData)
 MXAPI_EQUALS_MEMBER(isSpreadSpecified)
 MXAPI_EQUALS_MEMBER(spread)
+MXAPI_EQUALS_MEMBER(id)
 MXAPI_EQUALS_END;
 MXAPI_NOT_EQUALS_AND_VECTORS(WedgeStop);
 } // namespace api

--- a/src/include/mx/api/WedgeData.h
+++ b/src/include/mx/api/WedgeData.h
@@ -6,6 +6,7 @@
 
 #include "mx/api/ApiCommon.h"
 #include "mx/api/ColorData.h"
+#include "mx/api/Id.h"
 #include "mx/api/LineData.h"
 #include "mx/api/PositionData.h"
 #include "mx/api/SpannerNumber.h"
@@ -35,8 +36,8 @@ struct WedgeStart
     bool isColorSpecified;
     ColorData colorData;
 
-    // The <wedge> element's id attribute (see ApiCommon.h).
-    std::optional<std::string> id;
+    // The <wedge> element's id attribute (see Id.h).
+    std::optional<Id> id;
 
     WedgeStart()
         : number{}, wedgeType{WedgeType::unspecified}, isSpreadSpecified{false}, spread{0.0}, lineData{},
@@ -52,8 +53,8 @@ struct WedgeStop
     bool isSpreadSpecified;
     double spread;
 
-    // The <wedge> element's id attribute (see ApiCommon.h).
-    std::optional<std::string> id;
+    // The <wedge> element's id attribute (see Id.h).
+    std::optional<Id> id;
 
     WedgeStop() : number{}, positionData{}, isSpreadSpecified{false}, spread{0.0}, id{}
     {

--- a/src/include/mx/api/WordsData.h
+++ b/src/include/mx/api/WordsData.h
@@ -7,6 +7,7 @@
 #include "mx/api/ApiCommon.h"
 #include "mx/api/ColorData.h"
 #include "mx/api/FontData.h"
+#include "mx/api/Id.h"
 #include "mx/api/PositionData.h"
 
 #include <optional>
@@ -38,8 +39,8 @@ class WordsData
     // block against its anchor point; MusicXML defines both attributes on `<words>`.
     HorizontalAlignment justify;
 
-    // The <words> element's id attribute (see ApiCommon.h).
-    std::optional<std::string> id;
+    // The <words> element's id attribute (see Id.h).
+    std::optional<Id> id;
 
     WordsData()
         : text{}, positionData{}, fontData{}, isColorSpecified{false}, colorData{}, enclosure{Enclosure::unspecified},

--- a/src/include/mx/api/WordsData.h
+++ b/src/include/mx/api/WordsData.h
@@ -9,6 +9,9 @@
 #include "mx/api/FontData.h"
 #include "mx/api/PositionData.h"
 
+#include <optional>
+#include <string>
+
 namespace mx
 {
 namespace api
@@ -35,9 +38,12 @@ class WordsData
     // block against its anchor point; MusicXML defines both attributes on `<words>`.
     HorizontalAlignment justify;
 
+    // The <words> element's id attribute (see ApiCommon.h).
+    std::optional<std::string> id;
+
     WordsData()
         : text{}, positionData{}, fontData{}, isColorSpecified{false}, colorData{}, enclosure{Enclosure::unspecified},
-          justify{HorizontalAlignment::unspecified}
+          justify{HorizontalAlignment::unspecified}, id{}
     {
     }
 };
@@ -50,6 +56,7 @@ MXAPI_EQUALS_MEMBER(isColorSpecified)
 MXAPI_EQUALS_MEMBER(colorData)
 MXAPI_EQUALS_MEMBER(enclosure)
 MXAPI_EQUALS_MEMBER(justify)
+MXAPI_EQUALS_MEMBER(id)
 MXAPI_EQUALS_END;
 MXAPI_NOT_EQUALS_AND_VECTORS(WordsData);
 } // namespace api

--- a/src/private/mx/api/Id.cpp
+++ b/src/private/mx/api/Id.cpp
@@ -1,0 +1,100 @@
+// MusicXML Class Library
+// Copyright (c) by Matthew James Briggs
+// Distributed under the MIT License
+
+#include "mx/api/Id.h"
+
+#include "mx/api/IdAccess.h"
+
+#include <utility>
+
+namespace mx
+{
+namespace api
+{
+
+// core::Token is the type mx writes an id attribute with. It cannot hold text that breaks the XML
+// name rules, so an Id that holds one is valid for as long as it exists, and mx::impl hands the
+// token itself to mx::core rather than converting the text again.
+//
+// An Id never changes its token, so copies share one Impl instead of allocating another.
+class Id::Impl
+{
+  public:
+    explicit Impl(core::Token inToken) : token{std::move(inToken)}
+    {
+    }
+
+    // What a moved-from Id is left holding. An Id always holds an Impl, so reading one that has
+    // been moved from is harmless rather than undefined.
+    static const std::shared_ptr<const Impl> &movedFrom();
+
+    core::Token token;
+};
+
+const std::shared_ptr<const Id::Impl> &Id::Impl::movedFrom()
+{
+    static const std::shared_ptr<const Impl> value = std::make_shared<const Impl>(core::Token{});
+    return value;
+}
+
+Id::Id(std::string text) : myImpl{std::make_shared<const Impl>(core::Token{std::move(text)})}
+{
+}
+
+Id::Id(const char *text) : Id{std::string{text != nullptr ? text : ""}}
+{
+}
+
+Id::Id(std::shared_ptr<const Impl> impl) : myImpl{std::move(impl)}
+{
+}
+
+Id::Id(const Id &other) = default;
+
+Id::Id(Id &&other) noexcept : myImpl{std::move(other.myImpl)}
+{
+    other.myImpl = Impl::movedFrom();
+}
+
+Id &Id::operator=(const Id &other) = default;
+
+Id &Id::operator=(Id &&other) noexcept
+{
+    if (this != &other)
+    {
+        myImpl = std::move(other.myImpl);
+        other.myImpl = Impl::movedFrom();
+    }
+    return *this;
+}
+
+Id::~Id() = default;
+
+const std::string &Id::value() const
+{
+    return myImpl->token.value();
+}
+
+bool Id::operator==(const Id &other) const
+{
+    return myImpl == other.myImpl || myImpl->token == other.myImpl->token;
+}
+
+bool Id::operator<(const Id &other) const
+{
+    return myImpl->token.value() < other.myImpl->token.value();
+}
+
+const core::Token &IdAccess::token(const Id &inId)
+{
+    return inId.myImpl->token;
+}
+
+Id IdAccess::make(core::Token inToken)
+{
+    return Id{std::make_shared<const Id::Impl>(std::move(inToken))};
+}
+
+} // namespace api
+} // namespace mx

--- a/src/private/mx/api/IdAccess.h
+++ b/src/private/mx/api/IdAccess.h
@@ -1,0 +1,28 @@
+// MusicXML Class Library
+// Copyright (c) by Matthew James Briggs
+// Distributed under the MIT License
+
+#pragma once
+
+#include "mx/api/Id.h"
+#include "mx/core/Token.h"
+
+namespace mx
+{
+namespace api
+{
+
+// Reaches the core::Token that an api::Id holds. mx::impl uses this to carry an id between mx::api
+// and mx::core as a token, so the text is scrubbed when the Id is built and never again. This
+// header is private to mx and is not part of the public api.
+struct IdAccess
+{
+    // The token an Id holds. Pass it straight to a core element's setID.
+    static const core::Token &token(const Id &inId);
+
+    // An Id holding a token that mx::core already read from a file.
+    static Id make(core::Token inToken);
+};
+
+} // namespace api
+} // namespace mx

--- a/src/private/mx/api/TimeChoice.cpp
+++ b/src/private/mx/api/TimeChoice.cpp
@@ -111,7 +111,7 @@ const ComplexTimeSignature TimeChoice::complex() const
 
 bool TimeChoice::operator==(const TimeChoice &other) const
 {
-    return isImplicit == other.isImplicit && display == other.display && myValue == other.myValue;
+    return isImplicit == other.isImplicit && display == other.display && id == other.id && myValue == other.myValue;
 }
 
 } // namespace api

--- a/src/private/mx/impl/ArpeggiateFunctions.cpp
+++ b/src/private/mx/impl/ArpeggiateFunctions.cpp
@@ -5,6 +5,7 @@
 #include "mx/impl/ArpeggiateFunctions.h"
 #include "mx/core/generated/Arpeggiate.h"
 #include "mx/impl/Converter.h"
+#include "mx/impl/IdFunctions.h"
 #include "mx/impl/MarkDataFunctions.h"
 
 namespace mx
@@ -47,10 +48,7 @@ api::MarkData ArpeggiateFunctions::parseArpeggiate() const
         Converter converter;
         arpeggiateData.unbroken = converter.convert(*myArpeggiate.unbroken());
     }
-    if (myArpeggiate.id().has_value())
-    {
-        arpeggiateData.id = myArpeggiate.id()->value();
-    }
+    arpeggiateData.id = getId(myArpeggiate);
     markData.choice = arpeggiateData;
 
     return markData;

--- a/src/private/mx/impl/Converter.cpp
+++ b/src/private/mx/impl/Converter.cpp
@@ -6,6 +6,7 @@
 #include "mx/core/Decimal.h"
 #include "mx/core/generated/Semitones.h"
 #include "mx/core/generated/TransposeGroup.h"
+#include "mx/impl/IdFunctions.h"
 
 #include <algorithm>
 #include <cmath>
@@ -2323,7 +2324,9 @@ mx::api::TransposeData Converter::convertToTransposeData(const mx::core::Transpo
     const auto octaves = specifiedOctave.has_value() ? specifiedOctave.value() : 0;
     diatonic += octaves * 7;
     const auto chromatic = specifiedChromatic + (octaves * 12);
-    return mx::api::TransposeData{chromatic, diatonic};
+    mx::api::TransposeData out{chromatic, diatonic};
+    out.id = getId(inTranspose);
+    return out;
 }
 } // namespace impl
 } // namespace mx

--- a/src/private/mx/impl/CurveFunctions.h
+++ b/src/private/mx/impl/CurveFunctions.h
@@ -8,6 +8,7 @@
 #include "mx/api/NoteData.h"
 #include "mx/core/generated/Slur.h"
 #include "mx/core/generated/Tied.h"
+#include "mx/impl/IdFunctions.h"
 #include "mx/impl/LineFunctions.h"
 #include "mx/impl/PositionFunctions.h"
 #include "mx/impl/PrintFunctions.h"
@@ -105,6 +106,8 @@ api::CurveStart parseCurveStart(const SLUR_OR_TIE_ELEMENT_TYPE &inSlurOrTie)
         c.curveOrientation = *inAttributes.orientation() == core::OverUnder::over() ? api::CurveOrientation::overhand
                                                                                     : api::CurveOrientation::underhand;
     }
+
+    c.id = getId(inAttributes);
     return c;
 }
 
@@ -139,6 +142,7 @@ api::CurveContinue parseCurveContinue(const SLUR_OR_TIE_ELEMENT_TYPE &inSlurOrTi
     }
 
     c.curvePoints = parseCurvePoints(inAttributes);
+    c.id = getId(inAttributes);
     return c;
 }
 
@@ -154,6 +158,7 @@ template <typename SLUR_OR_TIE_ELEMENT_TYPE> api::CurveStop parseCurveStop(const
     }
 
     c.curvePoints = parseCurvePoints(inAttributes);
+    c.id = getId(inAttributes);
     return c;
 }
 
@@ -167,6 +172,7 @@ void writeAttributesFromCurveStart(const api::CurveStart inCurve, ATTRIBUTES_TYP
 {
     using CurveTypeAttribute = std::decay_t<decltype(outAttributes.type())>;
     outAttributes.setType(CurveTypeAttribute::start());
+    impl::setId(inCurve.id, outAttributes);
     impl::setAttributesFromPositionData(inCurve.curvePoints.positionData, outAttributes);
     impl::setAttributesFromLineData(inCurve.lineData, outAttributes);
 
@@ -210,6 +216,7 @@ void writeAttributesFromCurveContinue(const api::CurveContinue inCurve, ATTRIBUT
 {
     using CurveTypeAttribute = std::decay_t<decltype(outAttributes.type())>;
     outAttributes.setType(CurveTypeAttribute::continue_());
+    impl::setId(inCurve.id, outAttributes);
     impl::setAttributesFromPositionData(inCurve.curvePoints.positionData, outAttributes);
 
     if (inResolvedNumber.has_value())
@@ -255,6 +262,7 @@ void writeAttributesFromCurveStop(const api::CurveStop inCurve, ATTRIBUTES_TYPE 
 {
     using CurveTypeAttribute = std::decay_t<decltype(outAttributes.type())>;
     outAttributes.setType(CurveTypeAttribute::stop());
+    impl::setId(inCurve.id, outAttributes);
     impl::setAttributesFromPositionData(inCurve.curvePoints.positionData, outAttributes);
 
     if (inResolvedNumber.has_value())
@@ -285,6 +293,7 @@ inline void writeAttributesFromTieLetRing(const api::TieLetRing &inTie, core::Ti
 {
     outTied.setType(core::TiedType::letRing());
     impl::setAttributesFromPositionData(inTie.positionData, outTied);
+    impl::setId(inTie.id, outTied);
 
     if (inTie.isColorSpecified)
     {
@@ -318,6 +327,8 @@ inline api::TieLetRing parseTieLetRing(const core::Tied &inTied)
         c.curveOrientation = *inTied.orientation() == core::OverUnder::over() ? api::CurveOrientation::overhand
                                                                               : api::CurveOrientation::underhand;
     }
+
+    c.id = getId(inTied);
     return c;
 }
 

--- a/src/private/mx/impl/DirectionReader.cpp
+++ b/src/private/mx/impl/DirectionReader.cpp
@@ -84,6 +84,7 @@
 #include "mx/core/generated/WedgeType.h"
 #include "mx/core/generated/YesNo.h"
 #include "mx/impl/DynamicsReader.h"
+#include "mx/impl/IdFunctions.h"
 #include "mx/impl/MarkDataFunctions.h"
 #include "mx/impl/MetronomeReader.h"
 #include "mx/impl/PrintFunctions.h"
@@ -125,6 +126,7 @@ mx::api::DirectionData DirectionReader::initializeData()
     if (myDirection)
     {
         result.isStaffValueSpecified = myDirection->staff().has_value();
+        result.id = getId(*myDirection);
     }
     else if (myHarmony)
     {
@@ -367,6 +369,7 @@ void DirectionReader::parseRehearsal(const core::DirectionType &directionType)
         {
             outRehearsal.justify = myConverter.convert(*rehearsal.justify());
         }
+        outRehearsal.id = getId(rehearsal);
         myOutDirectionData.directionTypes.emplace_back(api::DirectionChoice{std::move(outRehearsal)});
     }
 }
@@ -428,6 +431,7 @@ void DirectionReader::parseWordsRun(const core::DirectionType &directionType)
             {
                 outSymbol.justify = myConverter.convert(*symbolEl.justify());
             }
+            outSymbol.id = getId(symbolEl);
             run.emplace_back(std::move(outSymbol));
             continue;
         }
@@ -449,6 +453,7 @@ void DirectionReader::parseWordsRun(const core::DirectionType &directionType)
         {
             outWords.justify = myConverter.convert(*wordEl.justify());
         }
+        outWords.id = getId(wordEl);
         run.emplace_back(std::move(outWords));
     }
 
@@ -510,6 +515,7 @@ void DirectionReader::parseWedge(const core::DirectionType &directionType)
             stop.spread = spread;
         }
         stop.positionData = positionData;
+        stop.id = getId(wedge);
         myOutDirectionData.directionTypes.emplace_back(api::DirectionChoice{std::move(stop)});
         return;
     }
@@ -530,6 +536,7 @@ void DirectionReader::parseWedge(const core::DirectionType &directionType)
         start.lineData = lineData;
         start.isColorSpecified = isColorSpecified;
         start.colorData = colorData;
+        start.id = getId(wedge);
         myOutDirectionData.directionTypes.emplace_back(api::DirectionChoice{std::move(start)});
     }
 }
@@ -622,6 +629,7 @@ void DirectionReader::parseBracket(const core::DirectionType &directionType)
         start.positionData = this->parsePositionData(bracket);
         start.lineData = makeBracketLineData();
         start.printData = impl::getPrintData(bracket);
+        start.id = getId(bracket);
         myOutDirectionData.directionTypes.emplace_back(api::DirectionChoice::bracketStart(std::move(start)));
         return;
     }
@@ -677,6 +685,7 @@ void DirectionReader::parsePedal(const core::DirectionType &directionType)
         pedalData.tickTimePosition = myOutDirectionData.tickTimePosition;
         pedalData.positionData = getPositionData(pedal);
         pedalData.positionData.placement = placement;
+        pedalData.id = getId(pedal);
         myOutDirectionData.directionTypes.emplace_back(api::DirectionChoice{std::move(pedalData)});
         return;
     }

--- a/src/private/mx/impl/DirectionReader.cpp
+++ b/src/private/mx/impl/DirectionReader.cpp
@@ -393,11 +393,7 @@ void DirectionReader::parseSegno(const core::DirectionType &directionType)
             outSegno.isSmuflSpecified = true;
             outSegno.smufl = segno.smufl()->toString();
         }
-        if (segno.id().has_value())
-        {
-            outSegno.isIdSpecified = true;
-            outSegno.id = segno.id()->value();
-        }
+        outSegno.id = getId(segno);
         myOutDirectionData.directionTypes.emplace_back(api::DirectionChoice{std::move(outSegno)});
     }
 }
@@ -482,11 +478,7 @@ void DirectionReader::parseCoda(const core::DirectionType &directionType)
             outCoda.isSmuflSpecified = true;
             outCoda.smufl = coda.smufl()->toString();
         }
-        if (coda.id().has_value())
-        {
-            outCoda.isIdSpecified = true;
-            outCoda.id = coda.id()->value();
-        }
+        outCoda.id = getId(coda);
         myOutDirectionData.directionTypes.emplace_back(api::DirectionChoice{std::move(outCoda)});
     }
 }
@@ -802,10 +794,7 @@ void DirectionReader::parseHarpPedals(const core::DirectionType &directionType)
     {
         outHarpPedals.color = getColor(harpPedals);
     }
-    if (harpPedals.id().has_value())
-    {
-        outHarpPedals.id = harpPedals.id()->value();
-    }
+    outHarpPedals.id = getId(harpPedals);
     myOutDirectionData.directionTypes.emplace_back(api::DirectionChoice{std::move(outHarpPedals)});
 }
 
@@ -819,10 +808,7 @@ void DirectionReader::parseDamp(const core::DirectionType &directionType)
     {
         outDamp.color = getColor(damp);
     }
-    if (damp.id().has_value())
-    {
-        outDamp.id = damp.id()->value();
-    }
+    outDamp.id = getId(damp);
     myOutDirectionData.directionTypes.emplace_back(api::DirectionChoice{std::move(outDamp)});
 }
 
@@ -836,10 +822,7 @@ void DirectionReader::parseDampAll(const core::DirectionType &directionType)
     {
         outDampAll.color = getColor(dampAll);
     }
-    if (dampAll.id().has_value())
-    {
-        outDampAll.id = dampAll.id()->value();
-    }
+    outDampAll.id = getId(dampAll);
     myOutDirectionData.directionTypes.emplace_back(api::DirectionChoice{std::move(outDampAll)});
 }
 
@@ -853,10 +836,7 @@ void DirectionReader::parseEyeglasses(const core::DirectionType &directionType)
     {
         outEyeglasses.color = getColor(eyeglasses);
     }
-    if (eyeglasses.id().has_value())
-    {
-        outEyeglasses.id = eyeglasses.id()->value();
-    }
+    outEyeglasses.id = getId(eyeglasses);
     myOutDirectionData.directionTypes.emplace_back(api::DirectionChoice{std::move(outEyeglasses)});
 }
 
@@ -872,10 +852,7 @@ void DirectionReader::parseStringMute(const core::DirectionType &directionType)
     {
         outStringMute.color = getColor(stringMute);
     }
-    if (stringMute.id().has_value())
-    {
-        outStringMute.id = stringMute.id()->value();
-    }
+    outStringMute.id = getId(stringMute);
     myOutDirectionData.directionTypes.emplace_back(api::DirectionChoice{std::move(outStringMute)});
 }
 
@@ -902,10 +879,7 @@ void DirectionReader::parseStaffDivide(const core::DirectionType &directionType)
     {
         outStaffDivide.color = getColor(staffDivide);
     }
-    if (staffDivide.id().has_value())
-    {
-        outStaffDivide.id = staffDivide.id()->value();
-    }
+    outStaffDivide.id = getId(staffDivide);
     myOutDirectionData.directionTypes.emplace_back(api::DirectionChoice{std::move(outStaffDivide)});
 }
 
@@ -931,10 +905,7 @@ void DirectionReader::parseScordatura(const core::DirectionType &directionType)
         outAccord.tuningOctave = accord.tuning().tuningOctave().value();
         outScordatura.accords.emplace_back(outAccord);
     }
-    if (scordatura.id().has_value())
-    {
-        outScordatura.id = scordatura.id()->value();
-    }
+    outScordatura.id = getId(scordatura);
     myOutDirectionData.directionTypes.emplace_back(api::DirectionChoice{std::move(outScordatura)});
 }
 
@@ -976,10 +947,7 @@ void DirectionReader::parseImage(const core::DirectionType &directionType)
     {
         outImage.positionData.verticalAlignment = api::VerticalAlignment::unspecified;
     }
-    if (image.id().has_value())
-    {
-        outImage.id = image.id()->value();
-    }
+    outImage.id = getId(image);
     myOutDirectionData.directionTypes.emplace_back(api::DirectionChoice{std::move(outImage)});
 }
 
@@ -1012,10 +980,7 @@ void DirectionReader::parsePrincipalVoice(const core::DirectionType &directionTy
     {
         outPrincipalVoice.color = getColor(principalVoice);
     }
-    if (principalVoice.id().has_value())
-    {
-        outPrincipalVoice.id = principalVoice.id()->value();
-    }
+    outPrincipalVoice.id = getId(principalVoice);
     myOutDirectionData.directionTypes.emplace_back(api::DirectionChoice{std::move(outPrincipalVoice)});
 }
 
@@ -1035,10 +1000,7 @@ void DirectionReader::parseAccordionRegistration(const core::DirectionType &dire
     {
         outAccordion.color = getColor(accordion);
     }
-    if (accordion.id().has_value())
-    {
-        outAccordion.id = accordion.id()->value();
-    }
+    outAccordion.id = getId(accordion);
     myOutDirectionData.directionTypes.emplace_back(api::DirectionChoice{std::move(outAccordion)});
 }
 
@@ -1169,10 +1131,7 @@ void DirectionReader::parsePercussion(const core::DirectionType &directionType)
         {
             outPercussion.color = getColor(percussion);
         }
-        if (percussion.id().has_value())
-        {
-            outPercussion.id = percussion.id()->value();
-        }
+        outPercussion.id = getId(percussion);
         myOutDirectionData.directionTypes.emplace_back(api::DirectionChoice{std::move(outPercussion)});
     }
 }
@@ -1193,10 +1152,7 @@ void DirectionReader::parseOtherDirection(const core::DirectionType &directionTy
     {
         outOtherDirection.color = getColor(otherDirection);
     }
-    if (otherDirection.id().has_value())
-    {
-        outOtherDirection.id = otherDirection.id()->value();
-    }
+    outOtherDirection.id = getId(otherDirection);
     myOutDirectionData.directionTypes.emplace_back(api::DirectionChoice{std::move(outOtherDirection)});
 }
 

--- a/src/private/mx/impl/DirectionWriter.cpp
+++ b/src/private/mx/impl/DirectionWriter.cpp
@@ -109,6 +109,7 @@
 #include "mx/core/generated/YesNo.h"
 #include "mx/impl/DynamicsWriter.h"
 #include "mx/impl/FontFunctions.h"
+#include "mx/impl/IdFunctions.h"
 #include "mx/impl/LineFunctions.h"
 #include "mx/impl/MarkDataFunctions.h"
 #include "mx/impl/PrintFunctions.h"
@@ -165,6 +166,7 @@ std::vector<core::MusicDataChoice> DirectionWriter::getDirectionLikeThings()
     // nullopt for unspecified, and for the bottom-of-system values that only measure numbering has.
     // <harmony> carries the same attribute; createHarmonyElements writes it there too.
     direction.setSystem(myConverter.convertDirectionSystemRelation(myDirectionData.systemRelation));
+    setId(myDirectionData.id, direction);
 
     if (myDirectionData.isStaffValueSpecified || myCursor.staffIndex != 0)
     {
@@ -331,6 +333,7 @@ void DirectionWriter::emitPedal(const api::PedalLineData &item, core::Direction 
     pedal.setType(corePedalType(item.kind));
     pedal.setLine(core::YesNo::yes());
     setAttributesFromPositionData(item.positionData, pedal);
+    setId(item.id, pedal);
     core::DirectionType dt{};
     dt.setChoice(core::DirectionTypeChoice::pedal(pedal));
     addDirectionType(std::move(dt), direction);
@@ -352,6 +355,7 @@ void DirectionWriter::emitWedgeStop(const api::WedgeStop &wedgeStop, const void 
         wedge.setSpread(core::Tenths{core::Decimal{static_cast<double>(wedgeStop.spread)}});
     }
     setAttributesFromPositionData(wedgeStop.positionData, wedge);
+    setId(wedgeStop.id, wedge);
     core::DirectionType dt{};
     dt.setChoice(core::DirectionTypeChoice::wedge(wedge));
     addDirectionType(std::move(dt), direction);
@@ -384,6 +388,7 @@ void DirectionWriter::emitWedgeStart(const api::WedgeStart &wedgeStart, const vo
     {
         setAttributesFromColorData(wedgeStart.colorData, wedge);
     }
+    setId(wedgeStart.id, wedge);
     core::DirectionType dt{};
     dt.setChoice(core::DirectionTypeChoice::wedge(wedge));
     addDirectionType(std::move(dt), direction);
@@ -409,6 +414,7 @@ void DirectionWriter::emitOttavaStart(const api::OttavaStart &ottavaStart, const
     impl::setAttributesFromPositionData(ottavaStart.spannerStart.positionData, os);
     impl::setAttributesFromPrintData(ottavaStart.spannerStart.printData, os);
     impl::setAttributesFromLineData(ottavaStart.spannerStart.lineData, os);
+    impl::setId(ottavaStart.spannerStart.id, os);
 
     const auto number = myNumberResolver.emittedNumber(ottavaStart.spannerStart.number, inIdentity);
     if (number.has_value())
@@ -749,6 +755,7 @@ void DirectionWriter::emitWordsRun(const std::vector<api::WordsChoice> &inRun, c
             {
                 outSymbol.setJustify(myConverter.convert(symbolData.justify));
             }
+            setId(symbolData.id, outSymbol);
             choiceItem = core::DirectionTypeChoiceChoice::symbol(std::move(outSymbol));
         }
         else
@@ -770,6 +777,7 @@ void DirectionWriter::emitWordsRun(const std::vector<api::WordsChoice> &inRun, c
             {
                 outWords.setJustify(myConverter.convert(wordsData.justify));
             }
+            setId(wordsData.id, outWords);
             choiceItem = core::DirectionTypeChoiceChoice::words(std::move(outWords));
         }
 
@@ -851,6 +859,7 @@ void DirectionWriter::emitRehearsal(const api::RehearsalData &item, core::Direct
     {
         rehearsal.setJustify(myConverter.convert(item.justify));
     }
+    setId(item.id, rehearsal);
     core::DirectionType dt{};
     dt.setChoice(core::DirectionTypeChoice::rehearsal(core::OneOrMore<core::FormattedTextID>{std::move(rehearsal)}));
     addDirectionType(std::move(dt), direction);
@@ -1811,6 +1820,8 @@ std::vector<core::MusicDataChoice> DirectionWriter::createFiguredBassElements()
                 figuredBass.addFigure(figure);
             }
         }
+
+        setId(figuredBassData.id, figuredBass);
 
         if (figuredBassData.parentheses != api::Bool::unspecified)
         {

--- a/src/private/mx/impl/DirectionWriter.cpp
+++ b/src/private/mx/impl/DirectionWriter.cpp
@@ -698,10 +698,7 @@ void DirectionWriter::emitTempo(const api::TempoData &tempo, core::Direction &di
     {
         setAttributesFromColorData(*tempo.color, metronome);
     }
-    if (tempo.id.has_value())
-    {
-        metronome.setID(core::Token{*tempo.id});
-    }
+    setId(tempo.id, metronome);
     if (tempo.justify != api::HorizontalAlignment::unspecified)
     {
         metronome.setJustify(myConverter.convert(tempo.justify));
@@ -810,10 +807,7 @@ void DirectionWriter::emitSegno(const api::SegnoData &item, core::Direction &dir
     {
         segno.setSmufl(core::SmuflSegnoGlyphName::parse(item.smufl));
     }
-    if (item.isIdSpecified)
-    {
-        segno.setID(core::Token{item.id});
-    }
+    setId(item.id, segno);
     core::DirectionType dt{};
     dt.setChoice(core::DirectionTypeChoice::segno(core::OneOrMore<core::Segno>{std::move(segno)}));
     addDirectionType(std::move(dt), direction);
@@ -832,10 +826,7 @@ void DirectionWriter::emitCoda(const api::CodaData &item, core::Direction &direc
     {
         coda.setSmufl(core::SmuflCodaGlyphName::parse(item.smufl));
     }
-    if (item.isIdSpecified)
-    {
-        coda.setID(core::Token{item.id});
-    }
+    setId(item.id, coda);
     core::DirectionType dt{};
     dt.setChoice(core::DirectionTypeChoice::coda(core::OneOrMore<core::Coda>{std::move(coda)}));
     addDirectionType(std::move(dt), direction);
@@ -868,7 +859,7 @@ void DirectionWriter::emitRehearsal(const api::RehearsalData &item, core::Direct
 core::EmptyPrintStyleAlignID DirectionWriter::createEmptyPrintStyleAlign(const api::PositionData &positionData,
                                                                          const api::FontData &fontData,
                                                                          const std::optional<api::ColorData> &color,
-                                                                         const std::optional<std::string> &id)
+                                                                         const std::optional<api::Id> &id)
 {
     core::EmptyPrintStyleAlignID element{};
     setAttributesFromPositionData(positionData, element);
@@ -877,10 +868,7 @@ core::EmptyPrintStyleAlignID DirectionWriter::createEmptyPrintStyleAlign(const a
     {
         setAttributesFromColorData(*color, element);
     }
-    if (id.has_value())
-    {
-        element.setID(core::Token{*id});
-    }
+    setId(id, element);
     return element;
 }
 
@@ -918,10 +906,7 @@ void DirectionWriter::emitStringMute(const api::StringMuteData &item, core::Dire
     {
         setAttributesFromColorData(*item.color, stringMute);
     }
-    if (item.id.has_value())
-    {
-        stringMute.setID(core::Token{*item.id});
-    }
+    setId(item.id, stringMute);
     core::DirectionType dt{};
     dt.setChoice(core::DirectionTypeChoice::stringMute(std::move(stringMute)));
     addDirectionType(std::move(dt), direction);
@@ -948,10 +933,7 @@ void DirectionWriter::emitStaffDivide(const api::StaffDivideData &item, core::Di
     {
         setAttributesFromColorData(*item.color, staffDivide);
     }
-    if (item.id.has_value())
-    {
-        staffDivide.setID(core::Token{*item.id});
-    }
+    setId(item.id, staffDivide);
     core::DirectionType dt{};
     dt.setChoice(core::DirectionTypeChoice::staffDivide(std::move(staffDivide)));
     addDirectionType(std::move(dt), direction);
@@ -984,10 +966,7 @@ void DirectionWriter::emitPrincipalVoice(const api::PrincipalVoiceData &item, co
     {
         setAttributesFromColorData(*item.color, principalVoice);
     }
-    if (item.id.has_value())
-    {
-        principalVoice.setID(core::Token{*item.id});
-    }
+    setId(item.id, principalVoice);
     core::DirectionType dt{};
     dt.setChoice(core::DirectionTypeChoice::principalVoice(std::move(principalVoice)));
     addDirectionType(std::move(dt), direction);
@@ -1011,10 +990,7 @@ void DirectionWriter::emitOtherDirection(const api::OtherDirectionData &item, co
     {
         setAttributesFromColorData(*item.color, otherDirection);
     }
-    if (item.id.has_value())
-    {
-        otherDirection.setID(core::Token{*item.id});
-    }
+    setId(item.id, otherDirection);
     core::DirectionType dt{};
     dt.setChoice(core::DirectionTypeChoice::otherDirection(std::move(otherDirection)));
     addDirectionType(std::move(dt), direction);
@@ -1053,10 +1029,7 @@ void DirectionWriter::emitImage(const api::ImageData &item, core::Direction &dir
     default:
         break;
     }
-    if (item.id.has_value())
-    {
-        image.setID(core::Token{*item.id});
-    }
+    setId(item.id, image);
     core::DirectionType dt{};
     dt.setChoice(core::DirectionTypeChoice::image(std::move(image)));
     addDirectionType(std::move(dt), direction);
@@ -1077,10 +1050,7 @@ void DirectionWriter::emitAccordionRegistration(const api::AccordionRegistration
     {
         setAttributesFromColorData(*item.color, accordion);
     }
-    if (item.id.has_value())
-    {
-        accordion.setID(core::Token{*item.id});
-    }
+    setId(item.id, accordion);
     core::DirectionType dt{};
     dt.setChoice(core::DirectionTypeChoice::accordionRegistration(std::move(accordion)));
     addDirectionType(std::move(dt), direction);
@@ -1118,10 +1088,7 @@ void DirectionWriter::emitHarpPedals(const api::HarpPedalsData &item, core::Dire
     {
         setAttributesFromColorData(*item.color, harpPedals);
     }
-    if (item.id.has_value())
-    {
-        harpPedals.setID(core::Token{*item.id});
-    }
+    setId(item.id, harpPedals);
     core::DirectionType dt{};
     dt.setChoice(core::DirectionTypeChoice::harpPedals(std::move(harpPedals)));
     addDirectionType(std::move(dt), direction);
@@ -1163,10 +1130,7 @@ void DirectionWriter::emitScordatura(const api::ScordaturaData &item, core::Dire
             scordatura.addAccord(std::move(accord));
         }
     }
-    if (item.id.has_value())
-    {
-        scordatura.setID(core::Token{*item.id});
-    }
+    setId(item.id, scordatura);
     core::DirectionType dt{};
     dt.setChoice(core::DirectionTypeChoice::scordatura(std::move(scordatura)));
     addDirectionType(std::move(dt), direction);
@@ -1296,10 +1260,7 @@ void DirectionWriter::emitPercussion(const api::PercussionData &item, core::Dire
     {
         setAttributesFromColorData(*item.color, percussion);
     }
-    if (item.id.has_value())
-    {
-        percussion.setID(core::Token{*item.id});
-    }
+    setId(item.id, percussion);
     core::DirectionType dt{};
     dt.setChoice(core::DirectionTypeChoice::percussion(core::OneOrMore<core::Percussion>{std::move(percussion)}));
     addDirectionType(std::move(dt), direction);

--- a/src/private/mx/impl/DirectionWriter.h
+++ b/src/private/mx/impl/DirectionWriter.h
@@ -58,7 +58,7 @@ class DirectionWriter
     core::EmptyPrintStyleAlignID createEmptyPrintStyleAlign(const api::PositionData &positionData,
                                                             const api::FontData &fontData,
                                                             const std::optional<api::ColorData> &color,
-                                                            const std::optional<std::string> &id);
+                                                            const std::optional<api::Id> &id);
     void emitDamp(const api::DampData &item, core::Direction &direction);
     void emitDampAll(const api::DampAllData &item, core::Direction &direction);
     void emitEyeglasses(const api::EyeglassesData &item, core::Direction &direction);

--- a/src/private/mx/impl/IdFunctions.h
+++ b/src/private/mx/impl/IdFunctions.h
@@ -4,33 +4,34 @@
 
 #pragma once
 
-#include "mx/core/Token.h"
+#include "mx/api/Id.h"
+#include "mx/api/IdAccess.h"
 
 #include <optional>
-#include <string>
 
 namespace mx
 {
 namespace impl
 {
-// Read the id attribute from any core element that has one. Absent stays absent.
-template <typename CORE_TYPE> std::optional<std::string> getId(const CORE_TYPE &inCoreElement)
+// Read the id attribute from any core element that has one. Absent stays absent. The token moves
+// across as a token, so the text is not scrubbed again.
+template <typename CORE_TYPE> std::optional<api::Id> getId(const CORE_TYPE &inCoreElement)
 {
     if (!inCoreElement.id().has_value())
     {
         return std::nullopt;
     }
 
-    return inCoreElement.id()->value();
+    return api::IdAccess::make(*inCoreElement.id());
 }
 
-// Write the id attribute onto any core element that has one. An absent or empty id writes no
-// attribute. core::Token repairs an id that is not a valid XML name.
-template <typename CORE_TYPE> void setId(const std::optional<std::string> &inId, CORE_TYPE &outCoreElement)
+// Write the id attribute onto any core element that has one. An absent id writes no attribute. The
+// element receives the token the Id already holds, so the text is not scrubbed again.
+template <typename CORE_TYPE> void setId(const std::optional<api::Id> &inId, CORE_TYPE &outCoreElement)
 {
-    if (inId.has_value() && !inId->empty())
+    if (inId.has_value())
     {
-        outCoreElement.setID(core::Token{*inId});
+        outCoreElement.setID(api::IdAccess::token(*inId));
     }
 }
 } // namespace impl

--- a/src/private/mx/impl/IdFunctions.h
+++ b/src/private/mx/impl/IdFunctions.h
@@ -1,0 +1,37 @@
+// MusicXML Class Library
+// Copyright (c) by Matthew James Briggs
+// Distributed under the MIT License
+
+#pragma once
+
+#include "mx/core/Token.h"
+
+#include <optional>
+#include <string>
+
+namespace mx
+{
+namespace impl
+{
+// Read the id attribute from any core element that has one. Absent stays absent.
+template <typename CORE_TYPE> std::optional<std::string> getId(const CORE_TYPE &inCoreElement)
+{
+    if (!inCoreElement.id().has_value())
+    {
+        return std::nullopt;
+    }
+
+    return inCoreElement.id()->value();
+}
+
+// Write the id attribute onto any core element that has one. An absent or empty id writes no
+// attribute. core::Token repairs an id that is not a valid XML name.
+template <typename CORE_TYPE> void setId(const std::optional<std::string> &inId, CORE_TYPE &outCoreElement)
+{
+    if (inId.has_value() && !inId->empty())
+    {
+        outCoreElement.setID(core::Token{*inId});
+    }
+}
+} // namespace impl
+} // namespace mx

--- a/src/private/mx/impl/MeasureReader.cpp
+++ b/src/private/mx/impl/MeasureReader.cpp
@@ -52,6 +52,7 @@
 #include "mx/core/generated/YesNo.h"
 #include "mx/impl/Converter.h"
 #include "mx/impl/DirectionReader.h"
+#include "mx/impl/IdFunctions.h"
 #include "mx/impl/NoteFunctions.h"
 #include "mx/impl/NoteReader.h"
 #include "mx/impl/SoundFunctions.h"
@@ -142,6 +143,7 @@ std::pair<api::MeasureData, std::optional<api::TransposeData>> MeasureReader::ge
     std::lock_guard<std::mutex> lock(myMutex);
     myOutMeasureData = api::MeasureData{};
     myOutMeasureData.number = myPartwiseMeasure.number();
+    myOutMeasureData.id = getId(myPartwiseMeasure);
 
     // if we are parsing the first measure of the part, then we need to return transpose information
     std::optional<api::TransposeData> transpose;
@@ -234,10 +236,13 @@ void MeasureReader::parseTimeSignature() const
         staffTimeSignatures = myPreviousMeasureCursor.staffTimeSignatures;
     }
 
+    // A carried-forward time signature is not the <time> element that stated it, so it keeps no id.
     timeSignature.isImplicit = true;
+    timeSignature.id.reset();
     for (auto &entry : staffTimeSignatures)
     {
         entry.second.isImplicit = true;
+        entry.second.id.reset();
     }
 
     TimeReader timeReader{myPartwiseMeasure.musicData()};
@@ -684,6 +689,7 @@ std::optional<api::TransposeData> MeasureReader::parseAttributes(const core::Att
                 keyData.nonTraditional.emplace_back(keyComponent);
             }
 
+            keyData.id = getId(key);
             myOutMeasureData.keys.emplace_back(std::move(keyData));
             continue;
         }
@@ -716,6 +722,7 @@ std::optional<api::TransposeData> MeasureReader::parseAttributes(const core::Att
             keyData.mode = myConverter.convert(*traditionalKey.mode());
         }
         keyData.tickTimePosition = myCurrentCursor.tickTimePosition;
+        keyData.id = getId(key);
 
         myOutMeasureData.keys.emplace_back(std::move(keyData));
     }
@@ -766,6 +773,7 @@ std::optional<api::TransposeData> MeasureReader::parseAttributes(const core::Att
             }
 
             transposeData.tickTimePosition = myCurrentCursor.tickTimePosition;
+            transposeData.id = getId(coreTranspose);
             myOutMeasureData.transpositions.emplace_back(std::move(transposeData));
         }
     }
@@ -828,6 +836,8 @@ void MeasureReader::parseFiguredBass(const core::FiguredBass &inMxFiguredBass, c
     {
         figuredBass.durationTimeTicks = myCurrentCursor.convertDurationToGlobalTickScale(*inMxFiguredBass.duration());
     }
+
+    figuredBass.id = getId(inMxFiguredBass);
 
     auto direction = api::DirectionData{};
     direction.tickTimePosition = myCurrentCursor.tickTimePosition;
@@ -978,6 +988,7 @@ void MeasureReader::parseBarline(const core::Barline &inMxBarline) const
     barline.repeatDirection = repeatDirection;
     barline.repeatAfterJump = repeatAfterJump;
     barline.repeatWinged = repeatWinged;
+    barline.id = getId(inMxBarline);
     myOutMeasureData.barlines.emplace_back(std::move(barline));
 }
 
@@ -1047,6 +1058,7 @@ void MeasureReader::importClef(const core::Clef &inClef) const
 {
     api::ClefData clefData;
     clefData.tickTimePosition = myCurrentCursor.tickTimePosition;
+    clefData.id = getId(inClef);
     auto converter = Converter{};
     clefData.symbol = converter.convert(inClef.clef().sign());
 

--- a/src/private/mx/impl/MeasureWriter.cpp
+++ b/src/private/mx/impl/MeasureWriter.cpp
@@ -35,6 +35,7 @@
 #include "mx/core/generated/YesNo.h"
 #include "mx/impl/Converter.h"
 #include "mx/impl/DirectionWriter.h"
+#include "mx/impl/IdFunctions.h"
 #include "mx/impl/LayoutFunctions.h"
 #include "mx/impl/NoteWriter.h"
 #include "mx/impl/ScoreWriter.h"
@@ -99,6 +100,8 @@ void MeasureWriter::writeMeasureGlobals()
     {
         myOutMeasure.setWidth(core::Tenths{core::Decimal{static_cast<double>(myMeasureData.width)}});
     }
+
+    impl::setId(myMeasureData.id, myOutMeasure);
 
     Converter converter;
 
@@ -916,6 +919,7 @@ void MeasureWriter::writeBarlines(int tickTimePosition)
             barlineElement.setRepeat(repeatElement);
         }
 
+        impl::setId(myBarlinesIter->id, barlineElement);
         myOutMeasure.addMusicData(core::MusicDataChoice::barline(barlineElement));
         myHistory.log("writeBarline");
     }

--- a/src/private/mx/impl/MetronomeReader.cpp
+++ b/src/private/mx/impl/MetronomeReader.cpp
@@ -23,6 +23,7 @@
 #include "mx/core/generated/TimeModificationGroup.h"
 #include "mx/impl/Converter.h"
 #include "mx/impl/FontFunctions.h"
+#include "mx/impl/IdFunctions.h"
 #include "mx/impl/PositionFunctions.h"
 #include "mx/impl/PrintFunctions.h"
 
@@ -138,10 +139,7 @@ api::TempoData MetronomeReader::getTempoData() const
     {
         myOutTempoData.color = getColor(myMetronome);
     }
-    if (myMetronome.id().has_value())
-    {
-        myOutTempoData.id = myMetronome.id()->value();
-    }
+    myOutTempoData.id = getId(myMetronome);
     if (myMetronome.justify().has_value())
     {
         myOutTempoData.justify = converter.convert(*myMetronome.justify());

--- a/src/private/mx/impl/NonArpeggiateFunctions.cpp
+++ b/src/private/mx/impl/NonArpeggiateFunctions.cpp
@@ -4,6 +4,7 @@
 
 #include "mx/impl/NonArpeggiateFunctions.h"
 #include "mx/core/generated/NonArpeggiate.h"
+#include "mx/impl/IdFunctions.h"
 #include "mx/impl/MarkDataFunctions.h"
 
 namespace mx
@@ -30,10 +31,7 @@ api::MarkData NonArpeggiateFunctions::parseNonArpeggiate() const
     {
         nonArpeggiateData.number = myNonArpeggiate.number()->value();
     }
-    if (myNonArpeggiate.id().has_value())
-    {
-        nonArpeggiateData.id = myNonArpeggiate.id()->value();
-    }
+    nonArpeggiateData.id = getId(myNonArpeggiate);
     markData.choice = nonArpeggiateData;
 
     return markData;

--- a/src/private/mx/impl/NotationsWriter.cpp
+++ b/src/private/mx/impl/NotationsWriter.cpp
@@ -375,10 +375,7 @@ core::Notations NotationsWriter::getNotations() const
             {
                 nonArpeggiate.setNumber(core::NumberLevel{*nonArpeggiateData.number});
             }
-            if (nonArpeggiateData.id.has_value())
-            {
-                nonArpeggiate.setID(core::Token{*nonArpeggiateData.id});
-            }
+            setId(nonArpeggiateData.id, nonArpeggiate);
 
             outNotations.addChoice(core::NotationsChoice::nonArpeggiate(nonArpeggiate));
         }
@@ -410,10 +407,7 @@ core::Notations NotationsWriter::getNotations() const
                 Converter converter;
                 arpeggiate.setUnbroken(converter.convert(arpeggiateData.unbroken));
             }
-            if (arpeggiateData.id.has_value())
-            {
-                arpeggiate.setID(core::Token{*arpeggiateData.id});
-            }
+            setId(arpeggiateData.id, arpeggiate);
 
             outNotations.addChoice(core::NotationsChoice::arpeggiate(arpeggiate));
         }
@@ -433,10 +427,7 @@ core::Notations NotationsWriter::getNotations() const
             {
                 other.setSmufl(core::SmuflGlyphName{*payload.smufl});
             }
-            if (payload.id.has_value())
-            {
-                other.setID(core::Token{*payload.id});
-            }
+            setId(payload.id, other);
 
             outNotations.addChoice(core::NotationsChoice::otherNotation(other));
         }

--- a/src/private/mx/impl/NotationsWriter.cpp
+++ b/src/private/mx/impl/NotationsWriter.cpp
@@ -62,6 +62,7 @@
 #include "mx/impl/Converter.h"
 #include "mx/impl/CurveFunctions.h"
 #include "mx/impl/DynamicsWriter.h"
+#include "mx/impl/IdFunctions.h"
 #include "mx/impl/MarkDataFunctions.h"
 #include "mx/impl/PositionFunctions.h"
 #include "mx/impl/ScoreWriter.h"
@@ -184,6 +185,7 @@ core::Notations NotationsWriter::getNotations() const
     {
         core::Tuplet tuplet;
         tuplet.setType(core::StartStop::stop());
+        setId(tupletStop.id, tuplet);
 
         if (tupletStop.numberLevel > 0)
         {
@@ -197,6 +199,7 @@ core::Notations NotationsWriter::getNotations() const
     {
         core::Tuplet tuplet;
         tuplet.setType(core::StartStop::start());
+        setId(tupletStart.id, tuplet);
 
         core::TupletPortion actual;
         core::TupletNumber tn1;

--- a/src/private/mx/impl/NoteFunctions.cpp
+++ b/src/private/mx/impl/NoteFunctions.cpp
@@ -316,10 +316,7 @@ void NoteFunctions::parseNotations() const
                 {
                     payload.smufl = other.smufl()->toString();
                 }
-                if (other.id().has_value())
-                {
-                    payload.id = other.id()->value();
-                }
+                payload.id = getId(other);
                 mark.choice = std::move(payload);
                 myOutNoteData.noteAttachmentData.marks.emplace_back(std::move(mark));
                 break;

--- a/src/private/mx/impl/NoteFunctions.cpp
+++ b/src/private/mx/impl/NoteFunctions.cpp
@@ -11,6 +11,7 @@
 #include "mx/impl/CurveFunctions.h"
 #include "mx/impl/DynamicsReader.h"
 #include "mx/impl/FermataFunctions.h"
+#include "mx/impl/IdFunctions.h"
 #include "mx/impl/MarkDataFunctions.h"
 #include "mx/impl/NonArpeggiateFunctions.h"
 #include "mx/impl/NoteReader.h"
@@ -159,6 +160,7 @@ api::NoteData NoteFunctions::parseNote() const
 
     parseMiscData();
     myOutNoteData.positionData = impl::getPositionData(myNote);
+    myOutNoteData.id = impl::getId(myNote);
 
     return myOutNoteData;
 }

--- a/src/private/mx/impl/NoteReader.cpp
+++ b/src/private/mx/impl/NoteReader.cpp
@@ -15,6 +15,7 @@
 #include "mx/core/generated/TextElementData.h"
 #include "mx/core/generated/Tied.h"
 #include "mx/impl/FontFunctions.h"
+#include "mx/impl/IdFunctions.h"
 #include "mx/impl/PositionFunctions.h"
 #include "mx/impl/PrintFunctions.h"
 #include "mx/utility/StringToInt.h"
@@ -527,6 +528,7 @@ void NoteReader::setLyric()
 
         api::LyricData lyricData;
         lyricData.positionData = getLyricPositionData(lyric);
+        lyricData.id = getId(lyric);
 
         if (lyric.number().has_value())
         {

--- a/src/private/mx/impl/NoteWriter.cpp
+++ b/src/private/mx/impl/NoteWriter.cpp
@@ -27,6 +27,7 @@
 #include "mx/core/generated/TimeModification.h"
 #include "mx/core/generated/TimeModificationGroup.h"
 #include "mx/core/generated/Unpitched.h"
+#include "mx/impl/IdFunctions.h"
 #include "mx/impl/NotationsWriter.h"
 #include "mx/impl/PositionFunctions.h"
 #include "mx/impl/PrintFunctions.h"
@@ -85,6 +86,7 @@ core::Note NoteWriter::getNote(bool isStartOfChord) const
     setNotehead();
     setStemDirection();
     setMiscData();
+    impl::setId(myNoteData.id, myOutNote);
     NotationsWriter notationsWriter{myNoteData, myCursor, myScoreWriter};
     impl::setAttributesFromPositionData(myNoteData.positionData, myOutNote);
     if (myNoteData.printData.printObject != api::Bool::unspecified)
@@ -559,6 +561,7 @@ void NoteWriter::setLyrics() const
         }
 
         impl::setAttributesFromPositionData(lyricData.positionData, lyric);
+        impl::setId(lyricData.id, lyric);
         if (lyricData.positionData.horizontalAlignment != api::HorizontalAlignment::unspecified)
         {
             lyric.setJustify(myConverter.convert(lyricData.positionData.horizontalAlignment));

--- a/src/private/mx/impl/PropertiesWriter.cpp
+++ b/src/private/mx/impl/PropertiesWriter.cpp
@@ -40,6 +40,7 @@
 #include "mx/core/generated/Transpose.h"
 #include "mx/core/generated/YesNo.h"
 #include "mx/impl/Converter.h"
+#include "mx/impl/IdFunctions.h"
 
 namespace mx
 {
@@ -94,6 +95,7 @@ void PropertiesWriter::writeMultipleRest(int measureCount, api::Bool useSymbols)
 void PropertiesWriter::writeKey(int staffIndex, const api::KeyData &inKeyData)
 {
     core::Key key{};
+    impl::setId(inKeyData.id, key);
 
     if (staffIndex >= 0)
     {
@@ -234,6 +236,7 @@ void PropertiesWriter::writeTime(const api::TimeChoice &value, int staffIndex)
 {
     Converter converter;
     core::Time time{};
+    impl::setId(value.id, time);
 
     if (value.isSimple())
     {
@@ -325,6 +328,7 @@ void PropertiesWriter::writeStaffDetails(int staffIndex, int staffLines, double 
 void PropertiesWriter::writeClef(int staffIndex, const api::ClefData &inClefData)
 {
     core::Clef mxClef{};
+    impl::setId(inClefData.id, mxClef);
 
     // staffIndex < 0 means a single-staff part (the caller's clefStaffIndex() collapses it), so the
     // auto rule omits the implied 1; staffIndex >= 0 is a multi-staff part, so the auto rule emits
@@ -403,6 +407,7 @@ void PropertiesWriter::writePartSymbol(const api::PartSymbolData &inPartSymbolDa
 void PropertiesWriter::writeTranspose(int staffIndex, const api::TransposeData &inTransposeData)
 {
     auto xpose = Converter::convertToTranspose(inTransposeData);
+    impl::setId(inTransposeData.id, xpose);
 
     if (staffIndex >= 0)
     {

--- a/src/private/mx/impl/SoundFunctions.cpp
+++ b/src/private/mx/impl/SoundFunctions.cpp
@@ -12,6 +12,7 @@
 #include "mx/core/generated/SwingChoiceGroup.h"
 #include "mx/core/generated/SwingTypeValue.h"
 #include "mx/core/generated/YesNo.h"
+#include "mx/impl/IdFunctions.h"
 
 namespace mx
 {
@@ -144,11 +145,15 @@ api::SoundData readSoundData(const core::Sound &inSound)
         out.swing = soundFunctionsToApiSwingData(*inSound.swing());
     }
 
+    out.id = getId(inSound);
+
     return out;
 }
 
 void writeSoundData(const api::SoundData &inSoundData, core::Sound &outSound)
 {
+    setId(inSoundData.id, outSound);
+
     if (inSoundData.tempo >= 0.0)
     {
         outSound.setTempo(core::NonNegativeDecimal{core::Decimal{inSoundData.tempo}});

--- a/src/private/mx/impl/SpannerFunctions.h
+++ b/src/private/mx/impl/SpannerFunctions.h
@@ -5,10 +5,10 @@
 #pragma once
 
 #include "mx/api/SpannerData.h"
+#include "mx/impl/IdFunctions.h"
 #include "mx/impl/LineFunctions.h"
 #include "mx/impl/PositionFunctions.h"
 #include "mx/impl/PrintFunctions.h"
-#include "mx/utility/Unused.h"
 
 #include <optional>
 
@@ -29,6 +29,7 @@ template <typename ATTRIBUTES_TYPE> api::SpannerStart getSpannerStart(const ATTR
     start.positionData = getPositionData(inAttributes);
     start.printData = getPrintData(inAttributes);
     start.lineData = getLineData(inAttributes);
+    start.id = getId(inAttributes);
     return start;
 }
 
@@ -41,6 +42,7 @@ template <typename ATTRIBUTES_TYPE> api::SpannerStop getSpannerStop(const ATTRIB
     }
     stop.positionData = getPositionData(inAttributes);
     stop.lineData = getLineData(inAttributes);
+    stop.id = getId(inAttributes);
     return stop;
 }
 
@@ -53,7 +55,8 @@ template <typename ATTRIBUTES_TYPE>
 void setAttributesFromSpannerStart(const api::SpannerStart &start, ATTRIBUTES_TYPE &outAttributes,
                                    const std::optional<int> &inResolvedNumber)
 {
-    MX_UNUSED(start);
+    setId(start.id, outAttributes);
+
     if (inResolvedNumber.has_value())
     {
         lookForAndSetHasNumber(true, &outAttributes);
@@ -81,6 +84,7 @@ void setAttributesFromSpannerStop(const api::SpannerStop &stop, ATTRIBUTES_TYPE 
 
     setAttributesFromPositionData(stop.positionData, outAttributes);
     setAttributesFromLineData(stop.lineData, outAttributes);
+    setId(stop.id, outAttributes);
 }
 } // namespace impl
 } // namespace mx

--- a/src/private/mx/impl/TimeReader.cpp
+++ b/src/private/mx/impl/TimeReader.cpp
@@ -11,6 +11,7 @@
 #include "mx/core/generated/TimeChoiceGroup.h"
 #include "mx/core/generated/TimeSignatureGroup.h"
 #include "mx/impl/Converter.h"
+#include "mx/impl/IdFunctions.h"
 
 #include <utility>
 #include <vector>
@@ -100,6 +101,7 @@ TimeReaderResult TimeReader::createTimeChoice(const core::Time &inTime)
     }
 
     timeChoice.isImplicit = false;
+    timeChoice.id = getId(inTime);
     if (inTime.printObject().has_value())
     {
         timeChoice.display = converter.convert(*inTime.printObject());

--- a/src/private/mx/impl/TupletReader.cpp
+++ b/src/private/mx/impl/TupletReader.cpp
@@ -9,6 +9,7 @@
 #include "mx/core/generated/Tuplet.h"
 #include "mx/core/generated/TupletPortion.h"
 #include "mx/impl/Converter.h"
+#include "mx/impl/IdFunctions.h"
 #include "mx/impl/MarkDataFunctions.h"
 
 namespace mx
@@ -25,6 +26,7 @@ void TupletReader::parseTuplet(std::vector<api::TupletStart> &outTupletStarts,
 {
     api::TupletStart tupletStart;
     tupletStart.positionData = impl::getPositionData(myTuplet);
+    tupletStart.id = getId(myTuplet);
 
     if (myTuplet.number().has_value())
     {
@@ -36,6 +38,7 @@ void TupletReader::parseTuplet(std::vector<api::TupletStart> &outTupletStarts,
         api::TupletStop tupletStop;
         tupletStop.positionData = tupletStart.positionData;
         tupletStop.numberLevel = tupletStart.numberLevel;
+        tupletStop.id = getId(myTuplet);
         outTupletStops.emplace_back(std::move(tupletStop));
         return;
     }

--- a/src/private/mxtest/api/IdAttributeApiTest.cpp
+++ b/src/private/mxtest/api/IdAttributeApiTest.cpp
@@ -1,0 +1,429 @@
+// MusicXML Class Library
+// Copyright (c) by Matthew James Briggs
+// Distributed under the MIT License
+
+#include "mxtest/control/CompileControl.h"
+#ifdef MX_COMPILE_API_TESTS
+
+#include "cpul/cpulTestHarness.h"
+#include "mx/api/DocumentManager.h"
+#include "mx/api/ScoreData.h"
+#include "mxtest/api/RoundTrip.h"
+#include "mxtest/api/TestHelpers.h"
+
+using namespace std;
+using namespace mx::api;
+using namespace mxtest;
+
+// A one-part, one-measure score holding a single quarter note, ready for a test to hang ids on.
+static ScoreData idAttributeMakeScore()
+{
+    ScoreData score;
+    score.ticksPerQuarter = 4;
+    score.parts.emplace_back();
+    auto &part = score.parts.back();
+    part.name = "P1";
+    part.uniqueId = "P1";
+    part.measures.emplace_back();
+    auto &measure = part.measures.back();
+    measure.staves.emplace_back();
+    auto &staff = measure.staves.back();
+
+    NoteData note{};
+    note.pitchData.step = Step::c;
+    note.pitchData.octave = 4;
+    note.durationData.durationTimeTicks = 4;
+    note.durationData.durationName = DurationName::quarter;
+    note.tickTimePosition = 0;
+    staff.voices[0].notes.push_back(note);
+
+    return score;
+}
+
+static MeasureData &idAttributeMeasure(ScoreData &score)
+{
+    return score.parts.back().measures.back();
+}
+
+static const MeasureData &idAttributeMeasure(const ScoreData &score)
+{
+    return score.parts.back().measures.back();
+}
+
+static NoteData &idAttributeNote(ScoreData &score)
+{
+    return idAttributeMeasure(score).staves.back().voices.at(0).notes.back();
+}
+
+static const NoteData &idAttributeNote(const ScoreData &score)
+{
+    return idAttributeMeasure(score).staves.back().voices.at(0).notes.back();
+}
+
+// The <note> id, the reason for issue 399, plus the <measure> and <lyric> ids around it.
+TEST(noteMeasureAndLyricIds, IdAttribute)
+{
+    auto score = idAttributeMakeScore();
+    idAttributeMeasure(score).id = "m1";
+
+    auto &note = idAttributeNote(score);
+    note.id = "n1";
+
+    LyricData lyric;
+    lyric.text = "la";
+    lyric.id = "ly1";
+    note.lyrics.push_back(lyric);
+
+    const auto xml = toXml(score);
+    CHECK(xml.find("id=\"n1\"") != std::string::npos);
+
+    const auto out = roundTrip(score);
+    CHECK(std::optional<std::string>{"m1"} == idAttributeMeasure(out).id);
+
+    const auto &onote = idAttributeNote(out);
+    CHECK(std::optional<std::string>{"n1"} == onote.id);
+    REQUIRE(onote.lyrics.size() == 1);
+    CHECK(std::optional<std::string>{"ly1"} == onote.lyrics.front().id);
+}
+
+T_END;
+
+// The ids on the elements that live in <attributes>, plus the <barline> id.
+TEST(attributesAndBarlineIds, IdAttribute)
+{
+    auto score = idAttributeMakeScore();
+    auto &measure = idAttributeMeasure(score);
+
+    measure.timeSignature = TimeChoice{TimeSignatureData{}};
+    measure.timeSignature.isImplicit = false;
+    measure.timeSignature.id = "t1";
+
+    KeyData key;
+    key.fifths = 2;
+    key.mode = KeyMode::major;
+    key.id = "k1";
+    measure.keys.push_back(key);
+
+    ClefData clef;
+    clef.setTreble();
+    clef.id = "c1";
+    measure.staves.back().clefs.push_back(clef);
+
+    TransposeData transpose{-2, -1};
+    transpose.id = "x1";
+    measure.transpositions.push_back(transpose);
+
+    BarlineData barline;
+    barline.barlineType = BarlineType::lightHeavy;
+    barline.location = HorizontalAlignment::right;
+    barline.id = "b1";
+    measure.barlines.push_back(barline);
+
+    const auto out = roundTrip(score);
+    const auto &omeasure = idAttributeMeasure(out);
+
+    CHECK(std::optional<std::string>{"t1"} == omeasure.timeSignature.id);
+    REQUIRE(omeasure.keys.size() == 1);
+    CHECK(std::optional<std::string>{"k1"} == omeasure.keys.front().id);
+    REQUIRE(omeasure.staves.back().clefs.size() == 1);
+    CHECK(std::optional<std::string>{"c1"} == omeasure.staves.back().clefs.front().id);
+    REQUIRE(omeasure.transpositions.size() == 1);
+    CHECK(std::optional<std::string>{"x1"} == omeasure.transpositions.front().id);
+    REQUIRE(omeasure.barlines.size() == 1);
+    CHECK(std::optional<std::string>{"b1"} == omeasure.barlines.front().id);
+}
+
+T_END;
+
+// A time signature that a later measure inherits carries no id: only the measure that states the
+// <time> element owns it.
+TEST(inheritedTimeSignatureHasNoId, IdAttribute)
+{
+    auto score = idAttributeMakeScore();
+    auto &measure = idAttributeMeasure(score);
+    measure.timeSignature = TimeChoice{TimeSignatureData{}};
+    measure.timeSignature.isImplicit = false;
+    measure.timeSignature.id = "t1";
+
+    auto &part = score.parts.back();
+    part.measures.push_back(part.measures.back());
+    part.measures.back().timeSignature.isImplicit = true;
+    part.measures.back().id = std::nullopt;
+
+    const auto out = roundTrip(score);
+    REQUIRE(out.parts.back().measures.size() == 2);
+    CHECK(std::optional<std::string>{"t1"} == out.parts.back().measures.front().timeSignature.id);
+    CHECK(!out.parts.back().measures.back().timeSignature.id.has_value());
+}
+
+T_END;
+
+// The <direction> id and the ids of the direction-type elements mx::api models as their own types.
+TEST(directionIds, IdAttribute)
+{
+    auto score = idAttributeMakeScore();
+    auto &staff = idAttributeMeasure(score).staves.back();
+
+    DirectionData direction;
+    direction.tickTimePosition = 0;
+    direction.id = "d1";
+
+    WordsData words;
+    words.text = "dolce";
+    words.id = "w1";
+
+    SymbolData symbol;
+    symbol.smufl = "arrowBlackUp";
+    symbol.id = "sy1";
+
+    direction.directionTypes.emplace_back(
+        DirectionChoice{std::vector<WordsChoice>{WordsChoice{words}, WordsChoice{symbol}}});
+
+    RehearsalData rehearsal;
+    rehearsal.text = "A";
+    rehearsal.id = "r1";
+    direction.directionTypes.emplace_back(DirectionChoice{rehearsal});
+
+    WedgeStart wedgeStart;
+    wedgeStart.wedgeType = WedgeType::crescendo;
+    wedgeStart.id = "we1";
+    direction.directionTypes.emplace_back(DirectionChoice{wedgeStart});
+
+    SpannerStart bracketStart;
+    bracketStart.id = "br1";
+    direction.directionTypes.emplace_back(DirectionChoice::bracketStart(bracketStart));
+
+    SpannerStart dashesStart;
+    dashesStart.id = "da1";
+    direction.directionTypes.emplace_back(DirectionChoice::dashesStart(dashesStart));
+
+    OttavaStart ottavaStart;
+    ottavaStart.ottavaType = OttavaType::o8va;
+    ottavaStart.spannerStart.id = "o1";
+    direction.directionTypes.emplace_back(DirectionChoice{ottavaStart});
+
+    PedalLineData pedal{PedalLineKind::start};
+    pedal.id = "p1";
+    direction.directionTypes.emplace_back(DirectionChoice{pedal});
+
+    direction.isSoundDataSpecified = true;
+    direction.soundData.tempo = 120.0;
+    direction.soundData.id = "so1";
+
+    staff.directions.push_back(direction);
+
+    const auto out = roundTrip(score);
+    const auto &odirections = idAttributeMeasure(out).staves.back().directions;
+    REQUIRE(odirections.size() == 1);
+    const auto &odirection = odirections.front();
+
+    CHECK(std::optional<std::string>{"d1"} == odirection.id);
+    CHECK(std::optional<std::string>{"so1"} == odirection.soundData.id);
+
+    std::optional<std::string> foundWords;
+    std::optional<std::string> foundSymbol;
+    std::optional<std::string> foundRehearsal;
+    std::optional<std::string> foundWedge;
+    std::optional<std::string> foundBracket;
+    std::optional<std::string> foundDashes;
+    std::optional<std::string> foundOttava;
+    std::optional<std::string> foundPedal;
+
+    for (const auto &choice : odirection.directionTypes)
+    {
+        switch (choice.kind())
+        {
+        case DirectionChoice::Kind::wordsRun:
+            for (const auto &item : choice.wordsRun())
+            {
+                if (item.isWords())
+                {
+                    foundWords = item.words().id;
+                }
+                else if (item.isSymbol())
+                {
+                    foundSymbol = item.symbol().id;
+                }
+            }
+            break;
+        case DirectionChoice::Kind::rehearsal:
+            foundRehearsal = choice.rehearsal().id;
+            break;
+        case DirectionChoice::Kind::wedgeStart:
+            foundWedge = choice.wedgeStart().id;
+            break;
+        case DirectionChoice::Kind::bracketStart:
+            foundBracket = choice.bracketStart().id;
+            break;
+        case DirectionChoice::Kind::dashesStart:
+            foundDashes = choice.dashesStart().id;
+            break;
+        case DirectionChoice::Kind::ottavaStart:
+            foundOttava = choice.ottavaStart().spannerStart.id;
+            break;
+        case DirectionChoice::Kind::pedal:
+            foundPedal = choice.pedal().id;
+            break;
+        default:
+            break;
+        }
+    }
+
+    CHECK(std::optional<std::string>{"w1"} == foundWords);
+    CHECK(std::optional<std::string>{"sy1"} == foundSymbol);
+    CHECK(std::optional<std::string>{"r1"} == foundRehearsal);
+    CHECK(std::optional<std::string>{"we1"} == foundWedge);
+    CHECK(std::optional<std::string>{"br1"} == foundBracket);
+    CHECK(std::optional<std::string>{"da1"} == foundDashes);
+    CHECK(std::optional<std::string>{"o1"} == foundOttava);
+    CHECK(std::optional<std::string>{"p1"} == foundPedal);
+}
+
+T_END;
+
+// The ids on the note-attached elements: <slur>, <tuplet> and a let-ring <tied>.
+TEST(notationIds, IdAttribute)
+{
+    auto score = idAttributeMakeScore();
+    auto &staff = idAttributeMeasure(score).staves.back();
+    auto &notes = staff.voices.at(0).notes;
+
+    NoteData second = notes.back();
+    second.tickTimePosition = 4;
+    notes.push_back(second);
+
+    CurveStart slurStart{CurveType::slur};
+    slurStart.id = "s1";
+    notes.front().noteAttachmentData.curveStarts.push_back(slurStart);
+
+    CurveStop slurStop{CurveType::slur};
+    slurStop.id = "s2";
+    notes.back().noteAttachmentData.curveStops.push_back(slurStop);
+
+    TupletStart tupletStart;
+    tupletStart.actualNumber = 3;
+    tupletStart.actualDurationName = DurationName::quarter;
+    tupletStart.normalNumber = 2;
+    tupletStart.normalDurationName = DurationName::quarter;
+    tupletStart.id = "tu1";
+    notes.front().noteAttachmentData.tupletStarts.push_back(tupletStart);
+
+    TupletStop tupletStop;
+    tupletStop.id = "tu2";
+    notes.back().noteAttachmentData.tupletStops.push_back(tupletStop);
+
+    TieLetRing letRing;
+    letRing.id = "lr1";
+    notes.back().tieLetRing = letRing;
+
+    const auto out = roundTrip(score);
+    const auto &onotes = idAttributeMeasure(out).staves.back().voices.at(0).notes;
+    REQUIRE(onotes.size() == 2);
+
+    REQUIRE(onotes.front().noteAttachmentData.curveStarts.size() == 1);
+    CHECK(std::optional<std::string>{"s1"} == onotes.front().noteAttachmentData.curveStarts.front().id);
+    REQUIRE(onotes.back().noteAttachmentData.curveStops.size() == 1);
+    CHECK(std::optional<std::string>{"s2"} == onotes.back().noteAttachmentData.curveStops.front().id);
+
+    REQUIRE(onotes.front().noteAttachmentData.tupletStarts.size() == 1);
+    CHECK(std::optional<std::string>{"tu1"} == onotes.front().noteAttachmentData.tupletStarts.front().id);
+    REQUIRE(onotes.back().noteAttachmentData.tupletStops.size() == 1);
+    CHECK(std::optional<std::string>{"tu2"} == onotes.back().noteAttachmentData.tupletStops.front().id);
+
+    REQUIRE(onotes.back().tieLetRing.has_value());
+    CHECK(std::optional<std::string>{"lr1"} == onotes.back().tieLetRing->id);
+}
+
+T_END;
+
+// The <figured-bass> id.
+TEST(figuredBassId, IdAttribute)
+{
+    auto score = idAttributeMakeScore();
+    auto &staff = idAttributeMeasure(score).staves.back();
+
+    FigureData figure;
+    figure.figureNumber = "6";
+
+    FiguredBassData figuredBass;
+    figuredBass.figures.push_back(figure);
+    figuredBass.id = "fb1";
+
+    DirectionData direction;
+    direction.tickTimePosition = 0;
+    direction.placement = Placement::below;
+    direction.figuredBasses.push_back(figuredBass);
+    staff.directions.push_back(direction);
+
+    const auto out = roundTrip(score);
+    const auto &odirections = idAttributeMeasure(out).staves.back().directions;
+    REQUIRE(odirections.size() == 1);
+    REQUIRE(odirections.front().figuredBasses.size() == 1);
+    CHECK(std::optional<std::string>{"fb1"} == odirections.front().figuredBasses.front().id);
+}
+
+T_END;
+
+// Reading ids straight off a MusicXML source.
+TEST(idsAreReadFromSourceXml, IdAttribute)
+{
+    const std::string xml = R"(<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE score-partwise PUBLIC "-//Recordare//DTD MusicXML 4.0 Partwise//EN" "http://www.musicxml.org/dtds/partwise.dtd">
+<score-partwise version="4.0">
+  <part-list>
+    <score-part id="P1">
+      <part-name>Music</part-name>
+    </score-part>
+  </part-list>
+  <part id="P1">
+    <measure number="1" id="m1">
+      <attributes>
+        <divisions>1</divisions>
+        <key id="k1">
+          <fifths>0</fifths>
+        </key>
+        <time id="t1">
+          <beats>4</beats>
+          <beat-type>4</beat-type>
+        </time>
+        <clef id="c1">
+          <sign>G</sign>
+          <line>2</line>
+        </clef>
+      </attributes>
+      <note id="n1">
+        <pitch>
+          <step>C</step>
+          <octave>4</octave>
+        </pitch>
+        <duration>4</duration>
+        <type>whole</type>
+      </note>
+      <barline location="right" id="b1">
+        <bar-style>light-heavy</bar-style>
+      </barline>
+    </measure>
+  </part>
+</score-partwise>)";
+
+    const auto score = fromXml(xml);
+    REQUIRE(score.parts.size() == 1);
+    const auto &measure = score.parts.front().measures.front();
+
+    CHECK(std::optional<std::string>{"m1"} == measure.id);
+    CHECK(std::optional<std::string>{"t1"} == measure.timeSignature.id);
+    REQUIRE(measure.keys.size() == 1);
+    CHECK(std::optional<std::string>{"k1"} == measure.keys.front().id);
+    REQUIRE(measure.staves.front().clefs.size() == 1);
+    CHECK(std::optional<std::string>{"c1"} == measure.staves.front().clefs.front().id);
+    REQUIRE(measure.barlines.size() == 1);
+    CHECK(std::optional<std::string>{"b1"} == measure.barlines.front().id);
+
+    const auto &notes = measure.staves.front().voices.at(0).notes;
+    REQUIRE(notes.size() == 1);
+    CHECK(std::optional<std::string>{"n1"} == notes.front().id);
+}
+
+T_END;
+
+#endif

--- a/src/private/mxtest/api/IdAttributeApiTest.cpp
+++ b/src/private/mxtest/api/IdAttributeApiTest.cpp
@@ -11,6 +11,9 @@
 #include "mxtest/api/RoundTrip.h"
 #include "mxtest/api/TestHelpers.h"
 
+#include <map>
+#include <unordered_map>
+
 using namespace std;
 using namespace mx::api;
 using namespace mxtest;
@@ -60,6 +63,12 @@ static const NoteData &idAttributeNote(const ScoreData &score)
     return idAttributeMeasure(score).staves.back().voices.at(0).notes.back();
 }
 
+// The text of an id, or an empty string when there is none.
+static std::string idAttributeText(const std::optional<Id> &id)
+{
+    return id.has_value() ? id->value() : std::string{};
+}
+
 // The <note> id, the reason for issue 399, plus the <measure> and <lyric> ids around it.
 TEST(noteMeasureAndLyricIds, IdAttribute)
 {
@@ -78,12 +87,12 @@ TEST(noteMeasureAndLyricIds, IdAttribute)
     CHECK(xml.find("id=\"n1\"") != std::string::npos);
 
     const auto out = roundTrip(score);
-    CHECK(std::optional<std::string>{"m1"} == idAttributeMeasure(out).id);
+    CHECK_EQUAL("m1", idAttributeText(idAttributeMeasure(out).id));
 
     const auto &onote = idAttributeNote(out);
-    CHECK(std::optional<std::string>{"n1"} == onote.id);
+    CHECK_EQUAL("n1", idAttributeText(onote.id));
     REQUIRE(onote.lyrics.size() == 1);
-    CHECK(std::optional<std::string>{"ly1"} == onote.lyrics.front().id);
+    CHECK_EQUAL("ly1", idAttributeText(onote.lyrics.front().id));
 }
 
 T_END;
@@ -122,15 +131,15 @@ TEST(attributesAndBarlineIds, IdAttribute)
     const auto out = roundTrip(score);
     const auto &omeasure = idAttributeMeasure(out);
 
-    CHECK(std::optional<std::string>{"t1"} == omeasure.timeSignature.id);
+    CHECK_EQUAL("t1", idAttributeText(omeasure.timeSignature.id));
     REQUIRE(omeasure.keys.size() == 1);
-    CHECK(std::optional<std::string>{"k1"} == omeasure.keys.front().id);
+    CHECK_EQUAL("k1", idAttributeText(omeasure.keys.front().id));
     REQUIRE(omeasure.staves.back().clefs.size() == 1);
-    CHECK(std::optional<std::string>{"c1"} == omeasure.staves.back().clefs.front().id);
+    CHECK_EQUAL("c1", idAttributeText(omeasure.staves.back().clefs.front().id));
     REQUIRE(omeasure.transpositions.size() == 1);
-    CHECK(std::optional<std::string>{"x1"} == omeasure.transpositions.front().id);
+    CHECK_EQUAL("x1", idAttributeText(omeasure.transpositions.front().id));
     REQUIRE(omeasure.barlines.size() == 1);
-    CHECK(std::optional<std::string>{"b1"} == omeasure.barlines.front().id);
+    CHECK_EQUAL("b1", idAttributeText(omeasure.barlines.front().id));
 }
 
 T_END;
@@ -152,7 +161,7 @@ TEST(inheritedTimeSignatureHasNoId, IdAttribute)
 
     const auto out = roundTrip(score);
     REQUIRE(out.parts.back().measures.size() == 2);
-    CHECK(std::optional<std::string>{"t1"} == out.parts.back().measures.front().timeSignature.id);
+    CHECK_EQUAL("t1", idAttributeText(out.parts.back().measures.front().timeSignature.id));
     CHECK(!out.parts.back().measures.back().timeSignature.id.has_value());
 }
 
@@ -206,6 +215,14 @@ TEST(directionIds, IdAttribute)
     pedal.id = "p1";
     direction.directionTypes.emplace_back(DirectionChoice{pedal});
 
+    SegnoData segno;
+    segno.id = "sg1";
+    direction.directionTypes.emplace_back(DirectionChoice{segno});
+
+    CodaData coda;
+    coda.id = "co1";
+    direction.directionTypes.emplace_back(DirectionChoice{coda});
+
     direction.isSoundDataSpecified = true;
     direction.soundData.tempo = 120.0;
     direction.soundData.id = "so1";
@@ -217,17 +234,19 @@ TEST(directionIds, IdAttribute)
     REQUIRE(odirections.size() == 1);
     const auto &odirection = odirections.front();
 
-    CHECK(std::optional<std::string>{"d1"} == odirection.id);
-    CHECK(std::optional<std::string>{"so1"} == odirection.soundData.id);
+    CHECK_EQUAL("d1", idAttributeText(odirection.id));
+    CHECK_EQUAL("so1", idAttributeText(odirection.soundData.id));
 
-    std::optional<std::string> foundWords;
-    std::optional<std::string> foundSymbol;
-    std::optional<std::string> foundRehearsal;
-    std::optional<std::string> foundWedge;
-    std::optional<std::string> foundBracket;
-    std::optional<std::string> foundDashes;
-    std::optional<std::string> foundOttava;
-    std::optional<std::string> foundPedal;
+    std::optional<Id> foundWords;
+    std::optional<Id> foundSymbol;
+    std::optional<Id> foundRehearsal;
+    std::optional<Id> foundWedge;
+    std::optional<Id> foundBracket;
+    std::optional<Id> foundDashes;
+    std::optional<Id> foundOttava;
+    std::optional<Id> foundPedal;
+    std::optional<Id> foundSegno;
+    std::optional<Id> foundCoda;
 
     for (const auto &choice : odirection.directionTypes)
     {
@@ -264,19 +283,27 @@ TEST(directionIds, IdAttribute)
         case DirectionChoice::Kind::pedal:
             foundPedal = choice.pedal().id;
             break;
+        case DirectionChoice::Kind::segno:
+            foundSegno = choice.segno().id;
+            break;
+        case DirectionChoice::Kind::coda:
+            foundCoda = choice.coda().id;
+            break;
         default:
             break;
         }
     }
 
-    CHECK(std::optional<std::string>{"w1"} == foundWords);
-    CHECK(std::optional<std::string>{"sy1"} == foundSymbol);
-    CHECK(std::optional<std::string>{"r1"} == foundRehearsal);
-    CHECK(std::optional<std::string>{"we1"} == foundWedge);
-    CHECK(std::optional<std::string>{"br1"} == foundBracket);
-    CHECK(std::optional<std::string>{"da1"} == foundDashes);
-    CHECK(std::optional<std::string>{"o1"} == foundOttava);
-    CHECK(std::optional<std::string>{"p1"} == foundPedal);
+    CHECK_EQUAL("w1", idAttributeText(foundWords));
+    CHECK_EQUAL("sy1", idAttributeText(foundSymbol));
+    CHECK_EQUAL("r1", idAttributeText(foundRehearsal));
+    CHECK_EQUAL("we1", idAttributeText(foundWedge));
+    CHECK_EQUAL("br1", idAttributeText(foundBracket));
+    CHECK_EQUAL("da1", idAttributeText(foundDashes));
+    CHECK_EQUAL("o1", idAttributeText(foundOttava));
+    CHECK_EQUAL("p1", idAttributeText(foundPedal));
+    CHECK_EQUAL("sg1", idAttributeText(foundSegno));
+    CHECK_EQUAL("co1", idAttributeText(foundCoda));
 }
 
 T_END;
@@ -321,17 +348,17 @@ TEST(notationIds, IdAttribute)
     REQUIRE(onotes.size() == 2);
 
     REQUIRE(onotes.front().noteAttachmentData.curveStarts.size() == 1);
-    CHECK(std::optional<std::string>{"s1"} == onotes.front().noteAttachmentData.curveStarts.front().id);
+    CHECK_EQUAL("s1", idAttributeText(onotes.front().noteAttachmentData.curveStarts.front().id));
     REQUIRE(onotes.back().noteAttachmentData.curveStops.size() == 1);
-    CHECK(std::optional<std::string>{"s2"} == onotes.back().noteAttachmentData.curveStops.front().id);
+    CHECK_EQUAL("s2", idAttributeText(onotes.back().noteAttachmentData.curveStops.front().id));
 
     REQUIRE(onotes.front().noteAttachmentData.tupletStarts.size() == 1);
-    CHECK(std::optional<std::string>{"tu1"} == onotes.front().noteAttachmentData.tupletStarts.front().id);
+    CHECK_EQUAL("tu1", idAttributeText(onotes.front().noteAttachmentData.tupletStarts.front().id));
     REQUIRE(onotes.back().noteAttachmentData.tupletStops.size() == 1);
-    CHECK(std::optional<std::string>{"tu2"} == onotes.back().noteAttachmentData.tupletStops.front().id);
+    CHECK_EQUAL("tu2", idAttributeText(onotes.back().noteAttachmentData.tupletStops.front().id));
 
     REQUIRE(onotes.back().tieLetRing.has_value());
-    CHECK(std::optional<std::string>{"lr1"} == onotes.back().tieLetRing->id);
+    CHECK_EQUAL("lr1", idAttributeText(onotes.back().tieLetRing->id));
 }
 
 T_END;
@@ -359,7 +386,7 @@ TEST(figuredBassId, IdAttribute)
     const auto &odirections = idAttributeMeasure(out).staves.back().directions;
     REQUIRE(odirections.size() == 1);
     REQUIRE(odirections.front().figuredBasses.size() == 1);
-    CHECK(std::optional<std::string>{"fb1"} == odirections.front().figuredBasses.front().id);
+    CHECK_EQUAL("fb1", idAttributeText(odirections.front().figuredBasses.front().id));
 }
 
 T_END;
@@ -410,18 +437,120 @@ TEST(idsAreReadFromSourceXml, IdAttribute)
     REQUIRE(score.parts.size() == 1);
     const auto &measure = score.parts.front().measures.front();
 
-    CHECK(std::optional<std::string>{"m1"} == measure.id);
-    CHECK(std::optional<std::string>{"t1"} == measure.timeSignature.id);
+    CHECK_EQUAL("m1", idAttributeText(measure.id));
+    CHECK_EQUAL("t1", idAttributeText(measure.timeSignature.id));
     REQUIRE(measure.keys.size() == 1);
-    CHECK(std::optional<std::string>{"k1"} == measure.keys.front().id);
+    CHECK_EQUAL("k1", idAttributeText(measure.keys.front().id));
     REQUIRE(measure.staves.front().clefs.size() == 1);
-    CHECK(std::optional<std::string>{"c1"} == measure.staves.front().clefs.front().id);
+    CHECK_EQUAL("c1", idAttributeText(measure.staves.front().clefs.front().id));
     REQUIRE(measure.barlines.size() == 1);
-    CHECK(std::optional<std::string>{"b1"} == measure.barlines.front().id);
+    CHECK_EQUAL("b1", idAttributeText(measure.barlines.front().id));
 
     const auto &notes = measure.staves.front().voices.at(0).notes;
     REQUIRE(notes.size() == 1);
-    CHECK(std::optional<std::string>{"n1"} == notes.front().id);
+    CHECK_EQUAL("n1", idAttributeText(notes.front().id));
+}
+
+T_END;
+
+// An id that breaks the XML name rules is scrubbed as the Id is built, so the api and the file
+// always hold the same text.
+TEST(idsAreScrubbedWhenBuilt, IdAttribute)
+{
+    CHECK_EQUAL("n1", Id{"n1"}.value());
+    CHECK_EQUAL("measure-1.a_b", Id{"measure-1.a_b"}.value());
+
+    // Characters the rules do not allow are dropped.
+    CHECK_EQUAL("blindmice", Id{"3 blind mice"}.value());
+
+    // An id cannot start with a digit, a hyphen, or a dot.
+    CHECK_EQUAL("abc", Id{"1abc"}.value());
+    CHECK_EQUAL("abc", Id{"-abc"}.value());
+
+    // Nothing usable left, so the id becomes "X".
+    CHECK_EQUAL("X", Id{""}.value());
+    CHECK_EQUAL("X", Id{"!!!"}.value());
+}
+
+T_END;
+
+// Compare the id you built with the text you gave it to find out whether the text was legal.
+TEST(scrubbingIsVisibleToTheCaller, IdAttribute)
+{
+    const std::string wanted = "3 blind mice";
+    const auto id = Id{wanted};
+    CHECK(id.value() != wanted);
+
+    const std::string legal = "n1";
+    CHECK(Id{legal}.value() == legal);
+}
+
+T_END;
+
+// A scrubbed id reaches the file scrubbed, and reads back the same way.
+TEST(scrubbedIdRoundTrips, IdAttribute)
+{
+    auto score = idAttributeMakeScore();
+    idAttributeNote(score).id = "3 blind mice";
+
+    const auto xml = toXml(score);
+    CHECK(xml.find("id=\"blindmice\"") != std::string::npos);
+
+    const auto out = roundTrip(score);
+    CHECK_EQUAL("blindmice", idAttributeText(idAttributeNote(out).id));
+}
+
+T_END;
+
+// Id behaves like any other value: copy it, assign it, compare it, sort it, hash it.
+TEST(idBehavesLikeAValue, IdAttribute)
+{
+    const Id first{"n1"};
+    const Id copy = first;
+    CHECK(first == copy);
+    CHECK(!(first != copy));
+
+    Id assigned{"other"};
+    assigned = first;
+    CHECK(first == assigned);
+    CHECK_EQUAL("n1", assigned.value());
+
+    // Assigning does not tie the two together.
+    assigned = Id{"n2"};
+    CHECK_EQUAL("n1", first.value());
+    CHECK(first != assigned);
+
+    // Equality is by text, not by where the id came from.
+    CHECK(Id{"n1"} == Id{"n1"});
+    CHECK(Id{"n1"} != Id{"n2"});
+
+    // Ordering is by text.
+    CHECK(Id{"a"} < Id{"b"});
+    CHECK(Id{"b"} > Id{"a"});
+    CHECK(Id{"a"} <= Id{"a"});
+    CHECK(Id{"a"} >= Id{"a"});
+
+    // Equal ids hash the same.
+    const std::hash<Id> hasher;
+    CHECK(hasher(Id{"n1"}) == hasher(copy));
+
+    // So an Id works as a key in either kind of map.
+    std::map<Id, int> ordered;
+    ordered[Id{"n2"}] = 2;
+    ordered[Id{"n1"}] = 1;
+    REQUIRE(ordered.size() == 2);
+    CHECK_EQUAL("n1", ordered.begin()->first.value());
+    CHECK_EQUAL(1, ordered.at(Id{"n1"}));
+
+    std::unordered_map<Id, int> hashed;
+    hashed[Id{"n1"}] = 1;
+    CHECK_EQUAL(1, hashed.at(Id{"n1"}));
+
+    // A moved-from Id is still readable.
+    Id source{"n3"};
+    const Id moved = std::move(source);
+    CHECK_EQUAL("n3", moved.value());
+    CHECK(!source.value().empty());
 }
 
 T_END;

--- a/src/private/mxtest/api/roundtrip-baseline.txt
+++ b/src/private/mxtest/api/roundtrip-baseline.txt
@@ -639,3 +639,8 @@ synthetic/harmonic.3.0.xml
 # attribute: this file's number="1, 2, 3" came back as number="1". BarlineData::ending
 # is now an optional EndingData holding the whole number list plus the display text.
 lysuite/ly45f_Repeats_InvalidEndings.xml
+
+# Unblocked by #399 (MusicXML id attributes). The id attribute of <bracket> and
+# <dashes> reaches the api on SpannerStart/SpannerStop, so it is no longer dropped.
+synthetic/bracket.3.1.xml
+synthetic/dashes.3.1.xml

--- a/src/private/mxtest/impl/DirectionWriterTest.cpp
+++ b/src/private/mxtest/impl/DirectionWriterTest.cpp
@@ -140,7 +140,6 @@ TEST(segnoAndCodaRoundTrip, DirectionWriter)
     segno.colorData.alpha = 255;
     segno.isSmuflSpecified = true;
     segno.smufl = "segno";
-    segno.isIdSpecified = true;
     segno.id = "id3";
 
     api::CodaData coda;
@@ -157,7 +156,6 @@ TEST(segnoAndCodaRoundTrip, DirectionWriter)
     coda.colorData.blue = 56;
     coda.isSmuflSpecified = true;
     coda.smufl = "coda";
-    coda.isIdSpecified = true;
     coda.id = "id7";
 
     api::DirectionData directionData;


### PR DESCRIPTION
## Human Summary

Model ID for those cases where the mx::api data model is close enough the MusicXML data model to make that simple.

Caveats:
- ID strings are silently coerced into valid NCNames.
- ID uniqueness is not yet enforced.

## Summary

Starting with MusicXML 3.1 most elements can carry an `id` attribute naming that one element within the document. `mx::api` dropped nearly all of them (only a handful of recently-added direction types had one). This adds an optional `id` member to every api type that maps one-to-one onto an element with an id, and reads and writes it in `mx::impl`.

Types that gained an `id`:

| Where | MusicXML element |
|---|---|
| `NoteData`, `LyricData` | note, lyric |
| `MeasureData`, `BarlineData` | measure, barline |
| `ClefData`, `KeyData`, `TimeChoice`, `TransposeData` | clef, key, time, transpose |
| `DirectionData`, `SoundData` | direction, sound |
| `WordsData`, `SymbolData`, `RehearsalData` | words, symbol, rehearsal |
| `WedgeStart`, `WedgeStop` | wedge |
| `SpannerStart`, `SpannerStop` | bracket, dashes, octave-shift |
| `PedalLineData` | pedal |
| `CurveStart`, `CurveContinue`, `CurveStop`, `TieLetRing` | slur, tied |
| `TupletStart`, `TupletStop` | tuplet |
| `FiguredBassData` | figured-bass |

Supporting changes:

- New `src/private/mx/impl/IdFunctions.h` with the two helpers (`getId`, `setId`) the readers and writers call.
- `ApiCommon.h` explains what ids are for, and that mx repairs a malformed id but does not check uniqueness (see #397).
- A carried-forward (implicit) time signature no longer keeps the previous measure's id; only the measure that states the `<time>` element carries it.
- `SoundData::isSpecified` now counts an id, so a `<sound>` that has nothing but an id is not dropped.

Left out, because placing the id would need a design decision:

- Grouping elements `mx::api` does not model as their own type: direction-type, notations, articulations, ornaments, technical, beam.
- Marks folded into `MarkData`: dynamics, fermata, accidental-mark. These would need new `MarkDataChoice` alternatives.
- harmony and frame: one `DirectionData` holds several `ChordData` that serialize into a single `<harmony>`, so it is not clear which chord owns the id.
- credit: both `<credit>` and `<credit-words>` have an id and `PageTextData` models the pair.
- Elements `mx::api` does not model at all: print, measure-style, grouping, for-part, glissando, slide (see #389).

## Testing

- [x] New `src/private/mxtest/api/IdAttributeApiTest.cpp`: 7 cases, 53 assertions, covering every new field through `roundTrip`, plus one case reading ids straight off source XML and one pinning the implicit-time-signature rule
- [x] `make test-all` green: core roundtrip (839 cases), core unit (44 cases), api/impl suite (6018 assertions in 542 cases), api roundtrip (366 pinned, 0 failed)
- [x] Discovery went from 366 to 368 passing files; `synthetic/bracket.3.1.xml` and `synthetic/dashes.3.1.xml` newly pass because of the bracket and dashes ids, and are pinned in `roundtrip-baseline.txt`. No file regressed.
- [x] `make fmt-check` passes

## References

- Progresses #399
- Related to #397 (id uniqueness is not constrained by `mx::core`)
- Related to #389 (glissando, slide and wavy-line are not modeled, so their ids are not exposed here)
- Requested in discussion #349, which also led to #393
