### PR TITLE
feat: add unplayed frame attribute to `mx::api`

### DIFF
--- a/src/include/mx/api/ChordData.h
+++ b/src/include/mx/api/ChordData.h
@@ -177,6 +177,8 @@ class FrameData
 
     int stringCount;
     int fretCount;
+    // What to display above a string without a frame note, such as "x" for a muted string.
+    std::optional<std::string> unplayed;
     int firstFret;
     bool isFirstFretSpecified;
     std::vector<FrameNoteData> notes;
@@ -185,6 +187,7 @@ class FrameData
 MXAPI_EQUALS_BEGIN(FrameData)
 MXAPI_EQUALS_MEMBER(stringCount)
 MXAPI_EQUALS_MEMBER(fretCount)
+MXAPI_EQUALS_MEMBER(unplayed)
 MXAPI_EQUALS_MEMBER(firstFret)
 MXAPI_EQUALS_MEMBER(isFirstFretSpecified)
 MXAPI_EQUALS_MEMBER(notes)

--- a/src/private/mx/api/ChordData.cpp
+++ b/src/private/mx/api/ChordData.cpp
@@ -24,7 +24,7 @@ FrameNoteData::FrameNoteData()
 {
 }
 
-FrameData::FrameData() : stringCount{6}, fretCount{4}, firstFret{1}, isFirstFretSpecified{false}, notes{}
+FrameData::FrameData() : stringCount{6}, fretCount{4}, unplayed{}, firstFret{1}, isFirstFretSpecified{false}, notes{}
 {
 }
 

--- a/src/private/mx/impl/DirectionReader.cpp
+++ b/src/private/mx/impl/DirectionReader.cpp
@@ -1428,6 +1428,10 @@ void DirectionReader::parseHarmony(const core::Harmony &inHarmony, const core::H
         const auto &frame = *inHarmony.frame();
         chord.frameData.stringCount = frame.frameStrings();
         chord.frameData.fretCount = frame.frameFrets();
+        if (frame.unplayed().has_value())
+        {
+            chord.frameData.unplayed = *frame.unplayed();
+        }
 
         if (frame.firstFret().has_value())
         {

--- a/src/private/mx/impl/DirectionWriter.cpp
+++ b/src/private/mx/impl/DirectionWriter.cpp
@@ -1699,6 +1699,10 @@ std::vector<core::MusicDataChoice> DirectionWriter::createHarmonyElements(int in
             core::Frame frame{};
             frame.setFrameStrings(chordIter->frameData.stringCount);
             frame.setFrameFrets(chordIter->frameData.fretCount);
+            if (chordIter->frameData.unplayed.has_value())
+            {
+                frame.setUnplayed(chordIter->frameData.unplayed);
+            }
 
             if (chordIter->frameData.isFirstFretSpecified)
             {

--- a/src/private/mxtest/api/HarmonyExtrasApiTest.cpp
+++ b/src/private/mxtest/api/HarmonyExtrasApiTest.cpp
@@ -206,6 +206,25 @@ TEST(harmonyInversionRoundTrip, HarmonyExtrasApi)
 
 T_END;
 
+TEST(harmonyFrameUnplayedRoundTrip, HarmonyExtrasApi)
+{
+    auto score = makeScoreWithChord();
+    auto &chord = chordOf(score);
+    chord.root = Step::c;
+    chord.chordKind = ChordKind::major;
+    chord.hasFrameData = true;
+    chord.frameData.unplayed = "x";
+
+    const auto xml = mxtest::toXml(score);
+    CHECK(xml.find("unplayed=\"x\"") != std::string::npos);
+
+    const auto out = mxtest::roundTrip(score);
+    CHECK(out.parts.front().measures.front().staves.front().directions.front().chords.front().frameData.unplayed ==
+          std::optional<std::string>{"x"});
+}
+
+T_END;
+
 TEST(harmonyFunctionRoundTrip, HarmonyExtrasApi)
 {
     auto score = makeScoreWithChord();


### PR DESCRIPTION
## Human Summary

Add unplayed frame attribute to `mx::api`.

## Summary

Expose the MusicXML `<frame unplayed="...">` attribute through `FrameData`, preserving it when reading and writing harmony frames. Adds an API round-trip test for the common muted-string value `x`.

## Testing

- [x] `git diff --check`
- [ ] `make fmt-check` — unavailable because Docker is not installed in this environment

## References

No related issue found.