### PR TITLE
build: define gitsha for swift package builds

### DIFF
--- a/src/private/mx/core/GitShaDefault.cpp
+++ b/src/private/mx/core/GitShaDefault.cpp
@@ -1,0 +1,21 @@
+// MusicXML Class Library
+// Copyright (c) by Matthew James Briggs
+// Distributed under the MIT License
+
+// The Swift package build's definition of mx::core::gitSha. CMake builds generate the real
+// value at build time (cmake/GitSha.cmake renders Version.cpp.in into the build tree) and list
+// mx_core's sources explicitly, so they never compile this file. The Swift package build globs
+// src/ and has no code-generation step, so without this fallback the Mx product carries an
+// undefined symbol that surfaces only when a consumer links an executable. "unknown" is the
+// value Version.h already documents for builds outside the git/CMake machinery.
+//
+// Do not add this file to any CMake source list: the linker would see two definitions.
+
+#include "mx/core/Version.h"
+
+namespace mx::core
+{
+
+const char *const gitSha = "unknown";
+
+} // namespace mx::core


### PR DESCRIPTION
## Human Summary

Basically the CMake stuff doesn't run if you consume the library through the Swift package. So this was the agent solution for that: a file that CMake doesn't glob but that Swift does include, which writes the sha as `unknown`. This is not ideal. I want to find a better versioning mechanism but everything is hard without a package manager.

## Summary

`mx::core::gitSha` is declared in Version.h and defined by `GitSha.cpp`, which `cmake/GitSha.cmake`
renders from `Version.cpp.in` into the build tree at build time. The Swift package has no code
generation step and simply globs src/, so the Mx product compiles the declaration with no
definition anywhere.

Nothing catches this today. `swift build --product Mx` only archives a static library, and an
undefined symbol in an archive is not diagnosed until something links an executable against it.
It surfaced when komp switched to consuming mx through the Swift package instead of a prebuilt
xcframework:

```
Undefined symbols for architecture x86_64:
  "mx::core::gitSha", referenced from:
      mx::core::mxSoftwareAttribution() in Mx.o
```

This adds GitShaDefault.cpp defining `gitSha` as "unknown", which is the value `Version.h` already
documents for a build made outside a git checkout.

CMake builds are unaffected. The mx_core source list is explicit and no glob covers
`mx/core/*.cpp`, so the generated definition stays the only one there.

Worth considering as a follow-up: the swift CI job could link a small executable rather than only
archiving, so this class of defect cannot go latent again. Left out of this PR because it is a
choice about the workflow rather than part of the fix.

## Testing

- [x] CMake api target builds with the new file present, never compiles it, and reports no duplicate symbol
- [x] `ar t libmx_core.a` lists GitSha.cpp.o and no GitShaDefault.o, so CMake still uses the generated definition
- [x] A consumer program linked against the Swift package objects builds and runs
- [x] Removing only GitShaDefault.cpp.o from that same link fails with undefined mx::core::gitSha, confirming this file is what resolves it
- [x] komp builds and runs on macOS and the iPad simulator against the Swift package

## References

- Related: #78. A consumer built during CI is the kind of check that would have caught this; the Swift package has the same blind spot the issue describes for the CMake install path.
