### PR TITLE
feat: derive octave-shift stop size from its start

### DIFF
--- a/src/include/mx/api/OttavaData.h
+++ b/src/include/mx/api/OttavaData.h
@@ -50,18 +50,12 @@ class OttavaStop
     SpannerStop spannerStop;
 
     // Most users can ignore this; leave it unspecified. It only controls whether the stop end of an
-    // octave-shift line repeats the line's size (8, 15, or 22). The size is not the stop's own
-    // fact: it belongs to the OttavaStart that opened the line, so an authored ottava states its
-    // octave shift once, on the start, and the writer puts the matching size on the stop.
+    // octave-shift line repeats the line's size (8, 15, or 22). The size is not required on the
+    // stop and carries no new information. Omitting it is legal, but but some importers (MuseScore)
+    // expect it. Therefore `mx::api` defaults to automatically writing the redundant stop size.
     //
-    // unspecified (the default) and yes both write that size; no omits it. Omitting it is legal
-    // MusicXML, but some importers (MuseScore among them) expect it, so the default is the
-    // interoperable spelling. It exists for round-trip fidelity - reading a file sets yes or no
-    // according to whether the source spelled the attribute out.
-    //
-    // The start a stop closes is found by spannerStop.number: an identity, an explicit level, or an
-    // unspecified number pairs with the nearest still-open start of the same kind, within the part
-    // and across measures. A stop that matches no start writes MusicXML's default size of 8.
+    // For the sake of file round-trip fidelity, this will be set to 'no' if a the file being read
+    // does not include the size attribute in the stop element.
     Bool writeSize;
 
     OttavaStop() : spannerStop{}, writeSize{Bool::unspecified}

--- a/src/include/mx/api/OttavaData.h
+++ b/src/include/mx/api/OttavaData.h
@@ -3,6 +3,7 @@
 // Distributed under the MIT License
 
 #pragma once
+#include "mx/api/ApiCommon.h"
 #include "mx/api/SpannerData.h"
 
 namespace mx
@@ -47,13 +48,21 @@ class OttavaStop
   public:
     SpannerStop spannerStop;
 
-    // MusicXML's octave-shift allows a size attribute ("8", "15", or "22") on the stop, not just the
-    // start. Most writers omit it there since it is implied by the corresponding start, but some
-    // importers (e.g. MuseScore) expect it to be present. Absent by default; set it to have the
-    // writer emit it explicitly.
-    std::optional<int> size;
+    // Octave-shift size fidelity knob. A stop's size (8, 15, or 22) is never its own musical fact:
+    // it belongs to the OttavaStart that opened the line, so the writer takes it from there. The
+    // stop is paired with its start by spannerStop.number -- an identity, an explicit level, or an
+    // unspecified number pairs with the nearest still-open start of the same kind, within the part
+    // and across measures.
+    //
+    // unspecified (the default) and yes both write the size the start implies; no omits the
+    // attribute. Omitting it is legal MusicXML, but some importers (e.g. MuseScore) expect it, so
+    // authoring leaves this alone and gets the interoperable spelling. The reader sets yes or no to
+    // record whether the source spelled the attribute out.
+    //
+    // A stop with no matching start writes MusicXML's default size of 8.
+    Bool writeSize;
 
-    OttavaStop() : spannerStop{}, size{std::nullopt}
+    OttavaStop() : spannerStop{}, writeSize{Bool::unspecified}
     {
     }
 };
@@ -67,7 +76,7 @@ MXAPI_NOT_EQUALS_AND_VECTORS(OttavaStart);
 
 MXAPI_EQUALS_BEGIN(OttavaStop)
 MXAPI_EQUALS_MEMBER(spannerStop)
-MXAPI_EQUALS_MEMBER(size)
+MXAPI_EQUALS_MEMBER(writeSize)
 MXAPI_EQUALS_END;
 MXAPI_NOT_EQUALS_AND_VECTORS(OttavaStop);
 } // namespace api

--- a/src/include/mx/api/OttavaData.h
+++ b/src/include/mx/api/OttavaData.h
@@ -31,11 +31,12 @@ class OttavaStart
     SpannerStart spannerStart;
     OttavaType ottavaType;
 
-    // Octave-shift size fidelity knob. The size value (8, 15, or 22) follows from ottavaType, so
-    // 15ma/15mb and 22ma/22mb lines always write their size while an 8va/8vb line omits the
-    // redundant, spec-default size="8". When true, the writer also emits that redundant size="8";
-    // the reader sets it when the source spelled the attribute out. Leave false (the default) when
-    // authoring. It has no effect on a 15ma/15mb or 22ma/22mb line, whose size is always written.
+    // Most users can ignore this; leave it false. It only controls whether an 8va/8vb line writes
+    // the redundant size="8" attribute. The size (8, 15, or 22) follows from ottavaType, and 8 is
+    // MusicXML's default, so a 15ma/15mb or 22ma/22mb line always writes its size while an 8va/8vb
+    // line omits it. When true, that redundant size="8" is written too; the flag has no effect on
+    // the larger lines, whose size is always written. It exists for round-trip fidelity - reading a
+    // file sets it when the source spelled the attribute out.
     bool writeDefaultSize;
 
     OttavaStart() : spannerStart{}, ottavaType{OttavaType::unspecified}, writeDefaultSize{false}
@@ -48,18 +49,19 @@ class OttavaStop
   public:
     SpannerStop spannerStop;
 
-    // Octave-shift size fidelity knob. A stop's size (8, 15, or 22) is never its own musical fact:
-    // it belongs to the OttavaStart that opened the line, so the writer takes it from there. The
-    // stop is paired with its start by spannerStop.number -- an identity, an explicit level, or an
+    // Most users can ignore this; leave it unspecified. It only controls whether the stop end of an
+    // octave-shift line repeats the line's size (8, 15, or 22). The size is not the stop's own
+    // fact: it belongs to the OttavaStart that opened the line, so an authored ottava states its
+    // octave shift once, on the start, and the writer puts the matching size on the stop.
+    //
+    // unspecified (the default) and yes both write that size; no omits it. Omitting it is legal
+    // MusicXML, but some importers (MuseScore among them) expect it, so the default is the
+    // interoperable spelling. It exists for round-trip fidelity - reading a file sets yes or no
+    // according to whether the source spelled the attribute out.
+    //
+    // The start a stop closes is found by spannerStop.number: an identity, an explicit level, or an
     // unspecified number pairs with the nearest still-open start of the same kind, within the part
-    // and across measures.
-    //
-    // unspecified (the default) and yes both write the size the start implies; no omits the
-    // attribute. Omitting it is legal MusicXML, but some importers (e.g. MuseScore) expect it, so
-    // authoring leaves this alone and gets the interoperable spelling. The reader sets yes or no to
-    // record whether the source spelled the attribute out.
-    //
-    // A stop with no matching start writes MusicXML's default size of 8.
+    // and across measures. A stop that matches no start writes MusicXML's default size of 8.
     Bool writeSize;
 
     OttavaStop() : spannerStop{}, writeSize{Bool::unspecified}

--- a/src/private/mx/impl/CurveFunctions.h
+++ b/src/private/mx/impl/CurveFunctions.h
@@ -162,8 +162,8 @@ template <typename SLUR_OR_TIE_ELEMENT_TYPE> api::CurveStop parseCurveStop(const
     return c;
 }
 
-// The number each writer helper emits is the one the SpannerNumberResolver
-// pass resolved for the object (verbatim for an explicit level, assigned from
+// The number each writer helper emits is the one the SpannerResolver pass
+// resolved for the object (verbatim for an explicit level, assigned from
 // serialization order for an identity, absent for unspecified) -- the helpers
 // never look at the SpannerNumber directly.
 template <typename ATTRIBUTES_TYPE>

--- a/src/private/mx/impl/DirectionReader.cpp
+++ b/src/private/mx/impl/DirectionReader.cpp
@@ -720,7 +720,11 @@ void DirectionReader::parseOctaveShift(const core::DirectionType &directionType)
         api::OttavaStop stop;
         stop.spannerStop = impl::getSpannerStop(octaveShift);
         stop.spannerStop.tickTimePosition = myCursor.tickTimePosition;
-        stop.size = octaveShift.size();
+
+        // The stop's size is not kept: it restates the start's octave shift, and a stop whose size
+        // contradicts its start would let the api hold two answers to one question. Only whether
+        // the source spelled the attribute out is recorded, so the same spelling is written back.
+        stop.writeSize = octaveShift.size().has_value() ? api::Bool::yes : api::Bool::no;
         myOutDirectionData.directionTypes.emplace_back(api::DirectionChoice{std::move(stop)});
         return;
     }
@@ -740,6 +744,10 @@ void DirectionReader::parseOctaveShift(const core::DirectionType &directionType)
     // to the "down" variants (o8vb/o15mb/o22mb).
     bool isUp = octaveShift.type().tag() == core::UpDownStopContinue::Tag::up;
 
+    // MusicXML allows any positive size, but notation only uses 8, 15, and 22, which is all
+    // OttavaType names. A size outside those three is normalized to the nearest named line it can
+    // stand for -- 22 exactly, anything else above 8 as 15, everything else 8 -- and the line is
+    // written back with that normalized size.
     if (!isUp && amount == 22)
     {
         ottavaType = api::OttavaType::o22ma;

--- a/src/private/mx/impl/DirectionReader.cpp
+++ b/src/private/mx/impl/DirectionReader.cpp
@@ -721,9 +721,8 @@ void DirectionReader::parseOctaveShift(const core::DirectionType &directionType)
         stop.spannerStop = impl::getSpannerStop(octaveShift);
         stop.spannerStop.tickTimePosition = myCursor.tickTimePosition;
 
-        // The stop's size is not kept: it restates the start's octave shift, and a stop whose size
-        // contradicts its start would let the api hold two answers to one question. Only whether
-        // the source spelled the attribute out is recorded, so the same spelling is written back.
+        // The api holds size information at the start since specifying it on the stop is redundant.
+        // Here we ignore the value and just record its presence or absence for round-trip fidelity.
         stop.writeSize = octaveShift.size().has_value() ? api::Bool::yes : api::Bool::no;
         myOutDirectionData.directionTypes.emplace_back(api::DirectionChoice{std::move(stop)});
         return;

--- a/src/private/mx/impl/DirectionReader.cpp
+++ b/src/private/mx/impl/DirectionReader.cpp
@@ -744,10 +744,8 @@ void DirectionReader::parseOctaveShift(const core::DirectionType &directionType)
     // to the "down" variants (o8vb/o15mb/o22mb).
     bool isUp = octaveShift.type().tag() == core::UpDownStopContinue::Tag::up;
 
-    // MusicXML allows any positive size, but notation only uses 8, 15, and 22, which is all
-    // OttavaType names. A size outside those three is normalized to the nearest named line it can
-    // stand for -- 22 exactly, anything else above 8 as 15, everything else 8 -- and the line is
-    // written back with that normalized size.
+    // MusicXML does not properly constrain the ottava size to valid music notation values. We do
+    // so here by interpolating the value into an enum that maps to valid music notation.
     if (!isUp && amount == 22)
     {
         ottavaType = api::OttavaType::o22ma;

--- a/src/private/mx/impl/DirectionWriter.cpp
+++ b/src/private/mx/impl/DirectionWriter.cpp
@@ -112,6 +112,7 @@
 #include "mx/impl/IdFunctions.h"
 #include "mx/impl/LineFunctions.h"
 #include "mx/impl/MarkDataFunctions.h"
+#include "mx/impl/OttavaFunctions.h"
 #include "mx/impl/PrintFunctions.h"
 #include "mx/impl/SoundFunctions.h"
 #include "mx/impl/SpannerFunctions.h"
@@ -145,8 +146,8 @@ static void applyBracketLineData(const api::LineData &lineData, core::Bracket &b
 }
 
 DirectionWriter::DirectionWriter(const api::DirectionData &inDirectionData, const Cursor &inCursor,
-                                 const SpannerNumberResolver &inNumberResolver)
-    : myDirectionData{inDirectionData}, myCursor{inCursor}, myNumberResolver{inNumberResolver}, myConverter{},
+                                 const SpannerResolver &inSpannerResolver)
+    : myDirectionData{inDirectionData}, myCursor{inCursor}, mySpannerResolver{inSpannerResolver}, myConverter{},
       myPlacements{}, myIsFirstDirectionTypeAdded{false}
 {
 }
@@ -344,7 +345,7 @@ void DirectionWriter::emitWedgeStop(const api::WedgeStop &wedgeStop, const void 
     core::Wedge wedge{};
     wedge.setType(core::WedgeType::stop());
 
-    const auto number = myNumberResolver.emittedNumber(wedgeStop.number, inIdentity);
+    const auto number = mySpannerResolver.emittedNumber(wedgeStop.number, inIdentity);
     if (number.has_value())
     {
         wedge.setNumber(core::NumberLevel{*number});
@@ -371,7 +372,7 @@ void DirectionWriter::emitWedgeStart(const api::WedgeStart &wedgeStart, const vo
         wedge.setType(myConverter.convert(wedgeStart.wedgeType));
     }
 
-    const auto number = myNumberResolver.emittedNumber(wedgeStart.number, inIdentity);
+    const auto number = mySpannerResolver.emittedNumber(wedgeStart.number, inIdentity);
     if (number.has_value())
     {
         wedge.setNumber(core::NumberLevel{*number});
@@ -399,9 +400,18 @@ void DirectionWriter::emitOttavaStop(const api::OttavaStop &ottavaStop, const vo
 {
     core::OctaveShift os{};
     setAttributesFromSpannerStop(ottavaStop.spannerStop, os,
-                                 myNumberResolver.emittedNumber(ottavaStop.spannerStop.number, inIdentity));
+                                 mySpannerResolver.emittedNumber(ottavaStop.spannerStop.number, inIdentity));
     os.setType(core::UpDownStopContinue::stop());
-    os.setSize(ottavaStop.size);
+
+    // The stop has no size of its own; it inherits the size of the start it closes, which the
+    // resolver pass paired for it (8 when nothing matched). Bool::no is the only value that
+    // suppresses the attribute -- an authored stop leaves writeSize unspecified and still gets the
+    // size, because importers such as MuseScore expect it there.
+    if (ottavaStop.writeSize != api::Bool::no)
+    {
+        os.setSize(mySpannerResolver.ottavaStopSize(inIdentity));
+    }
+
     core::DirectionType dt{};
     dt.setChoice(core::DirectionTypeChoice::octaveShift(os));
     addDirectionType(std::move(dt), direction);
@@ -416,46 +426,28 @@ void DirectionWriter::emitOttavaStart(const api::OttavaStart &ottavaStart, const
     impl::setAttributesFromLineData(ottavaStart.spannerStart.lineData, os);
     impl::setId(ottavaStart.spannerStart.id, os);
 
-    const auto number = myNumberResolver.emittedNumber(ottavaStart.spannerStart.number, inIdentity);
+    const auto number = mySpannerResolver.emittedNumber(ottavaStart.spannerStart.number, inIdentity);
     if (number.has_value())
     {
         os.setNumber(core::NumberLevel{*number});
     }
 
-    int sizeValue = 8;
-
+    // An "up" ottava (o8va and friends) writes notes below their sounding pitch, which the spec
+    // spells type="down"; see the OttavaType comment in api/OttavaData.h.
     switch (ottavaStart.ottavaType)
     {
-    case api::OttavaType::o15ma: {
+    case api::OttavaType::o8va:
+    case api::OttavaType::o15ma:
+    case api::OttavaType::o22ma:
         os.setType(core::UpDownStopContinue::down());
-        sizeValue = 15;
         break;
-    }
-    case api::OttavaType::o15mb: {
+
+    case api::OttavaType::o8vb:
+    case api::OttavaType::o15mb:
+    case api::OttavaType::o22mb:
         os.setType(core::UpDownStopContinue::up());
-        sizeValue = 15;
         break;
-    }
-    case api::OttavaType::o22ma: {
-        os.setType(core::UpDownStopContinue::down());
-        sizeValue = 22;
-        break;
-    }
-    case api::OttavaType::o22mb: {
-        os.setType(core::UpDownStopContinue::up());
-        sizeValue = 22;
-        break;
-    }
-    case api::OttavaType::o8va: {
-        os.setType(core::UpDownStopContinue::down());
-        sizeValue = 8;
-        break;
-    }
-    case api::OttavaType::o8vb: {
-        os.setType(core::UpDownStopContinue::up());
-        sizeValue = 8;
-        break;
-    }
+
     default:
         break;
     }
@@ -463,6 +455,7 @@ void DirectionWriter::emitOttavaStart(const api::OttavaStart &ottavaStart, const
     // size follows from ottavaType; non-8va lines need an explicit size to encode their shift, while
     // the redundant default size="8" is emitted only when writeDefaultSize is set (the source spelled
     // it out).
+    const int sizeValue = ottavaTypeSize(ottavaStart.ottavaType);
     if (sizeValue != 8 || ottavaStart.writeDefaultSize)
     {
         os.setSize(sizeValue);
@@ -477,7 +470,7 @@ void DirectionWriter::emitBracketStart(const api::SpannerStart &item, const void
                                        core::Direction &direction)
 {
     core::Bracket bracket{};
-    setAttributesFromSpannerStart(item, bracket, myNumberResolver.emittedNumber(item.number, inIdentity));
+    setAttributesFromSpannerStart(item, bracket, mySpannerResolver.emittedNumber(item.number, inIdentity));
     bracket.setType(core::StartStopContinue::start());
     setAttributesFromPositionData(item.positionData, bracket);
     setAttributesFromPrintData(item.printData, bracket);
@@ -490,7 +483,7 @@ void DirectionWriter::emitBracketStart(const api::SpannerStart &item, const void
 void DirectionWriter::emitBracketStop(const api::SpannerStop &item, const void *inIdentity, core::Direction &direction)
 {
     core::Bracket bracket{};
-    setAttributesFromSpannerStop(item, bracket, myNumberResolver.emittedNumber(item.number, inIdentity));
+    setAttributesFromSpannerStop(item, bracket, mySpannerResolver.emittedNumber(item.number, inIdentity));
     bracket.setType(core::StartStopContinue::stop());
     applyBracketLineData(item.lineData, bracket, myConverter);
     core::DirectionType dt{};
@@ -501,7 +494,7 @@ void DirectionWriter::emitBracketStop(const api::SpannerStop &item, const void *
 void DirectionWriter::emitDashesStart(const api::SpannerStart &item, const void *inIdentity, core::Direction &direction)
 {
     core::Dashes dashes{};
-    setAttributesFromSpannerStart(item, dashes, myNumberResolver.emittedNumber(item.number, inIdentity));
+    setAttributesFromSpannerStart(item, dashes, mySpannerResolver.emittedNumber(item.number, inIdentity));
     dashes.setType(core::StartStopContinue::start());
     setAttributesFromPositionData(item.positionData, dashes);
     setAttributesFromPrintData(item.printData, dashes);
@@ -514,7 +507,7 @@ void DirectionWriter::emitDashesStart(const api::SpannerStart &item, const void 
 void DirectionWriter::emitDashesStop(const api::SpannerStop &item, const void *inIdentity, core::Direction &direction)
 {
     core::Dashes dashes{};
-    setAttributesFromSpannerStop(item, dashes, myNumberResolver.emittedNumber(item.number, inIdentity));
+    setAttributesFromSpannerStop(item, dashes, mySpannerResolver.emittedNumber(item.number, inIdentity));
     dashes.setType(core::StartStopContinue::stop());
     core::DirectionType dt{};
     dt.setChoice(core::DirectionTypeChoice::dashes(dashes));

--- a/src/private/mx/impl/DirectionWriter.h
+++ b/src/private/mx/impl/DirectionWriter.h
@@ -23,10 +23,9 @@ namespace impl
 class DirectionWriter
 {
   public:
-    // inSpannerResolver supplies the resolved 'number' for each wedge, octave
-    // shift, bracket, and dashes start/stop, and the size each octave-shift
-    // stop inherits from its start (see SpannerResolver); it must outlive this
-    // writer.
+    // inSpannerResolver supplies the resolved 'number' for start/stop pairs such as wedge,
+    // octave-shift, bracket, and dashes and stop semantics such as the size attribute of an
+    // octave-shift (see SpannerResolver); it outlives this writer.
     DirectionWriter(const api::DirectionData &inDirectionData, const Cursor &inCursor,
                     const SpannerResolver &inSpannerResolver);
     std::vector<core::MusicDataChoice> getDirectionLikeThings();

--- a/src/private/mx/impl/DirectionWriter.h
+++ b/src/private/mx/impl/DirectionWriter.h
@@ -11,7 +11,7 @@
 #include "mx/core/generated/PercussionChoice.h"
 #include "mx/impl/Converter.h"
 #include "mx/impl/Cursor.h"
-#include "mx/impl/SpannerNumberResolver.h"
+#include "mx/impl/SpannerResolver.h"
 
 #include <set>
 #include <vector>
@@ -23,11 +23,12 @@ namespace impl
 class DirectionWriter
 {
   public:
-    // inNumberResolver supplies the resolved 'number' for each wedge, octave
-    // shift, bracket, and dashes start/stop (see SpannerNumberResolver); it
-    // must outlive this writer.
+    // inSpannerResolver supplies the resolved 'number' for each wedge, octave
+    // shift, bracket, and dashes start/stop, and the size each octave-shift
+    // stop inherits from its start (see SpannerResolver); it must outlive this
+    // writer.
     DirectionWriter(const api::DirectionData &inDirectionData, const Cursor &inCursor,
-                    const SpannerNumberResolver &inNumberResolver);
+                    const SpannerResolver &inSpannerResolver);
     std::vector<core::MusicDataChoice> getDirectionLikeThings();
 
   private:
@@ -38,8 +39,8 @@ class DirectionWriter
                              std::vector<core::MusicDataChoice> &ioOutputSet);
 
     // The spanner emitters take inIdentity, the address of the DirectionChoice that holds the
-    // spanner: the same address the SpannerNumberResolver saw when it walked the score, so the
-    // resolved 'number' can be looked up for the emitted element.
+    // spanner: the same address the SpannerResolver saw when it walked the score, so the resolved
+    // 'number' -- and, for an ottava stop, the size -- can be looked up for the emitted element.
     void emitMark(api::MarkData mark, core::Direction &direction);
     void emitPedal(const api::PedalLineData &pedal, core::Direction &direction);
     void emitWedgeStop(const api::WedgeStop &wedgeStop, const void *inIdentity, core::Direction &direction);
@@ -77,7 +78,7 @@ class DirectionWriter
   private:
     const api::DirectionData &myDirectionData;
     const Cursor myCursor;
-    const SpannerNumberResolver &myNumberResolver;
+    const SpannerResolver &mySpannerResolver;
     const Converter myConverter;
     bool myIsFirstDirectionTypeAdded;
     std::set<api::Placement> myPlacements;

--- a/src/private/mx/impl/GlissandoFunctions.h
+++ b/src/private/mx/impl/GlissandoFunctions.h
@@ -108,7 +108,7 @@ void parseGlissandoOrSlide(const GLISSANDO_OR_SLIDE_TYPE &inElement, api::NoteAt
     }
 }
 
-// The number written is the one the SpannerNumberResolver pass resolved for the object -- mirrors
+// The number written is the one the SpannerResolver pass resolved for the object -- mirrors
 // writeAttributesFromCurveStart/Stop in CurveFunctions.h.
 template <typename GLISSANDO_OR_SLIDE_TYPE>
 void writeAttributesFromGlissandoStart(const api::GlissandoStart &inStart, GLISSANDO_OR_SLIDE_TYPE &outElement,

--- a/src/private/mx/impl/MeasureWriter.cpp
+++ b/src/private/mx/impl/MeasureWriter.cpp
@@ -826,7 +826,7 @@ void MeasureWriter::writeDirection(const api::DirectionData &inDirectionData)
         myPropertiesWriter->flushBuffer();
     }
 
-    DirectionWriter directionWriter{inDirectionData, myHistory.getCursor(), myScoreWriter.getSpannerNumberResolver()};
+    DirectionWriter directionWriter{inDirectionData, myHistory.getCursor(), myScoreWriter.getSpannerResolver()};
     auto mdcSet = directionWriter.getDirectionLikeThings();
     for (const auto &mdc : mdcSet)
     {

--- a/src/private/mx/impl/NotationsWriter.cpp
+++ b/src/private/mx/impl/NotationsWriter.cpp
@@ -108,7 +108,7 @@ core::Notations NotationsWriter::getNotations() const
     core::Ornaments ornaments;
     core::Technical technicals;
 
-    const auto &numberResolver = myScoreWriter.getSpannerNumberResolver();
+    const auto &spannerResolver = myScoreWriter.getSpannerResolver();
 
     for (const auto &curve : myNoteData.noteAttachmentData.curveStops)
     {
@@ -116,7 +116,7 @@ core::Notations NotationsWriter::getNotations() const
         {
             continue;
         }
-        const auto resolvedNumber = numberResolver.emittedNumber(curve.number, &curve);
+        const auto resolvedNumber = spannerResolver.emittedNumber(curve.number, &curve);
         if (curve.curveType == api::CurveType::tie)
         {
             core::Tied tied;
@@ -137,7 +137,7 @@ core::Notations NotationsWriter::getNotations() const
         {
             continue;
         }
-        const auto resolvedNumber = numberResolver.emittedNumber(curve.number, &curve);
+        const auto resolvedNumber = spannerResolver.emittedNumber(curve.number, &curve);
         if (curve.curveType == api::CurveType::tie)
         {
             core::Tied tied;
@@ -158,7 +158,7 @@ core::Notations NotationsWriter::getNotations() const
         {
             continue;
         }
-        const auto resolvedNumber = numberResolver.emittedNumber(curve.number, &curve);
+        const auto resolvedNumber = spannerResolver.emittedNumber(curve.number, &curve);
         if (curve.curveType == api::CurveType::tie)
         {
             core::Tied tied;
@@ -465,13 +465,13 @@ core::Notations NotationsWriter::getNotations() const
 
 void NotationsWriter::addGlissandoAndSlide(core::Notations &outNotations) const
 {
-    const auto &numberResolver = myScoreWriter.getSpannerNumberResolver();
+    const auto &spannerResolver = myScoreWriter.getSpannerResolver();
 
     // Glissando and slide are top-level <notations> children, like slur/tie. Stops are emitted
     // before starts so a chain of glissandi on one note keeps score order (see #139).
     for (const auto &glissandoStop : myNoteData.noteAttachmentData.glissandoStops)
     {
-        const auto resolvedNumber = numberResolver.emittedNumber(glissandoStop.number, &glissandoStop);
+        const auto resolvedNumber = spannerResolver.emittedNumber(glissandoStop.number, &glissandoStop);
         if (glissandoStop.glissandoType == api::GlissandoType::slide)
         {
             core::Slide slide;
@@ -488,7 +488,7 @@ void NotationsWriter::addGlissandoAndSlide(core::Notations &outNotations) const
 
     for (const auto &glissandoStart : myNoteData.noteAttachmentData.glissandoStarts)
     {
-        const auto resolvedNumber = numberResolver.emittedNumber(glissandoStart.number, &glissandoStart);
+        const auto resolvedNumber = spannerResolver.emittedNumber(glissandoStart.number, &glissandoStart);
         if (glissandoStart.glissandoType == api::GlissandoType::slide)
         {
             core::Slide slide;
@@ -506,11 +506,11 @@ void NotationsWriter::addGlissandoAndSlide(core::Notations &outNotations) const
 
 void NotationsWriter::addWavyLineStopsAndContinues(core::Ornaments &outOrnaments) const
 {
-    const auto &numberResolver = myScoreWriter.getSpannerNumberResolver();
+    const auto &spannerResolver = myScoreWriter.getSpannerResolver();
 
     for (const auto &wavyLineStop : myNoteData.noteAttachmentData.wavyLineStops)
     {
-        const auto resolvedNumber = numberResolver.emittedNumber(wavyLineStop.number, &wavyLineStop);
+        const auto resolvedNumber = spannerResolver.emittedNumber(wavyLineStop.number, &wavyLineStop);
         core::OrnamentsGroup group;
         group.setChoice(core::OrnamentsGroupChoice::wavyLine(writeWavyLineStop(wavyLineStop, resolvedNumber)));
         outOrnaments.addGroup(group);
@@ -518,7 +518,7 @@ void NotationsWriter::addWavyLineStopsAndContinues(core::Ornaments &outOrnaments
 
     for (const auto &wavyLineContinue : myNoteData.noteAttachmentData.wavyLineContinuations)
     {
-        const auto resolvedNumber = numberResolver.emittedNumber(wavyLineContinue.number, &wavyLineContinue);
+        const auto resolvedNumber = spannerResolver.emittedNumber(wavyLineContinue.number, &wavyLineContinue);
         core::OrnamentsGroup group;
         group.setChoice(core::OrnamentsGroupChoice::wavyLine(writeWavyLineContinue(wavyLineContinue, resolvedNumber)));
         outOrnaments.addGroup(group);
@@ -527,11 +527,11 @@ void NotationsWriter::addWavyLineStopsAndContinues(core::Ornaments &outOrnaments
 
 void NotationsWriter::addWavyLineStarts(core::Ornaments &outOrnaments) const
 {
-    const auto &numberResolver = myScoreWriter.getSpannerNumberResolver();
+    const auto &spannerResolver = myScoreWriter.getSpannerResolver();
 
     for (const auto &wavyLineStart : myNoteData.noteAttachmentData.wavyLineStarts)
     {
-        const auto resolvedNumber = numberResolver.emittedNumber(wavyLineStart.number, &wavyLineStart);
+        const auto resolvedNumber = spannerResolver.emittedNumber(wavyLineStart.number, &wavyLineStart);
         core::OrnamentsGroup group;
         group.setChoice(core::OrnamentsGroupChoice::wavyLine(writeWavyLineStart(wavyLineStart, resolvedNumber)));
         outOrnaments.addGroup(group);

--- a/src/private/mx/impl/OttavaFunctions.h
+++ b/src/private/mx/impl/OttavaFunctions.h
@@ -1,0 +1,33 @@
+// MusicXML Class Library
+// Copyright (c) by Matthew James Briggs
+// Distributed under the MIT License
+
+#pragma once
+
+#include "mx/api/OttavaData.h"
+
+namespace mx
+{
+namespace impl
+{
+// The octave-shift size an ottava line encodes: 8 for 8va/8vb, 15 for 15ma/15mb, 22 for 22ma/22mb.
+// An unspecified type falls back to MusicXML's default size of 8. This is the single source of the
+// size fact -- the start writes it from its own OttavaType and the matching stop borrows it.
+inline int ottavaTypeSize(api::OttavaType inOttavaType)
+{
+    switch (inOttavaType)
+    {
+    case api::OttavaType::o15ma:
+    case api::OttavaType::o15mb:
+        return 15;
+
+    case api::OttavaType::o22ma:
+    case api::OttavaType::o22mb:
+        return 22;
+
+    default:
+        return 8;
+    }
+}
+} // namespace impl
+} // namespace mx

--- a/src/private/mx/impl/ScoreWriter.cpp
+++ b/src/private/mx/impl/ScoreWriter.cpp
@@ -32,7 +32,7 @@ namespace mx
 namespace impl
 {
 ScoreWriter::ScoreWriter(const api::ScoreData &inScoreData)
-    : myScoreData{inScoreData}, mySpannerNumberResolver{}, myMutex{}, myOutScorePartwise{}
+    : myScoreData{inScoreData}, mySpannerResolver{}, myMutex{}, myOutScorePartwise{}
 {
     myScoreData.sort();
 
@@ -40,7 +40,7 @@ ScoreWriter::ScoreWriter(const api::ScoreData &inScoreData)
     // ones the measure/note writers will visit.
     for (const auto &part : myScoreData.parts)
     {
-        mySpannerNumberResolver.resolvePart(part);
+        mySpannerResolver.resolvePart(part);
     }
 }
 

--- a/src/private/mx/impl/ScoreWriter.h
+++ b/src/private/mx/impl/ScoreWriter.h
@@ -10,7 +10,7 @@
 #include "mx/core/generated/ScorePart.h"
 #include "mx/core/generated/ScorePartwise.h"
 #include "mx/impl/Cursor.h"
-#include "mx/impl/SpannerNumberResolver.h"
+#include "mx/impl/SpannerResolver.h"
 
 #include <mutex>
 #include <optional>
@@ -39,17 +39,18 @@ class ScoreWriter
     std::optional<api::PageData> findPageLayoutData(api::MeasureIndex measureIndex) const;
     api::SystemData getSystemData(int measureIndex) const;
 
-    // Spanner 'number' assignments for the ScoreData held by this writer,
-    // computed once at construction (after the score is sorted, so the
-    // resolved object addresses match what the measure/note writers visit).
-    inline const SpannerNumberResolver &getSpannerNumberResolver() const
+    // Spanner 'number' assignments and octave-shift stop sizes for the
+    // ScoreData held by this writer, computed once at construction (after the
+    // score is sorted, so the resolved object addresses match what the
+    // measure/note writers visit).
+    inline const SpannerResolver &getSpannerResolver() const
     {
-        return mySpannerNumberResolver;
+        return mySpannerResolver;
     }
 
   private:
     api::ScoreData myScoreData;
-    SpannerNumberResolver mySpannerNumberResolver;
+    SpannerResolver mySpannerResolver;
     mutable std::mutex myMutex;
     mutable core::ScorePartwise myOutScorePartwise;
 

--- a/src/private/mx/impl/ScoreWriter.h
+++ b/src/private/mx/impl/ScoreWriter.h
@@ -39,10 +39,7 @@ class ScoreWriter
     std::optional<api::PageData> findPageLayoutData(api::MeasureIndex measureIndex) const;
     api::SystemData getSystemData(int measureIndex) const;
 
-    // Spanner 'number' assignments and octave-shift stop sizes for the
-    // ScoreData held by this writer, computed once at construction (after the
-    // score is sorted, so the resolved object addresses match what the
-    // measure/note writers visit).
+    // Get the writers shared spanner resolution state object.
     inline const SpannerResolver &getSpannerResolver() const
     {
         return mySpannerResolver;

--- a/src/private/mx/impl/SpannerFunctions.h
+++ b/src/private/mx/impl/SpannerFunctions.h
@@ -49,8 +49,8 @@ template <typename ATTRIBUTES_TYPE> api::SpannerStop getSpannerStop(const ATTRIB
 MX_OPTIONAL_SET_HAS_FUNC(number, setNumber, Number);
 MX_OPTIONAL_SET_INT_FUNC(number, setNumber, Number);
 
-// The number written is the one the SpannerNumberResolver pass resolved for
-// the object; these helpers never look at the SpannerNumber directly.
+// The number written is the one the SpannerResolver pass resolved for the
+// object; these helpers never look at the SpannerNumber directly.
 template <typename ATTRIBUTES_TYPE>
 void setAttributesFromSpannerStart(const api::SpannerStart &start, ATTRIBUTES_TYPE &outAttributes,
                                    const std::optional<int> &inResolvedNumber)

--- a/src/private/mx/impl/SpannerResolver.cpp
+++ b/src/private/mx/impl/SpannerResolver.cpp
@@ -2,8 +2,9 @@
 // Copyright (c) by Matthew James Briggs
 // Distributed under the MIT License
 
-#include "mx/impl/SpannerNumberResolver.h"
+#include "mx/impl/SpannerResolver.h"
 #include "mx/api/GlissandoData.h"
+#include "mx/impl/OttavaFunctions.h"
 #include "mx/utility/Throw.h"
 
 #include <algorithm>
@@ -62,11 +63,39 @@ inline bool spannerNumberIntervalsOverlap(const SpannerNumberInterval &inLeft, c
     return inLeft.first <= inRight.last && inRight.first <= inLeft.last;
 }
 
+// One octave-shift start or stop, in serialized order. Starts carry the OttavaType that states
+// the line's size; stops carry the address the writer will present when it asks for that size.
+struct SpannerOttavaEvent
+{
+    const void *object;
+    api::SpannerNumber number;
+    api::OttavaType ottavaType;
+    bool isStart;
+};
+
+// The bucket an ottava endpoint pairs within: identity endpoints pair by id, explicit endpoints
+// by level, and unspecified endpoints with each other. The prefix keeps the three kinds from
+// colliding (an identity of "3" is not the explicit level 3).
+static std::string spannerOttavaPairingKey(const api::SpannerNumber &inNumber)
+{
+    switch (inNumber.kind())
+    {
+    case api::SpannerNumber::Kind::explicitLevel:
+        return "e" + std::to_string(inNumber.level());
+
+    case api::SpannerNumber::Kind::identity:
+        return "i" + inNumber.identity();
+
+    default:
+        return "u";
+    }
+}
+
 // Collects spanner events in the exact order MeasureWriter serializes them.
 // The position counter is global; only events within the same class are ever
 // compared, so cross-class interleaving is irrelevant, but within a class the
 // order matches what a streaming reader sees.
-class SpannerNumberEventCollector
+class SpannerEventCollector
 {
   public:
     void addNote(const api::NoteData &inNote)
@@ -131,13 +160,21 @@ class SpannerNumberEventCollector
                 add(SpannerNumberClass::wedge, &choice, choice.wedgeStop().number, false, true);
                 break;
 
-            case api::DirectionChoice::Kind::ottavaStart:
-                add(SpannerNumberClass::octaveShift, &choice, choice.ottavaStart().spannerStart.number, true, false);
+            case api::DirectionChoice::Kind::ottavaStart: {
+                const auto ottavaStart = choice.ottavaStart();
+                add(SpannerNumberClass::octaveShift, &choice, ottavaStart.spannerStart.number, true, false);
+                myOttavaEvents.push_back(
+                    SpannerOttavaEvent{&choice, ottavaStart.spannerStart.number, ottavaStart.ottavaType, true});
                 break;
+            }
 
-            case api::DirectionChoice::Kind::ottavaStop:
-                add(SpannerNumberClass::octaveShift, &choice, choice.ottavaStop().spannerStop.number, false, true);
+            case api::DirectionChoice::Kind::ottavaStop: {
+                const auto ottavaStop = choice.ottavaStop();
+                add(SpannerNumberClass::octaveShift, &choice, ottavaStop.spannerStop.number, false, true);
+                myOttavaEvents.push_back(
+                    SpannerOttavaEvent{&choice, ottavaStop.spannerStop.number, api::OttavaType::unspecified, false});
                 break;
+            }
 
             case api::DirectionChoice::Kind::bracketStart:
                 add(SpannerNumberClass::bracket, &choice, choice.bracketStart().number, true, false);
@@ -164,6 +201,11 @@ class SpannerNumberEventCollector
     const std::map<SpannerNumberClass, std::vector<SpannerNumberEvent>> &events() const
     {
         return myEvents;
+    }
+
+    const std::vector<SpannerOttavaEvent> &ottavaEvents() const
+    {
+        return myOttavaEvents;
     }
 
   private:
@@ -197,6 +239,7 @@ class SpannerNumberEventCollector
 
     int myPosition = 0;
     std::map<SpannerNumberClass, std::vector<SpannerNumberEvent>> myEvents;
+    std::vector<SpannerOttavaEvent> myOttavaEvents;
 };
 
 // Assigns numbers within one spanner class. Explicit levels reserve their
@@ -325,9 +368,35 @@ static void spannerNumberAssignClass(const std::vector<SpannerNumberEvent> &inEv
     }
 }
 
-void SpannerNumberResolver::resolvePart(const api::PartData &inPart)
+// Pairs each ottava stop with the start it closes and records that start's size. Within one
+// pairing bucket a stop closes the most recently opened start still open, so a stop that opens
+// and closes inside another ottava of the same bucket does not steal the outer line's start. A
+// stop with nothing open is left out of ioResolved and falls back to size 8 at write time.
+static void spannerResolveOttavaSizes(const std::vector<SpannerOttavaEvent> &inEvents,
+                                      std::unordered_map<const void *, int> &ioResolved)
 {
-    SpannerNumberEventCollector collector;
+    std::map<std::string, std::vector<api::OttavaType>> openStarts;
+
+    for (const auto &event : inEvents)
+    {
+        auto &stack = openStarts[spannerOttavaPairingKey(event.number)];
+        if (event.isStart)
+        {
+            stack.push_back(event.ottavaType);
+            continue;
+        }
+        if (stack.empty())
+        {
+            continue;
+        }
+        ioResolved[event.object] = ottavaTypeSize(stack.back());
+        stack.pop_back();
+    }
+}
+
+void SpannerResolver::resolvePart(const api::PartData &inPart)
+{
+    SpannerEventCollector collector;
 
     for (const auto &measure : inPart.measures)
     {
@@ -351,9 +420,11 @@ void SpannerNumberResolver::resolvePart(const api::PartData &inPart)
     {
         spannerNumberAssignClass(classAndEvents.second, myResolved);
     }
+
+    spannerResolveOttavaSizes(collector.ottavaEvents(), myOttavaStopSizes);
 }
 
-std::optional<int> SpannerNumberResolver::emittedNumber(const api::SpannerNumber &inNumber, const void *inObject) const
+std::optional<int> SpannerResolver::emittedNumber(const api::SpannerNumber &inNumber, const void *inObject) const
 {
     switch (inNumber.kind())
     {
@@ -373,6 +444,16 @@ std::optional<int> SpannerNumberResolver::emittedNumber(const api::SpannerNumber
     default:
         return std::nullopt;
     }
+}
+
+int SpannerResolver::ottavaStopSize(const void *inObject) const
+{
+    const auto iter = myOttavaStopSizes.find(inObject);
+    if (iter == myOttavaStopSizes.cend())
+    {
+        return ottavaTypeSize(api::OttavaType::unspecified);
+    }
+    return iter->second;
 }
 } // namespace impl
 } // namespace mx

--- a/src/private/mx/impl/SpannerResolver.h
+++ b/src/private/mx/impl/SpannerResolver.h
@@ -13,8 +13,12 @@ namespace mx
 {
 namespace impl
 {
-// Resolves the MusicXML 'number' attribute for every spanner start/continue/stop
-// in a part before the part is written.
+// Resolves the writer-side facts that a spanner endpoint cannot know on its
+// own, in one pass over a part before the part is written: the MusicXML
+// 'number' attribute for every spanner start/continue/stop, and the size an
+// octave-shift stop inherits from the start it closes.
+//
+// == Numbers ==
 //
 // A SpannerNumber self-describes as unspecified, explicit, or identity (see
 // mx/api/ApiCommon.h). Explicit levels are emitted verbatim and unspecified
@@ -48,14 +52,31 @@ namespace impl
 // If more than 16 spanners of one class are open at once in a part (which no
 // real score approaches), resolution fails loudly with an exception rather
 // than emitting an illegal number.
-class SpannerNumberResolver
+//
+// == Octave-shift stop sizes ==
+//
+// An octave-shift's size is stated by api::OttavaStart::ottavaType alone;
+// api::OttavaStop has no size of its own. The same walk therefore pairs each
+// ottava stop with the start it closes and records that start's size, so
+// DirectionWriter can write the stop's size attribute without the author
+// restating it (see api/OttavaData.h).
+//
+// Pairing is by SpannerNumber within the part, in serialized order: identity
+// endpoints pair by id, explicit endpoints by level, and unspecified
+// endpoints with each other. Within one of those groups a stop closes the
+// most recently opened start that is still open, so overlapping ottavas that
+// carry distinct numbers or identities never cross, and pairing spans
+// measures. A stop with no open start is left unpaired and falls back to
+// MusicXML's default size of 8.
+class SpannerResolver
 {
   public:
-    SpannerNumberResolver() = default;
+    SpannerResolver() = default;
 
-    // Walks inPart in serialization order and assigns a number to every
-    // identity spanner event. May be called once per part of a score; results
-    // accumulate (object addresses are unique across parts).
+    // Walks inPart in serialization order, assigning a number to every
+    // identity spanner event and a size to every ottava stop. May be called
+    // once per part of a score; results accumulate (object addresses are
+    // unique across parts).
     void resolvePart(const api::PartData &inPart);
 
     // The number the writer should emit for the given spanner object, or
@@ -66,8 +87,16 @@ class SpannerNumberResolver
     // colliding spanner pair.
     std::optional<int> emittedNumber(const api::SpannerNumber &inNumber, const void *inObject) const;
 
+    // The size (8, 15, or 22) the writer should emit for the given ottava
+    // stop, taken from the start it closes. inObject must be the address of
+    // the same object resolvePart visited. A stop this resolver never paired
+    // -- one with no matching start, or one written outside a resolved part --
+    // gets MusicXML's default size of 8.
+    int ottavaStopSize(const void *inObject) const;
+
   private:
     std::unordered_map<const void *, int> myResolved;
+    std::unordered_map<const void *, int> myOttavaStopSizes;
 };
 } // namespace impl
 } // namespace mx

--- a/src/private/mx/impl/WavyLineFunctions.h
+++ b/src/private/mx/impl/WavyLineFunctions.h
@@ -22,7 +22,7 @@ namespace impl
 // start/continue/stop vector on outAttachments matches its type attribute.
 void parseWavyLine(const core::WavyLine &inWavyLine, api::NoteAttachmentData &outAttachments);
 
-// The number written is the one the SpannerNumberResolver pass resolved for the object.
+// The number written is the one the SpannerResolver pass resolved for the object.
 core::WavyLine writeWavyLineStart(const api::WavyLineStart &inStart, const std::optional<int> &inResolvedNumber);
 core::WavyLine writeWavyLineContinue(const api::WavyLineContinue &inContinue,
                                      const std::optional<int> &inResolvedNumber);

--- a/src/private/mxtest/api/GlissandoApiTest.cpp
+++ b/src/private/mxtest/api/GlissandoApiTest.cpp
@@ -211,7 +211,7 @@ TEST(stopPrecedesStartOnAChainedNote, Glissando)
 
 T_END
 
-// Requirement 2: identity spanners draw from the writer-side SpannerNumberResolver, and glissando
+// Requirement 2: identity spanners draw from the writer-side SpannerResolver, and glissando
 // and slide draw from separate pools even when open at the same time.
 TEST(identityNumbersAssignedPerElementPool, Glissando)
 {

--- a/src/private/mxtest/api/OttavaSizeApiTest.cpp
+++ b/src/private/mxtest/api/OttavaSizeApiTest.cpp
@@ -1,0 +1,346 @@
+// MusicXML Class Library
+// Copyright (c) by Matthew James Briggs
+// Distributed under the MIT License
+
+#include "mxtest/control/CompileControl.h"
+#ifdef MX_COMPILE_API_TESTS
+
+#include "cpul/cpulTestHarness.h"
+#include "mx/api/DocumentManager.h"
+#include "mx/api/OttavaData.h"
+#include "mx/api/ScoreData.h"
+#include "mxtest/api/RoundTrip.h"
+#include "mxtest/api/TestHelpers.h"
+
+#include <string>
+#include <vector>
+
+using namespace mx::api;
+
+// One <octave-shift> element as it was written, reduced to the two attributes these tests care
+// about. An absent size is an empty string.
+struct OttavaSizeWrittenShift
+{
+    std::string type;
+    std::string size;
+};
+
+// Reads the value of inAttribute from inTag, or an empty string when the attribute is absent.
+inline std::string ottavaSizeAttribute(const std::string &inTag, const std::string &inAttribute)
+{
+    const std::string needle = " " + inAttribute + "=\"";
+    const auto valueStart = inTag.find(needle);
+    if (valueStart == std::string::npos)
+    {
+        return {};
+    }
+    const auto from = valueStart + needle.size();
+    const auto to = inTag.find('"', from);
+    if (to == std::string::npos)
+    {
+        return {};
+    }
+    return inTag.substr(from, to - from);
+}
+
+// Every <octave-shift> in the document, in document order.
+inline std::vector<OttavaSizeWrittenShift> ottavaSizeWrittenShifts(const std::string &inXml)
+{
+    std::vector<OttavaSizeWrittenShift> shifts;
+    std::string::size_type pos = 0;
+    while ((pos = inXml.find("<octave-shift", pos)) != std::string::npos)
+    {
+        const auto end = inXml.find('>', pos);
+        if (end == std::string::npos)
+        {
+            break;
+        }
+        const auto tag = inXml.substr(pos, end - pos + 1);
+        shifts.push_back(OttavaSizeWrittenShift{ottavaSizeAttribute(tag, "type"), ottavaSizeAttribute(tag, "size")});
+        pos = end;
+    }
+    return shifts;
+}
+
+// A part of inMeasureCount measures, each holding one quarter note so the directions have
+// somewhere to live.
+inline ScoreData ottavaSizeMakeScore(int inMeasureCount)
+{
+    ScoreData score;
+    score.ticksPerQuarter = 10;
+    auto &part = score.parts.emplace_back();
+    part.uniqueId = "P1";
+    for (int i = 0; i < inMeasureCount; ++i)
+    {
+        auto &measure = part.measures.emplace_back();
+        auto &staff = measure.staves.emplace_back();
+        auto &note = staff.voices[0].notes.emplace_back();
+        note.durationData.durationTimeTicks = 10;
+        note.durationData.durationName = DurationName::quarter;
+    }
+    return score;
+}
+
+inline void ottavaSizeAddDirection(ScoreData &ioScore, int inMeasureIndex, const DirectionChoice &inChoice)
+{
+    DirectionData direction;
+    direction.directionTypes.emplace_back(inChoice);
+    ioScore.parts.front()
+        .measures.at(static_cast<size_t>(inMeasureIndex))
+        .staves.front()
+        .directions.emplace_back(direction);
+}
+
+// Authoring an ottava states its size once, on the start. Every one of the six lines writes the
+// matching size onto its stop without the author restating it, and the stop can sit in a later
+// measure than its start.
+TEST(OttavaStopSizeFollowsStartAcrossMeasures, OttavaSize)
+{
+    struct Expectation
+    {
+        OttavaType ottavaType;
+        std::string startType;
+        std::string size;
+    };
+
+    const std::vector<Expectation> expectations = {{OttavaType::o8va, "down", "8"},   {OttavaType::o8vb, "up", "8"},
+                                                   {OttavaType::o15ma, "down", "15"}, {OttavaType::o15mb, "up", "15"},
+                                                   {OttavaType::o22ma, "down", "22"}, {OttavaType::o22mb, "up", "22"}};
+
+    for (const auto &expectation : expectations)
+    {
+        auto score = ottavaSizeMakeScore(3);
+
+        OttavaStart start;
+        start.ottavaType = expectation.ottavaType;
+        ottavaSizeAddDirection(score, 0, DirectionChoice{start});
+        ottavaSizeAddDirection(score, 2, DirectionChoice{OttavaStop{}});
+
+        const auto xml = mxtest::toXml(score);
+        REQUIRE(!xml.empty());
+        const auto shifts = ottavaSizeWrittenShifts(xml);
+        REQUIRE(shifts.size() == 2);
+        CHECK_EQUAL(expectation.startType, shifts.front().type);
+        CHECK_EQUAL(std::string{"stop"}, shifts.back().type);
+        CHECK_EQUAL(expectation.size, shifts.back().size);
+
+        // Reading the document back recovers the line, and the stop now records that its source
+        // spelled the size out.
+        const auto roundTripped = mxtest::roundTrip(score);
+        const auto &parts = roundTripped.parts;
+        REQUIRE(parts.size() == 1);
+        const auto &measures = parts.front().measures;
+        REQUIRE(measures.size() == 3);
+        const auto &startTypes = measures.front().staves.front().directions.front().directionTypes;
+        REQUIRE(startTypes.size() == 1);
+        REQUIRE(startTypes.front().isOttavaStart());
+        CHECK(expectation.ottavaType == startTypes.front().ottavaStart().ottavaType);
+        const auto &stopTypes = measures.back().staves.front().directions.front().directionTypes;
+        REQUIRE(stopTypes.size() == 1);
+        REQUIRE(stopTypes.front().isOttavaStop());
+        CHECK(Bool::yes == stopTypes.front().ottavaStop().writeSize);
+    }
+}
+
+T_END;
+
+// Two ottavas of different sizes overlap; explicit numbers keep them apart, so each stop takes
+// the size of the start that carries its own number rather than the nearest one.
+TEST(OttavaStopSizeOverlappingExplicitNumbers, OttavaSize)
+{
+    auto score = ottavaSizeMakeScore(4);
+
+    OttavaStart outer;
+    outer.ottavaType = OttavaType::o15ma;
+    outer.spannerStart.number = SpannerNumber(1);
+    ottavaSizeAddDirection(score, 0, DirectionChoice{outer});
+
+    OttavaStart inner;
+    inner.ottavaType = OttavaType::o8vb;
+    inner.spannerStart.number = SpannerNumber(2);
+    ottavaSizeAddDirection(score, 1, DirectionChoice{inner});
+
+    OttavaStop innerStop;
+    innerStop.spannerStop.number = SpannerNumber(2);
+    ottavaSizeAddDirection(score, 2, DirectionChoice{innerStop});
+
+    OttavaStop outerStop;
+    outerStop.spannerStop.number = SpannerNumber(1);
+    ottavaSizeAddDirection(score, 3, DirectionChoice{outerStop});
+
+    const auto xml = mxtest::toXml(score);
+    REQUIRE(!xml.empty());
+    const auto shifts = ottavaSizeWrittenShifts(xml);
+    REQUIRE(shifts.size() == 4);
+    CHECK_EQUAL(std::string{"stop"}, shifts.at(2).type);
+    CHECK_EQUAL(std::string{"8"}, shifts.at(2).size);
+    CHECK_EQUAL(std::string{"stop"}, shifts.at(3).type);
+    CHECK_EQUAL(std::string{"15"}, shifts.at(3).size);
+}
+
+T_END;
+
+// The same overlap authored with identity spanners, which never serialize their label: the writer
+// assigns the MusicXML numbers and each stop still finds its own start.
+TEST(OttavaStopSizeOverlappingIdentities, OttavaSize)
+{
+    auto score = ottavaSizeMakeScore(4);
+
+    OttavaStart outer;
+    outer.ottavaType = OttavaType::o22mb;
+    outer.spannerStart.number = SpannerNumber(std::string{"outer"});
+    ottavaSizeAddDirection(score, 0, DirectionChoice{outer});
+
+    OttavaStart inner;
+    inner.ottavaType = OttavaType::o8va;
+    inner.spannerStart.number = SpannerNumber(std::string{"inner"});
+    ottavaSizeAddDirection(score, 1, DirectionChoice{inner});
+
+    OttavaStop innerStop;
+    innerStop.spannerStop.number = SpannerNumber(std::string{"inner"});
+    ottavaSizeAddDirection(score, 2, DirectionChoice{innerStop});
+
+    OttavaStop outerStop;
+    outerStop.spannerStop.number = SpannerNumber(std::string{"outer"});
+    ottavaSizeAddDirection(score, 3, DirectionChoice{outerStop});
+
+    const auto xml = mxtest::toXml(score);
+    REQUIRE(!xml.empty());
+    const auto shifts = ottavaSizeWrittenShifts(xml);
+    REQUIRE(shifts.size() == 4);
+    CHECK_EQUAL(std::string{"stop"}, shifts.at(2).type);
+    CHECK_EQUAL(std::string{"8"}, shifts.at(2).size);
+    CHECK_EQUAL(std::string{"stop"}, shifts.at(3).type);
+    CHECK_EQUAL(std::string{"22"}, shifts.at(3).size);
+}
+
+T_END;
+
+// Two unnumbered ottavas in a row are not concurrent, so each stop closes the start before it.
+TEST(OttavaStopSizeSequentialUnnumbered, OttavaSize)
+{
+    auto score = ottavaSizeMakeScore(4);
+
+    OttavaStart first;
+    first.ottavaType = OttavaType::o15mb;
+    ottavaSizeAddDirection(score, 0, DirectionChoice{first});
+    ottavaSizeAddDirection(score, 1, DirectionChoice{OttavaStop{}});
+
+    OttavaStart second;
+    second.ottavaType = OttavaType::o8va;
+    ottavaSizeAddDirection(score, 2, DirectionChoice{second});
+    ottavaSizeAddDirection(score, 3, DirectionChoice{OttavaStop{}});
+
+    const auto xml = mxtest::toXml(score);
+    REQUIRE(!xml.empty());
+    const auto shifts = ottavaSizeWrittenShifts(xml);
+    REQUIRE(shifts.size() == 4);
+    CHECK_EQUAL(std::string{"15"}, shifts.at(1).size);
+    CHECK_EQUAL(std::string{"8"}, shifts.at(3).size);
+}
+
+T_END;
+
+// A stop with no start is an authoring error, not a crash: it writes MusicXML's default size of 8
+// and the document still reads back.
+TEST(OttavaStopSizeDanglingStopFallsBackToEight, OttavaSize)
+{
+    auto score = ottavaSizeMakeScore(2);
+    ottavaSizeAddDirection(score, 1, DirectionChoice{OttavaStop{}});
+
+    const auto xml = mxtest::toXml(score);
+    REQUIRE(!xml.empty());
+    const auto shifts = ottavaSizeWrittenShifts(xml);
+    REQUIRE(shifts.size() == 1);
+    CHECK_EQUAL(std::string{"stop"}, shifts.front().type);
+    CHECK_EQUAL(std::string{"8"}, shifts.front().size);
+
+    const auto roundTripped = mxtest::roundTrip(score);
+    const auto &stopTypes = roundTripped.parts.front().measures.back().staves.front().directions.front().directionTypes;
+    REQUIRE(stopTypes.size() == 1);
+    CHECK(stopTypes.front().isOttavaStop());
+}
+
+T_END;
+
+// writeSize is the one way to suppress the attribute, for a caller who needs the terser spelling.
+TEST(OttavaStopWriteSizeNoOmitsTheAttribute, OttavaSize)
+{
+    auto score = ottavaSizeMakeScore(2);
+
+    OttavaStart start;
+    start.ottavaType = OttavaType::o15ma;
+    ottavaSizeAddDirection(score, 0, DirectionChoice{start});
+
+    OttavaStop stop;
+    stop.writeSize = Bool::no;
+    ottavaSizeAddDirection(score, 1, DirectionChoice{stop});
+
+    const auto xml = mxtest::toXml(score);
+    REQUIRE(!xml.empty());
+    const auto shifts = ottavaSizeWrittenShifts(xml);
+    REQUIRE(shifts.size() == 2);
+    CHECK_EQUAL(std::string{"stop"}, shifts.back().type);
+    CHECK(shifts.back().size.empty());
+
+    // The absence survives the trip, because the reader records it.
+    const auto roundTripped = mxtest::roundTrip(score);
+    const auto &stopTypes = roundTripped.parts.front().measures.back().staves.front().directions.front().directionTypes;
+    REQUIRE(stopTypes.size() == 1);
+    REQUIRE(stopTypes.front().isOttavaStop());
+    CHECK(Bool::no == stopTypes.front().ottavaStop().writeSize);
+}
+
+T_END;
+
+// Bool::yes writes the size the start implies -- the same output the unspecified default produces.
+TEST(OttavaStopWriteSizeYesMatchesTheDefault, OttavaSize)
+{
+    auto score = ottavaSizeMakeScore(2);
+
+    OttavaStart start;
+    start.ottavaType = OttavaType::o22ma;
+    ottavaSizeAddDirection(score, 0, DirectionChoice{start});
+
+    OttavaStop stop;
+    stop.writeSize = Bool::yes;
+    ottavaSizeAddDirection(score, 1, DirectionChoice{stop});
+
+    const auto xml = mxtest::toXml(score);
+    REQUIRE(!xml.empty());
+    const auto shifts = ottavaSizeWrittenShifts(xml);
+    REQUIRE(shifts.size() == 2);
+    CHECK_EQUAL(std::string{"22"}, shifts.back().size);
+}
+
+T_END;
+
+// A source whose stop size contradicts its start is normalized: the start states the octave shift,
+// so the stop is rewritten to agree with it.
+TEST(OttavaStopSizeContradictionIsNormalizedToTheStart, OttavaSize)
+{
+    const std::string sourceXml =
+        R"(<?xml version="1.0" encoding="UTF-8"?>)"
+        R"(<!DOCTYPE score-partwise PUBLIC "-//Recordare//DTD MusicXML 4.0 Partwise//EN" "http://www.musicxml.org/dtds/partwise.dtd">)"
+        R"(<score-partwise version="4.0"><part-list><score-part id="P1"><part-name>P</part-name></score-part></part-list>)"
+        R"(<part id="P1"><measure number="1"><attributes><divisions>1</divisions></attributes>)"
+        R"(<direction><direction-type><octave-shift type="down" size="15"/></direction-type></direction>)"
+        R"(<note><pitch><step>C</step><octave>4</octave></pitch><duration>1</duration><type>quarter</type></note>)"
+        R"(<direction><direction-type><octave-shift type="stop" size="8"/></direction-type></direction>)"
+        R"(</measure></part></score-partwise>)";
+
+    const auto score = mxtest::fromXml(sourceXml);
+    REQUIRE(score.parts.size() == 1);
+
+    const auto xml = mxtest::toXml(score);
+    REQUIRE(!xml.empty());
+    const auto shifts = ottavaSizeWrittenShifts(xml);
+    REQUIRE(shifts.size() == 2);
+    CHECK_EQUAL(std::string{"15"}, shifts.front().size);
+    CHECK_EQUAL(std::string{"stop"}, shifts.back().type);
+    CHECK_EQUAL(std::string{"15"}, shifts.back().size);
+}
+
+T_END;
+
+#endif

--- a/src/private/mxtest/api/roundtrip-baseline.txt
+++ b/src/private/mxtest/api/roundtrip-baseline.txt
@@ -663,3 +663,9 @@ synthetic/slide.3.0.xml
 synthetic/slide.3.1.xml
 synthetic/wavy-line.3.0.xml
 synthetic/wavy-line.4.0.xml
+
+# Discovered already passing while working on #372 (automatic octave-shift stop
+# size); neither file contains an <octave-shift>, so they were unblocked by
+# earlier work and simply had not been pinned yet.
+lysuite/ly71c_ChordsFrets.xml
+musuite/testHarmony3.xml

--- a/src/private/mxtest/impl/DirectionReaderTest.cpp
+++ b/src/private/mxtest/impl/DirectionReaderTest.cpp
@@ -142,8 +142,27 @@ TEST(ottavaStop, DirectionReader)
     const auto ottavaStop = directionData.directionTypes.front().ottavaStop();
     CHECK_EQUAL(tickTimePosition, ottavaStop.spannerStop.tickTimePosition);
     CHECK(ottavaStop.spannerStop.number.isUnspecified());
-    CHECK(ottavaStop.size.has_value());
-    CHECK_EQUAL(15, *ottavaStop.size);
+    CHECK(api::Bool::yes == ottavaStop.writeSize);
+}
+
+T_END
+
+// A source stop without a size attribute records that absence, so the same spelling is written
+// back. The size itself is not read: it belongs to the start (see api/OttavaData.h).
+TEST(ottavaStopWithoutSize, DirectionReader)
+{
+    core::OctaveShift oct{};
+    oct.setType(core::UpDownStopContinue::stop());
+    core::DirectionType dirType{};
+    dirType.setChoice(core::DirectionTypeChoice::octaveShift(oct));
+    core::Direction dir{};
+    dir.setDirectionType(core::OneOrMore<core::DirectionType>{dirType});
+    Cursor cursor{1, 100};
+    DirectionReader reader{dir, cursor};
+    const auto directionData = reader.getDirectionData();
+    REQUIRE(directionData.directionTypes.size() == 1);
+    REQUIRE(directionData.directionTypes.front().isOttavaStop());
+    CHECK(api::Bool::no == directionData.directionTypes.front().ottavaStop().writeSize);
 }
 
 T_END

--- a/src/private/mxtest/impl/DirectionWriterTest.cpp
+++ b/src/private/mxtest/impl/DirectionWriterTest.cpp
@@ -14,7 +14,7 @@
 #include "mx/core/generated/OctaveShift.h"
 #include "mx/impl/DirectionReader.h"
 #include "mx/impl/DirectionWriter.h"
-#include "mx/impl/SpannerNumberResolver.h"
+#include "mx/impl/SpannerResolver.h"
 
 #include <memory>
 
@@ -27,9 +27,10 @@ TEST(ottavaStartStop, DirectionWriter)
     cursor.isFirstMeasureInPart = false;
     api::DirectionData directionData;
 
+    // No matching start is visible to the resolver, so this stop takes the documented dangling
+    // fallback and writes MusicXML's default size of 8.
     api::OttavaStop stop{};
     stop.spannerStop.number = api::SpannerNumber(2);
-    stop.size = 15;
     directionData.directionTypes.emplace_back(api::DirectionChoice{stop});
 
     api::OttavaStart start{};
@@ -53,8 +54,8 @@ TEST(ottavaStartStop, DirectionWriter)
     start.spannerStart.printData.color.blue = 56;
     directionData.directionTypes.emplace_back(api::DirectionChoice{start});
 
-    SpannerNumberResolver numberResolver;
-    DirectionWriter writer{directionData, cursor, numberResolver};
+    SpannerResolver spannerResolver;
+    DirectionWriter writer{directionData, cursor, spannerResolver};
     const auto mdcSet = writer.getDirectionLikeThings();
     CHECK(mdcSet.front().isDirection());
     const auto &direction = mdcSet.front().asDirection();
@@ -68,8 +69,10 @@ TEST(ottavaStartStop, DirectionWriter)
     REQUIRE(roundTripped.directionTypes.front().isOttavaStop());
     const auto roundTrippedStop = roundTripped.directionTypes.front().ottavaStop();
     CHECK(api::SpannerNumber(2) == roundTrippedStop.spannerStop.number);
-    CHECK(roundTrippedStop.size.has_value());
-    CHECK_EQUAL(15, *roundTrippedStop.size);
+    CHECK(api::Bool::yes == roundTrippedStop.writeSize);
+    const auto &stopCore = directionTypes.front().choice().asOctaveShift();
+    REQUIRE(stopCore.size().has_value());
+    CHECK_EQUAL(8, *stopCore.size());
     REQUIRE(roundTripped.directionTypes.back().isOttavaStart());
     CHECK(start == roundTripped.directionTypes.back().ottavaStart());
 }
@@ -89,8 +92,8 @@ TEST(ottava22maAnd22mb, DirectionWriter)
     directionData.directionTypes.emplace_back(api::DirectionChoice{down});
 
     Cursor cursor{1, 100};
-    SpannerNumberResolver numberResolver;
-    DirectionWriter writer{directionData, cursor, numberResolver};
+    SpannerResolver spannerResolver;
+    DirectionWriter writer{directionData, cursor, spannerResolver};
     const auto mdcSet = writer.getDirectionLikeThings();
 
     REQUIRE(mdcSet.size() == 1);
@@ -163,8 +166,8 @@ TEST(segnoAndCodaRoundTrip, DirectionWriter)
     directionData.directionTypes.emplace_back(api::DirectionChoice{coda});
 
     Cursor cursor{1, 100};
-    SpannerNumberResolver numberResolver;
-    DirectionWriter writer{directionData, cursor, numberResolver};
+    SpannerResolver spannerResolver;
+    DirectionWriter writer{directionData, cursor, spannerResolver};
     const auto mdcSet = writer.getDirectionLikeThings();
     REQUIRE(mdcSet.size() >= 1);
     CHECK(mdcSet.front().isDirection());
@@ -216,8 +219,8 @@ TEST(rehearsalRoundTrip, DirectionWriter)
     directionData.directionTypes.emplace_back(api::DirectionChoice{rehearsal});
 
     Cursor cursor{1, 100};
-    SpannerNumberResolver numberResolver;
-    DirectionWriter writer{directionData, cursor, numberResolver};
+    SpannerResolver spannerResolver;
+    DirectionWriter writer{directionData, cursor, spannerResolver};
     const auto mdcSet = writer.getDirectionLikeThings();
     REQUIRE(mdcSet.size() >= 1);
     CHECK(mdcSet.front().isDirection());


### PR DESCRIPTION
## Human Summary

Automatically writes the ottava stop size as required by MuseScore. Retains round-trip fidelity through a suppression flag.

## Summary

An ottava stated its size twice. `OttavaStart::ottavaType` implies it, and `OttavaStop::size` repeated it, so the two could contradict each other and an author who wanted the interoperable spelling (MuseScore and others expect a size on the stop) had to copy the start's value by hand.

`OttavaStop::size` is replaced by a fidelity knob, `Bool writeSize`. The size itself now comes from the start the stop closes.

- The writer's part-wide spanner pass, generalized from `SpannerNumberResolver` to `SpannerResolver`, pairs each ottava stop with its start and records that start's size alongside the resolved spanner numbers. Pairing is by `SpannerNumber` in serialized order (identity endpoints by id, explicit endpoints by level, unspecified endpoints with each other), so it works across measures and keeps overlapping ottavas apart.
- `unspecified` (the authoring default) and `yes` both write the derived size; `no` omits the attribute. The reader sets `yes` or `no` according to whether the source spelled it out, so existing documents round-trip unchanged.
- A stop with no matching start writes MusicXML's default size of 8 rather than throwing, and a source stop whose size contradicts its start is normalized to the start's value.
- Nonstandard sizes keep their existing normalization (22 exactly, anything else above 8 as 15, everything else 8), now documented at the point of the mapping.
- `ottavaTypeSize` in a new `impl/OttavaFunctions.h` is the single source of the size fact, used by both the start emitter and the stop pairing.

Breaking public api change: `OttavaStop::size` is gone. Authoring an ottava is now start type, stop, done.

Also pins two files in the api round-trip baseline that discovery reported passing. Neither contains an `octave-shift`, so they were unblocked by earlier work and simply had not been pinned.

## Testing

- [x] New `OttavaSizeApiTest` covers all six lines across measures, overlapping numbered and identity spanners, sequential unnumbered lines, the dangling-stop fallback, both `writeSize` settings, and contradiction normalization (`*OttavaSize*`: 116 assertions in 8 test cases)
- [x] `DirectionReader`/`DirectionWriter` unit tests updated, including a new reader case for a stop with no size attribute
- [x] `make api-test` (6171 assertions in 556 test cases)
- [x] `make api-roundtrip` (368 passed, 0 failed of 368 pinned)
- [x] `make core-roundtrip-test` and `make core-unit`
- [x] `make fmt-check`
- [x] Unity build of the `mx` target (`CMAKE_UNITY_BUILD=ON`, batch size 0)

## References

- Closes #372
- Related to #393 (modeling a spanner as one object rather than a start/stop pair, the larger alternative the issue sets aside)
